### PR TITLE
feat(widgets): add Log widget for append-only scrollable log display

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -291,6 +291,8 @@ export {
 	wordWrap,
 	wrapText,
 } from './textWrap';
+// Time utilities
+export { formatDate, unixTimestamp, unixTimestampMs } from './time';
 // Unicode utilities
 export type {
 	CodePointRange,

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Time Utilities Tests
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatDate, unixTimestamp, unixTimestampMs } from './time';
+
+describe('Time Utilities', () => {
+	describe('formatDate', () => {
+		// Fixed test date: 2026-02-05 14:30:45.123
+		const testDate = new Date(2026, 1, 5, 14, 30, 45, 123);
+
+		it('formats year tokens', () => {
+			expect(formatDate(testDate, 'YYYY')).toBe('2026');
+			expect(formatDate(testDate, 'YY')).toBe('26');
+		});
+
+		it('formats month tokens', () => {
+			expect(formatDate(testDate, 'MM')).toBe('02');
+		});
+
+		it('formats day tokens', () => {
+			expect(formatDate(testDate, 'DD')).toBe('05');
+		});
+
+		it('formats 24-hour time tokens', () => {
+			expect(formatDate(testDate, 'HH')).toBe('14');
+		});
+
+		it('formats 12-hour time tokens', () => {
+			expect(formatDate(testDate, 'hh')).toBe('02');
+		});
+
+		it('formats minute tokens', () => {
+			expect(formatDate(testDate, 'mm')).toBe('30');
+		});
+
+		it('formats second tokens', () => {
+			expect(formatDate(testDate, 'ss')).toBe('45');
+		});
+
+		it('formats millisecond tokens', () => {
+			expect(formatDate(testDate, 'SSS')).toBe('123');
+			expect(formatDate(testDate, 'SS')).toBe('12');
+		});
+
+		it('formats AM/PM tokens', () => {
+			expect(formatDate(testDate, 'AA')).toBe('PM');
+			expect(formatDate(testDate, 'aa')).toBe('pm');
+
+			const morningDate = new Date(2026, 1, 5, 9, 30, 45);
+			expect(formatDate(morningDate, 'AA')).toBe('AM');
+			expect(formatDate(morningDate, 'aa')).toBe('am');
+		});
+
+		it('formats combined patterns', () => {
+			expect(formatDate(testDate, 'YYYY-MM-DD')).toBe('2026-02-05');
+			expect(formatDate(testDate, 'HH:mm:ss')).toBe('14:30:45');
+			expect(formatDate(testDate, 'HH:mm:ss.SSS')).toBe('14:30:45.123');
+			expect(formatDate(testDate, 'YYYY-MM-DD HH:mm:ss')).toBe('2026-02-05 14:30:45');
+		});
+
+		it('formats 12-hour time with AM/PM', () => {
+			expect(formatDate(testDate, 'hh:mm:ss AA')).toBe('02:30:45 PM');
+		});
+
+		it('preserves non-token characters', () => {
+			expect(formatDate(testDate, 'Date: YYYY/MM/DD')).toBe('Date: 2026/02/05');
+			expect(formatDate(testDate, '[Time] HH:mm')).toBe('[Time] 14:30');
+		});
+
+		it('handles midnight hour in 12-hour format', () => {
+			const midnightDate = new Date(2026, 1, 5, 0, 15, 0);
+			expect(formatDate(midnightDate, 'hh:mm AA')).toBe('12:15 AM');
+		});
+
+		it('handles noon hour in 12-hour format', () => {
+			const noonDate = new Date(2026, 1, 5, 12, 0, 0);
+			expect(formatDate(noonDate, 'hh:mm AA')).toBe('12:00 PM');
+		});
+
+		it('handles padded values correctly', () => {
+			const singleDigitDate = new Date(2026, 0, 5, 3, 5, 7, 8);
+			expect(formatDate(singleDigitDate, 'MM/DD HH:mm:ss.SSS')).toBe('01/05 03:05:07.008');
+		});
+	});
+
+	describe('unixTimestamp', () => {
+		it('returns seconds since epoch', () => {
+			const date = new Date(1707149445000);
+			expect(unixTimestamp(date)).toBe(1707149445);
+		});
+
+		it('uses current time when no date provided', () => {
+			const before = Math.floor(Date.now() / 1000);
+			const result = unixTimestamp();
+			const after = Math.floor(Date.now() / 1000);
+
+			expect(result).toBeGreaterThanOrEqual(before);
+			expect(result).toBeLessThanOrEqual(after);
+		});
+
+		it('truncates to whole seconds', () => {
+			const date = new Date(1707149445999);
+			expect(unixTimestamp(date)).toBe(1707149445);
+		});
+	});
+
+	describe('unixTimestampMs', () => {
+		it('returns milliseconds since epoch', () => {
+			const date = new Date(1707149445123);
+			expect(unixTimestampMs(date)).toBe(1707149445123);
+		});
+
+		it('uses current time when no date provided', () => {
+			const before = Date.now();
+			const result = unixTimestampMs();
+			const after = Date.now();
+
+			expect(result).toBeGreaterThanOrEqual(before);
+			expect(result).toBeLessThanOrEqual(after);
+		});
+	});
+});

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,140 @@
+/**
+ * Time Utilities
+ *
+ * Date and time formatting utilities for timestamps and log entries.
+ *
+ * @module utils/time
+ */
+
+/**
+ * Format tokens for date formatting.
+ * All tokens are at least 2 characters to avoid ambiguity.
+ */
+const FORMAT_TOKENS: Record<string, (date: Date) => string> = {
+	// Year
+	YYYY: (d) => d.getFullYear().toString(),
+	YY: (d) => d.getFullYear().toString().slice(-2),
+
+	// Month
+	MM: (d) => (d.getMonth() + 1).toString().padStart(2, '0'),
+
+	// Day
+	DD: (d) => d.getDate().toString().padStart(2, '0'),
+
+	// Hour (24-hour)
+	HH: (d) => d.getHours().toString().padStart(2, '0'),
+
+	// Hour (12-hour)
+	hh: (d) => {
+		const h = d.getHours() % 12;
+		return (h === 0 ? 12 : h).toString().padStart(2, '0');
+	},
+
+	// Minute
+	mm: (d) => d.getMinutes().toString().padStart(2, '0'),
+
+	// Second
+	ss: (d) => d.getSeconds().toString().padStart(2, '0'),
+
+	// Millisecond
+	SSS: (d) => d.getMilliseconds().toString().padStart(3, '0'),
+	SS: (d) =>
+		Math.floor(d.getMilliseconds() / 10)
+			.toString()
+			.padStart(2, '0'),
+
+	// AM/PM
+	AA: (d) => (d.getHours() < 12 ? 'AM' : 'PM'),
+	aa: (d) => (d.getHours() < 12 ? 'am' : 'pm'),
+};
+
+// Sort tokens by length (longest first) to match longer tokens before shorter ones
+const TOKEN_REGEX = new RegExp(
+	Object.keys(FORMAT_TOKENS)
+		.sort((a, b) => b.length - a.length)
+		.join('|'),
+	'g',
+);
+
+/**
+ * Formats a date according to a format string.
+ *
+ * Supported tokens:
+ * - YYYY: 4-digit year
+ * - YY: 2-digit year
+ * - MM: 2-digit month (01-12)
+ * - DD: 2-digit day (01-31)
+ * - HH: 2-digit hour, 24-hour (00-23)
+ * - hh: 2-digit hour, 12-hour (01-12)
+ * - mm: 2-digit minute (00-59)
+ * - ss: 2-digit second (00-59)
+ * - SSS: 3-digit millisecond (000-999)
+ * - SS: 2-digit centisecond (00-99)
+ * - AA: AM/PM (uppercase)
+ * - aa: am/pm (lowercase)
+ *
+ * @param date - The date to format
+ * @param format - The format string
+ * @returns The formatted date string
+ *
+ * @example
+ * ```typescript
+ * import { formatDate } from 'blecsd/utils';
+ *
+ * const now = new Date();
+ *
+ * // ISO-like format
+ * formatDate(now, 'YYYY-MM-DD HH:mm:ss');
+ * // => "2026-02-05 14:30:45"
+ *
+ * // Time only with milliseconds
+ * formatDate(now, 'HH:mm:ss.SSS');
+ * // => "14:30:45.123"
+ *
+ * // 12-hour format
+ * formatDate(now, 'hh:mm:ss AA');
+ * // => "02:30:45 PM"
+ * ```
+ */
+export function formatDate(date: Date, format: string): string {
+	return format.replace(TOKEN_REGEX, (token) => {
+		const formatter = FORMAT_TOKENS[token];
+		return formatter ? formatter(date) : token;
+	});
+}
+
+/**
+ * Gets a Unix timestamp (seconds since epoch).
+ *
+ * @param date - The date (defaults to now)
+ * @returns Unix timestamp in seconds
+ *
+ * @example
+ * ```typescript
+ * import { unixTimestamp } from 'blecsd/utils';
+ *
+ * const ts = unixTimestamp();
+ * // => 1707149445
+ * ```
+ */
+export function unixTimestamp(date: Date = new Date()): number {
+	return Math.floor(date.getTime() / 1000);
+}
+
+/**
+ * Gets a Unix timestamp in milliseconds.
+ *
+ * @param date - The date (defaults to now)
+ * @returns Unix timestamp in milliseconds
+ *
+ * @example
+ * ```typescript
+ * import { unixTimestampMs } from 'blecsd/utils';
+ *
+ * const ts = unixTimestampMs();
+ * // => 1707149445123
+ * ```
+ */
+export function unixTimestampMs(date: Date = new Date()): number {
+	return date.getTime();
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -180,6 +180,27 @@ export {
 	showLoading,
 	updateLoadingAnimation,
 } from './loading';
+// Log widget
+export type {
+	BorderConfig as LogBorderConfig,
+	DimensionValue as LogDimensionValue,
+	LogConfig,
+	LogWidget,
+	PaddingConfig as LogPaddingConfig,
+	PositionValue as LogPositionValue,
+	ScrollbarConfig as LogScrollbarConfig,
+	ScrollbarMode as LogScrollbarMode,
+} from './log';
+export {
+	createLog,
+	getScrollback,
+	isKeysScrollEnabled as isLogKeysScrollEnabled,
+	isLog,
+	isMouseScrollEnabled as isLogMouseScrollEnabled,
+	Log,
+	LogConfigSchema,
+	resetLogStore,
+} from './log';
 // Modal widget
 export type {
 	ModalBorderConfig,

--- a/src/widgets/log.test.ts
+++ b/src/widgets/log.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Log Widget Tests
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { addEntity, createWorld } from '../core/ecs';
+import type { World } from '../core/types';
+import { createLog, isLog, Log, resetLogStore } from './log';
+
+describe('Log Widget', () => {
+	let world: World;
+
+	afterEach(() => {
+		resetLogStore();
+	});
+
+	describe('createLog', () => {
+		it('creates a log widget with default config', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			expect(log.eid).toBe(eid);
+			expect(isLog(world, eid)).toBe(true);
+			expect(Log.scrollback[eid]).toBe(1000); // default
+			expect(Log.scrollOnInput[eid]).toBe(1); // default true
+			expect(Log.timestamps[eid]).toBe(0); // default false
+		});
+
+		it('creates a log widget with custom scrollback', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			createLog(world, eid, {
+				scrollback: 500,
+			});
+
+			expect(Log.scrollback[eid]).toBe(500);
+		});
+
+		it('creates a log widget with timestamps enabled', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			createLog(world, eid, {
+				timestamps: true,
+				timestampFormat: 'HH:mm:ss',
+			});
+
+			expect(Log.timestamps[eid]).toBe(1);
+		});
+
+		it('creates a log widget with scroll on input disabled', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			createLog(world, eid, {
+				scrollOnInput: false,
+			});
+
+			expect(Log.scrollOnInput[eid]).toBe(0);
+		});
+	});
+
+	describe('log()', () => {
+		it('logs a simple string message', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			log.log('Hello, world!');
+
+			expect(log.getLines()).toEqual(['Hello, world!']);
+			expect(log.getLineCount()).toBe(1);
+		});
+
+		it('logs multiple messages', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			log.log('Line 1');
+			log.log('Line 2');
+			log.log('Line 3');
+
+			expect(log.getLines()).toEqual(['Line 1', 'Line 2', 'Line 3']);
+			expect(log.getLineCount()).toBe(3);
+		});
+
+		it('formats messages with %s substitution', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			log.log('Hello, %s!', 'world');
+
+			expect(log.getLines()).toEqual(['Hello, world!']);
+		});
+
+		it('formats messages with %d substitution', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			log.log('The answer is %d', 42);
+
+			expect(log.getLines()).toEqual(['The answer is 42']);
+		});
+
+		it('formats messages with multiple substitutions', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			log.log('User %s has %d items', 'alice', 5);
+
+			expect(log.getLines()).toEqual(['User alice has 5 items']);
+		});
+
+		it('formats objects with %j substitution', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			log.log('Data: %j', { key: 'value' });
+
+			expect(log.getLines()).toEqual(['Data: {"key":"value"}']);
+		});
+
+		it('logs non-string values directly', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			log.log(42);
+			log.log({ foo: 'bar' });
+
+			expect(log.getLines()).toEqual(['42', '[object Object]']);
+		});
+
+		it('adds timestamps when enabled', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid, {
+				timestamps: true,
+				timestampFormat: 'HH:mm:ss',
+			});
+
+			log.log('Test message');
+
+			const lines = log.getLines();
+			expect(lines.length).toBe(1);
+			expect(lines[0]).toMatch(/^\[\d{2}:\d{2}:\d{2}\] Test message$/);
+		});
+
+		it('returns widget for chaining', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			const result = log.log('test');
+
+			expect(result).toBe(log);
+		});
+	});
+
+	describe('scrollback limit', () => {
+		it('prunes old lines when exceeding scrollback', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid, {
+				scrollback: 3,
+			});
+
+			log.log('Line 1');
+			log.log('Line 2');
+			log.log('Line 3');
+			log.log('Line 4');
+			log.log('Line 5');
+
+			expect(log.getLines()).toEqual(['Line 3', 'Line 4', 'Line 5']);
+			expect(log.getLineCount()).toBe(3);
+		});
+
+		it('handles scrollback of 1', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid, {
+				scrollback: 1,
+			});
+
+			log.log('Line 1');
+			log.log('Line 2');
+
+			expect(log.getLines()).toEqual(['Line 2']);
+			expect(log.getLineCount()).toBe(1);
+		});
+	});
+
+	describe('clear()', () => {
+		it('clears all lines', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			log.log('Line 1');
+			log.log('Line 2');
+			log.clear();
+
+			expect(log.getLines()).toEqual([]);
+			expect(log.getLineCount()).toBe(0);
+		});
+
+		it('returns widget for chaining', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			const result = log.clear();
+
+			expect(result).toBe(log);
+		});
+	});
+
+	describe('getLines()', () => {
+		it('returns a copy of lines', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			log.log('Line 1');
+			const lines = log.getLines() as string[];
+			lines.push('Modified');
+
+			// Original should be unmodified since getLines returns a copy
+			expect(log.getLines()).toEqual(['Line 1']);
+		});
+
+		it('returns empty array when no lines', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			expect(log.getLines()).toEqual([]);
+		});
+	});
+
+	describe('visibility', () => {
+		it('show() returns widget for chaining', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			expect(log.show()).toBe(log);
+		});
+
+		it('hide() returns widget for chaining', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			expect(log.hide()).toBe(log);
+		});
+	});
+
+	describe('focus', () => {
+		it('focus() returns widget for chaining', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			expect(log.focus()).toBe(log);
+		});
+
+		it('blur() returns widget for chaining', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			expect(log.blur()).toBe(log);
+		});
+
+		it('isFocused() returns boolean', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			expect(typeof log.isFocused()).toBe('boolean');
+		});
+	});
+
+	describe('scrolling', () => {
+		it('scrollTo() returns widget for chaining', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			expect(log.scrollTo(0, 0)).toBe(log);
+		});
+
+		it('scrollBy() returns widget for chaining', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			expect(log.scrollBy(0, 5)).toBe(log);
+		});
+
+		it('scrollToTop() returns widget for chaining', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			expect(log.scrollToTop()).toBe(log);
+		});
+
+		it('scrollToBottom() returns widget for chaining', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			expect(log.scrollToBottom()).toBe(log);
+		});
+	});
+
+	describe('destroy()', () => {
+		it('cleans up log state', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid);
+
+			log.log('Line 1');
+			log.destroy();
+
+			expect(isLog(world, eid)).toBe(false);
+			expect(Log.scrollback[eid]).toBe(0);
+			expect(Log.lineCount[eid]).toBe(0);
+		});
+	});
+
+	describe('isLog()', () => {
+		it('returns true for log widgets', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			createLog(world, eid);
+
+			expect(isLog(world, eid)).toBe(true);
+		});
+
+		it('returns false for non-log entities', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+
+			expect(isLog(world, eid)).toBe(false);
+		});
+	});
+
+	describe('config validation', () => {
+		it('validates position values', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid, {
+				left: 10,
+				top: 5,
+				width: 80,
+				height: 20,
+			});
+
+			expect(log.eid).toBe(eid);
+		});
+
+		it('validates border config', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid, {
+				border: {
+					type: 'line',
+					ch: 'rounded',
+				},
+			});
+
+			expect(log.eid).toBe(eid);
+		});
+
+		it('validates scrollbar config', () => {
+			world = createWorld();
+			const eid = addEntity(world);
+			const log = createLog(world, eid, {
+				scrollbar: {
+					mode: 'visible',
+					fg: '#ffffff',
+					bg: '#000000',
+				},
+			});
+
+			expect(log.eid).toBe(eid);
+		});
+	});
+});

--- a/src/widgets/log.ts
+++ b/src/widgets/log.ts
@@ -1,0 +1,1060 @@
+/**
+ * Log Widget
+ *
+ * An append-only scrollable log display widget. Optimized for displaying
+ * log messages, console output, and other streaming text content.
+ *
+ * Features:
+ * - Auto-scroll to bottom on new content
+ * - Optional timestamps for each line
+ * - Scrollback limit to prune old lines
+ * - Printf-style logging with interpolation
+ *
+ * @module widgets/log
+ */
+
+import { z } from 'zod';
+import {
+	BORDER_ASCII,
+	BORDER_BOLD,
+	BORDER_DOUBLE,
+	BORDER_ROUNDED,
+	BORDER_SINGLE,
+	type BorderCharset,
+	BorderType,
+	setBorder,
+	setBorderChars,
+} from '../components/border';
+import { setContent } from '../components/content';
+import { setDimensions } from '../components/dimensions';
+import { blur, focus, isFocused, setFocusable } from '../components/focusable';
+import { appendChild, getChildren } from '../components/hierarchy';
+import { setPadding } from '../components/padding';
+import { moveBy, setPosition } from '../components/position';
+import { hexToColor, markDirty, setStyle, setVisible } from '../components/renderable';
+import {
+	canScroll,
+	canScrollX,
+	canScrollY,
+	scrollBy as componentScrollBy,
+	scrollTo as componentScrollTo,
+	getScroll,
+	getScrollable,
+	getScrollPercentage,
+	isAtBottom,
+	isAtLeft,
+	isAtRight,
+	isAtTop,
+	type ScrollableData,
+	ScrollbarVisibility,
+	type ScrollPercentage,
+	type ScrollPosition,
+	scrollToBottom,
+	scrollToLeft,
+	scrollToRight,
+	scrollToTop,
+	setScrollable,
+	setScrollPercentage,
+	setScrollSize,
+	setViewport,
+} from '../components/scrollable';
+import { removeEntity } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+import { formatDate } from '../utils/time';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Dimension value that can be a number, percentage string, or 'auto'.
+ */
+export type DimensionValue = number | `${number}%` | 'auto';
+
+/**
+ * Position value that can be a number, percentage string, or keyword.
+ */
+export type PositionValue = number | `${number}%` | 'center' | 'left' | 'right' | 'top' | 'bottom';
+
+/**
+ * Border configuration for the log widget.
+ */
+export interface BorderConfig {
+	/** Border type */
+	readonly type?: 'line' | 'bg' | 'none';
+	/** Foreground color for border (hex string or packed number) */
+	readonly fg?: string | number;
+	/** Background color for border (hex string or packed number) */
+	readonly bg?: string | number;
+	/** Border charset ('single', 'double', 'rounded', 'bold', 'ascii', or custom) */
+	readonly ch?: 'single' | 'double' | 'rounded' | 'bold' | 'ascii' | BorderCharset;
+}
+
+/**
+ * Padding configuration (all sides, or individual sides).
+ */
+export type PaddingConfig =
+	| number
+	| {
+			readonly left?: number;
+			readonly top?: number;
+			readonly right?: number;
+			readonly bottom?: number;
+	  };
+
+/**
+ * Scrollbar visibility mode.
+ */
+export type ScrollbarMode = 'auto' | 'visible' | 'hidden';
+
+/**
+ * Scrollbar configuration.
+ */
+export interface ScrollbarConfig {
+	/** Scrollbar visibility mode */
+	readonly mode?: ScrollbarMode;
+	/** Scrollbar foreground color */
+	readonly fg?: string | number;
+	/** Scrollbar background color */
+	readonly bg?: string | number;
+	/** Track character */
+	readonly trackChar?: string;
+	/** Thumb character */
+	readonly thumbChar?: string;
+}
+
+/**
+ * Configuration for creating a Log widget.
+ */
+export interface LogConfig {
+	// Position
+	/** Left position (absolute or percentage) */
+	readonly left?: PositionValue;
+	/** Top position (absolute or percentage) */
+	readonly top?: PositionValue;
+	/** Right position (absolute or percentage) */
+	readonly right?: PositionValue;
+	/** Bottom position (absolute or percentage) */
+	readonly bottom?: PositionValue;
+	/** Width (absolute, percentage, or 'auto') */
+	readonly width?: DimensionValue;
+	/** Height (absolute, percentage, or 'auto') */
+	readonly height?: DimensionValue;
+
+	// Style
+	/** Foreground color (hex string or packed number) */
+	readonly fg?: string | number;
+	/** Background color (hex string or packed number) */
+	readonly bg?: string | number;
+	/** Border configuration */
+	readonly border?: BorderConfig;
+	/** Padding configuration */
+	readonly padding?: PaddingConfig;
+
+	// Scrolling
+	/** Scrollbar configuration (true for default, false to disable, or config) */
+	readonly scrollbar?: boolean | ScrollbarConfig;
+	/** Enable mouse wheel scrolling (default: true) */
+	readonly mouse?: boolean;
+	/** Enable keyboard scrolling (default: true) */
+	readonly keys?: boolean;
+
+	// Log-specific options
+	/** Maximum number of lines to keep in scrollback (default: 1000) */
+	readonly scrollback?: number;
+	/** Auto-scroll to bottom when new content is added (default: true) */
+	readonly scrollOnInput?: boolean;
+	/** Add timestamps to log entries (default: false) */
+	readonly timestamps?: boolean;
+	/** Timestamp format using date format tokens (default: 'HH:mm:ss') */
+	readonly timestampFormat?: string;
+}
+
+/**
+ * Log widget interface providing chainable methods.
+ */
+export interface LogWidget {
+	/** The underlying entity ID */
+	readonly eid: Entity;
+
+	// Logging
+	/** Logs a message with optional interpolation */
+	log(...args: unknown[]): LogWidget;
+	/** Clears all log entries */
+	clear(): LogWidget;
+	/** Gets all lines in the log */
+	getLines(): readonly string[];
+	/** Gets the number of lines in the log */
+	getLineCount(): number;
+
+	// Visibility
+	/** Shows the log widget */
+	show(): LogWidget;
+	/** Hides the log widget */
+	hide(): LogWidget;
+
+	// Position
+	/** Moves the log widget by dx, dy */
+	move(dx: number, dy: number): LogWidget;
+	/** Sets the absolute position */
+	setPosition(x: number, y: number): LogWidget;
+
+	// Focus
+	/** Focuses the log widget */
+	focus(): LogWidget;
+	/** Blurs the log widget */
+	blur(): LogWidget;
+	/** Checks if the log widget is focused */
+	isFocused(): boolean;
+
+	// Children
+	/** Appends a child entity to this log widget */
+	append(child: Entity): LogWidget;
+	/** Gets all direct children of this log widget */
+	getChildren(): Entity[];
+
+	// Scrolling
+	/** Scrolls to absolute position */
+	scrollTo(x: number, y: number): LogWidget;
+	/** Scrolls by delta */
+	scrollBy(dx: number, dy: number): LogWidget;
+	/** Scrolls to percentage (0-100) */
+	setScrollPerc(percX: number, percY: number): LogWidget;
+	/** Gets scroll percentage (0-100) */
+	getScrollPerc(): ScrollPercentage;
+	/** Gets scroll position */
+	getScroll(): ScrollPosition;
+	/** Sets viewport size */
+	setViewport(width: number, height: number): LogWidget;
+	/** Gets full scrollable data */
+	getScrollable(): ScrollableData | undefined;
+	/** Scrolls to top */
+	scrollToTop(): LogWidget;
+	/** Scrolls to bottom */
+	scrollToBottom(): LogWidget;
+	/** Scrolls to left */
+	scrollToLeft(): LogWidget;
+	/** Scrolls to right */
+	scrollToRight(): LogWidget;
+	/** Checks if can scroll (content exceeds viewport) */
+	canScroll(): boolean;
+	/** Checks if can scroll horizontally */
+	canScrollX(): boolean;
+	/** Checks if can scroll vertically */
+	canScrollY(): boolean;
+	/** Checks if scrolled to top */
+	isAtTop(): boolean;
+	/** Checks if scrolled to bottom */
+	isAtBottom(): boolean;
+	/** Checks if scrolled to left */
+	isAtLeft(): boolean;
+	/** Checks if scrolled to right */
+	isAtRight(): boolean;
+
+	// Lifecycle
+	/** Destroys the widget and removes it from the world */
+	destroy(): void;
+}
+
+// =============================================================================
+// SCHEMAS
+// =============================================================================
+
+/**
+ * Zod schema for dimension values.
+ */
+const DimensionValueSchema = z.union([
+	z.number(),
+	z.string().regex(/^\d+(\.\d+)?%$/, 'Percentage must be in format "50%"'),
+	z.literal('auto'),
+]);
+
+/**
+ * Zod schema for position values.
+ */
+const PositionValueSchema = z.union([
+	z.number(),
+	z.string().regex(/^\d+(\.\d+)?%$/, 'Percentage must be in format "50%"'),
+	z.enum(['center', 'left', 'right', 'top', 'bottom']),
+]);
+
+/**
+ * Zod schema for border configuration.
+ */
+const BorderConfigSchema = z
+	.object({
+		type: z.enum(['line', 'bg', 'none']).optional(),
+		fg: z.union([z.string(), z.number()]).optional(),
+		bg: z.union([z.string(), z.number()]).optional(),
+		ch: z
+			.union([
+				z.enum(['single', 'double', 'rounded', 'bold', 'ascii']),
+				z.custom<BorderCharset>((val) => {
+					return (
+						typeof val === 'object' &&
+						val !== null &&
+						'topLeft' in val &&
+						'topRight' in val &&
+						'bottomLeft' in val &&
+						'bottomRight' in val &&
+						'horizontal' in val &&
+						'vertical' in val
+					);
+				}),
+			])
+			.optional(),
+	})
+	.optional();
+
+/**
+ * Zod schema for padding configuration.
+ */
+const PaddingConfigSchema = z
+	.union([
+		z.number().int().nonnegative(),
+		z.object({
+			left: z.number().int().nonnegative().optional(),
+			top: z.number().int().nonnegative().optional(),
+			right: z.number().int().nonnegative().optional(),
+			bottom: z.number().int().nonnegative().optional(),
+		}),
+	])
+	.optional();
+
+/**
+ * Zod schema for scrollbar configuration.
+ */
+const ScrollbarConfigSchema = z
+	.union([
+		z.boolean(),
+		z.object({
+			mode: z.enum(['auto', 'visible', 'hidden']).optional(),
+			fg: z.union([z.string(), z.number()]).optional(),
+			bg: z.union([z.string(), z.number()]).optional(),
+			trackChar: z.string().optional(),
+			thumbChar: z.string().optional(),
+		}),
+	])
+	.optional();
+
+/**
+ * Zod schema for log widget configuration.
+ */
+export const LogConfigSchema = z.object({
+	// Position
+	left: PositionValueSchema.optional(),
+	top: PositionValueSchema.optional(),
+	right: PositionValueSchema.optional(),
+	bottom: PositionValueSchema.optional(),
+	width: DimensionValueSchema.optional(),
+	height: DimensionValueSchema.optional(),
+
+	// Style
+	fg: z.union([z.string(), z.number()]).optional(),
+	bg: z.union([z.string(), z.number()]).optional(),
+	border: BorderConfigSchema,
+	padding: PaddingConfigSchema,
+
+	// Scrolling
+	scrollbar: ScrollbarConfigSchema,
+	mouse: z.boolean().optional(),
+	keys: z.boolean().optional(),
+
+	// Log-specific options
+	scrollback: z.number().int().positive().optional(),
+	scrollOnInput: z.boolean().optional(),
+	timestamps: z.boolean().optional(),
+	timestampFormat: z.string().optional(),
+});
+
+// =============================================================================
+// COMPONENT TAG
+// =============================================================================
+
+/** Default entity capacity for typed arrays */
+const DEFAULT_CAPACITY = 10000;
+
+/**
+ * Log component marker for identifying log widget entities.
+ */
+export const Log = {
+	/** Tag indicating this is a log widget (1 = yes) */
+	isLog: new Uint8Array(DEFAULT_CAPACITY),
+	/** Mouse scrolling enabled (1 = yes) */
+	mouseEnabled: new Uint8Array(DEFAULT_CAPACITY),
+	/** Keyboard scrolling enabled (1 = yes) */
+	keysEnabled: new Uint8Array(DEFAULT_CAPACITY),
+	/** Auto-scroll on input enabled (1 = yes) */
+	scrollOnInput: new Uint8Array(DEFAULT_CAPACITY),
+	/** Timestamps enabled (1 = yes) */
+	timestamps: new Uint8Array(DEFAULT_CAPACITY),
+	/** Maximum scrollback lines */
+	scrollback: new Uint32Array(DEFAULT_CAPACITY),
+	/** Current line count */
+	lineCount: new Uint32Array(DEFAULT_CAPACITY),
+};
+
+/**
+ * Log state stored outside ECS for complex data.
+ */
+interface LogState {
+	/** Lines stored in the log */
+	lines: string[];
+	/** Timestamp format string */
+	timestampFormat: string;
+}
+
+/** Map of entity to log state */
+const logStateMap = new Map<Entity, LogState>();
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+/**
+ * Parses a color value to a packed 32-bit color.
+ */
+function parseColor(color: string | number): number {
+	if (typeof color === 'string') {
+		return hexToColor(color);
+	}
+	return color;
+}
+
+/**
+ * Gets the appropriate BorderCharset for a named style.
+ */
+function getBorderCharset(ch: 'single' | 'double' | 'rounded' | 'bold' | 'ascii'): BorderCharset {
+	switch (ch) {
+		case 'single':
+			return BORDER_SINGLE;
+		case 'double':
+			return BORDER_DOUBLE;
+		case 'rounded':
+			return BORDER_ROUNDED;
+		case 'bold':
+			return BORDER_BOLD;
+		case 'ascii':
+			return BORDER_ASCII;
+	}
+}
+
+/**
+ * Converts border type string to BorderType enum.
+ */
+function borderTypeToEnum(type: 'line' | 'bg' | 'none'): BorderType {
+	switch (type) {
+		case 'line':
+			return BorderType.Line;
+		case 'bg':
+			return BorderType.Background;
+		case 'none':
+			return BorderType.None;
+	}
+}
+
+/**
+ * Parses a position value to a number.
+ */
+function parsePositionToNumber(value: string | number | undefined): number {
+	if (value === undefined) return 0;
+	if (typeof value === 'number') return value;
+	if (value === 'left' || value === 'top') return 0;
+	return 0;
+}
+
+/**
+ * Parses a dimension value for setDimensions.
+ */
+function parseDimension(value: string | number | undefined): number | `${number}%` | 'auto' {
+	if (value === undefined) return 'auto';
+	if (typeof value === 'string') {
+		if (value === 'auto') return 'auto';
+		return value as `${number}%`;
+	}
+	return value;
+}
+
+/**
+ * Converts scrollbar mode to ScrollbarVisibility enum.
+ */
+function scrollbarModeToVisibility(mode: ScrollbarMode): ScrollbarVisibility {
+	switch (mode) {
+		case 'auto':
+			return ScrollbarVisibility.Auto;
+		case 'visible':
+			return ScrollbarVisibility.Visible;
+		case 'hidden':
+			return ScrollbarVisibility.Hidden;
+	}
+}
+
+/**
+ * Validated config type from LogConfigSchema.
+ */
+interface ValidatedLogConfig {
+	left?: string | number;
+	top?: string | number;
+	right?: string | number;
+	bottom?: string | number;
+	width?: string | number;
+	height?: string | number;
+	fg?: string | number;
+	bg?: string | number;
+	border?: {
+		type?: 'line' | 'bg' | 'none';
+		fg?: string | number;
+		bg?: string | number;
+		ch?: 'single' | 'double' | 'rounded' | 'bold' | 'ascii' | BorderCharset;
+	};
+	padding?:
+		| number
+		| {
+				left?: number;
+				top?: number;
+				right?: number;
+				bottom?: number;
+		  };
+	scrollbar?:
+		| boolean
+		| {
+				mode?: 'auto' | 'visible' | 'hidden';
+				fg?: string | number;
+				bg?: string | number;
+				trackChar?: string;
+				thumbChar?: string;
+		  };
+	mouse?: boolean;
+	keys?: boolean;
+	scrollback?: number;
+	scrollOnInput?: boolean;
+	timestamps?: boolean;
+	timestampFormat?: string;
+}
+
+/**
+ * Formats a log message with printf-style interpolation.
+ */
+function formatLogMessage(...args: unknown[]): string {
+	if (args.length === 0) return '';
+	if (args.length === 1) return String(args[0]);
+
+	const format = String(args[0]);
+	let argIndex = 1;
+
+	return format.replace(/%([sdfjioO%])/g, (match, type) => {
+		if (type === '%') return '%';
+		if (argIndex >= args.length) return match;
+
+		const arg = args[argIndex++];
+
+		switch (type) {
+			case 's':
+				return String(arg);
+			case 'd':
+			case 'i':
+				return typeof arg === 'number' ? Math.floor(arg).toString() : 'NaN';
+			case 'f':
+				return typeof arg === 'number' ? arg.toString() : 'NaN';
+			case 'j':
+			case 'o':
+			case 'O':
+				try {
+					return JSON.stringify(arg);
+				} catch {
+					return '[Circular]';
+				}
+			default:
+				return match;
+		}
+	});
+}
+
+/**
+ * Formats a timestamp for a log entry.
+ */
+function formatTimestamp(format: string): string {
+	return formatDate(new Date(), format);
+}
+
+/**
+ * Updates the content of a log entity from its lines.
+ */
+function updateLogContent(world: World, eid: Entity): void {
+	const state = logStateMap.get(eid);
+	if (!state) return;
+
+	const content = state.lines.join('\n');
+	setContent(world, eid, content);
+
+	// Update scroll size based on line count
+	const lineCount = state.lines.length;
+	setScrollSize(world, eid, 0, lineCount);
+	Log.lineCount[eid] = lineCount;
+
+	markDirty(world, eid);
+}
+
+/**
+ * Prunes old lines if exceeding scrollback limit.
+ */
+function pruneLines(eid: Entity): void {
+	const state = logStateMap.get(eid);
+	if (!state) return;
+
+	const scrollback = Log.scrollback[eid] ?? 0;
+	if (scrollback === 0) return; // No limit
+
+	while (state.lines.length > scrollback) {
+		state.lines.shift();
+	}
+}
+
+// =============================================================================
+// SETUP HELPERS
+// =============================================================================
+
+/**
+ * Sets up log-specific component options.
+ * @internal
+ */
+function setupLogOptions(eid: Entity, config: ValidatedLogConfig): void {
+	Log.isLog[eid] = 1;
+	Log.scrollback[eid] = config.scrollback ?? 1000;
+	Log.scrollOnInput[eid] = config.scrollOnInput !== false ? 1 : 0;
+	Log.timestamps[eid] = config.timestamps ? 1 : 0;
+	Log.mouseEnabled[eid] = config.mouse !== false ? 1 : 0;
+	Log.keysEnabled[eid] = config.keys !== false ? 1 : 0;
+	Log.lineCount[eid] = 0;
+
+	logStateMap.set(eid, {
+		lines: [],
+		timestampFormat: config.timestampFormat ?? 'HH:mm:ss',
+	});
+}
+
+/**
+ * Sets up position and dimensions on the log entity.
+ * @internal
+ */
+function setupPositionAndDimensions(world: World, eid: Entity, config: ValidatedLogConfig): void {
+	const x = parsePositionToNumber(config.left);
+	const y = parsePositionToNumber(config.top);
+	setPosition(world, eid, x, y);
+
+	const width = parseDimension(config.width);
+	const height = parseDimension(config.height);
+	setDimensions(world, eid, width, height);
+}
+
+/**
+ * Sets up style colors on the log entity.
+ * @internal
+ */
+function setupStyle(world: World, eid: Entity, config: ValidatedLogConfig): void {
+	if (config.fg === undefined && config.bg === undefined) return;
+
+	setStyle(world, eid, {
+		fg: config.fg !== undefined ? parseColor(config.fg) : undefined,
+		bg: config.bg !== undefined ? parseColor(config.bg) : undefined,
+	});
+}
+
+/**
+ * Sets up border on the log entity.
+ * @internal
+ */
+function setupBorder(
+	world: World,
+	eid: Entity,
+	borderConfig: NonNullable<ValidatedLogConfig['border']>,
+): void {
+	const borderType = borderConfig.type ? borderTypeToEnum(borderConfig.type) : BorderType.Line;
+
+	setBorder(world, eid, {
+		type: borderType,
+		fg: borderConfig.fg !== undefined ? parseColor(borderConfig.fg) : undefined,
+		bg: borderConfig.bg !== undefined ? parseColor(borderConfig.bg) : undefined,
+	});
+
+	if (borderConfig.ch) {
+		const charset =
+			typeof borderConfig.ch === 'string' ? getBorderCharset(borderConfig.ch) : borderConfig.ch;
+		setBorderChars(world, eid, charset);
+	}
+}
+
+/**
+ * Sets up padding on the log entity.
+ * @internal
+ */
+function setupPadding(
+	world: World,
+	eid: Entity,
+	paddingConfig: NonNullable<ValidatedLogConfig['padding']>,
+): void {
+	if (typeof paddingConfig === 'number') {
+		setPadding(world, eid, {
+			left: paddingConfig,
+			top: paddingConfig,
+			right: paddingConfig,
+			bottom: paddingConfig,
+		});
+	} else {
+		setPadding(world, eid, paddingConfig);
+	}
+}
+
+/**
+ * Sets up scrollable component on the log entity.
+ * @internal
+ */
+function setupScrollable(world: World, eid: Entity, config: ValidatedLogConfig): void {
+	let scrollbarVisible = ScrollbarVisibility.Auto;
+
+	if (config.scrollbar === false) {
+		scrollbarVisible = ScrollbarVisibility.Hidden;
+	} else if (typeof config.scrollbar === 'object' && config.scrollbar.mode) {
+		scrollbarVisible = scrollbarModeToVisibility(config.scrollbar.mode);
+	}
+
+	setScrollable(world, eid, {
+		alwaysScroll: true,
+		scrollbarVisible,
+	});
+}
+
+// =============================================================================
+// FACTORY
+// =============================================================================
+
+/**
+ * Creates a Log widget with the given configuration.
+ *
+ * The Log widget is an append-only scrollable display for log messages.
+ * It supports auto-scrolling, timestamps, and scrollback limits.
+ *
+ * @param world - The ECS world
+ * @param entity - The entity to wrap
+ * @param config - Widget configuration
+ * @returns The Log widget instance
+ *
+ * @example
+ * ```typescript
+ * import { createWorld, addEntity } from '../core/ecs';
+ * import { createLog } from 'blecsd/widgets';
+ *
+ * const world = createWorld();
+ * const eid = addEntity(world);
+ *
+ * // Create a log display
+ * const logView = createLog(world, eid, {
+ *   left: 0,
+ *   top: 0,
+ *   width: 80,
+ *   height: 20,
+ *   scrollback: 500,       // Keep last 500 lines
+ *   timestamps: true,       // Add timestamps
+ *   timestampFormat: 'HH:mm:ss.SSS',
+ *   border: { type: 'line' },
+ *   scrollbar: true,
+ * });
+ *
+ * // Log messages
+ * logView.log('Server started on port %d', 3000);
+ * logView.log('Connection from %s', '192.168.1.1');
+ * logView.log({ user: 'alice', action: 'login' });
+ * ```
+ */
+export function createLog(world: World, entity: Entity, config: LogConfig = {}): LogWidget {
+	const validated = LogConfigSchema.parse(config) as ValidatedLogConfig;
+	const eid = entity;
+
+	// Set up components using helper functions
+	setupLogOptions(eid, validated);
+	setupPositionAndDimensions(world, eid, validated);
+	setupStyle(world, eid, validated);
+	if (validated.border) setupBorder(world, eid, validated.border);
+	if (validated.padding !== undefined) setupPadding(world, eid, validated.padding);
+	setupScrollable(world, eid, validated);
+
+	// Make focusable and set initial content
+	setFocusable(world, eid, { focusable: true });
+	setContent(world, eid, '');
+
+	// Create the widget object with chainable methods
+	const widget: LogWidget = {
+		eid,
+
+		// Logging
+		log(...args: unknown[]): LogWidget {
+			const state = logStateMap.get(eid);
+			if (!state) return widget;
+
+			let message = formatLogMessage(...args);
+
+			// Add timestamp if enabled
+			if (Log.timestamps[eid] === 1) {
+				const timestamp = formatTimestamp(state.timestampFormat);
+				message = `[${timestamp}] ${message}`;
+			}
+
+			state.lines.push(message);
+			pruneLines(eid);
+			updateLogContent(world, eid);
+
+			// Auto-scroll to bottom if enabled
+			if (Log.scrollOnInput[eid] === 1) {
+				scrollToBottom(world, eid);
+			}
+
+			return widget;
+		},
+
+		clear(): LogWidget {
+			const state = logStateMap.get(eid);
+			if (!state) return widget;
+
+			state.lines = [];
+			Log.lineCount[eid] = 0;
+			updateLogContent(world, eid);
+			scrollToTop(world, eid);
+
+			return widget;
+		},
+
+		getLines(): readonly string[] {
+			const state = logStateMap.get(eid);
+			return state ? [...state.lines] : [];
+		},
+
+		getLineCount(): number {
+			return Log.lineCount[eid] ?? 0;
+		},
+
+		// Visibility
+		show(): LogWidget {
+			setVisible(world, eid, true);
+			return widget;
+		},
+
+		hide(): LogWidget {
+			setVisible(world, eid, false);
+			return widget;
+		},
+
+		// Position
+		move(dx: number, dy: number): LogWidget {
+			moveBy(world, eid, dx, dy);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		setPosition(x: number, y: number): LogWidget {
+			setPosition(world, eid, x, y);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		// Focus
+		focus(): LogWidget {
+			focus(world, eid);
+			return widget;
+		},
+
+		blur(): LogWidget {
+			blur(world, eid);
+			return widget;
+		},
+
+		isFocused(): boolean {
+			return isFocused(world, eid);
+		},
+
+		// Children
+		append(child: Entity): LogWidget {
+			appendChild(world, eid, child);
+			return widget;
+		},
+
+		getChildren(): Entity[] {
+			return getChildren(world, eid);
+		},
+
+		// Scrolling
+		scrollTo(x: number, y: number): LogWidget {
+			componentScrollTo(world, eid, x, y);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		scrollBy(dx: number, dy: number): LogWidget {
+			componentScrollBy(world, eid, dx, dy);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		setScrollPerc(percX: number, percY: number): LogWidget {
+			setScrollPercentage(world, eid, percX, percY);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		getScrollPerc(): ScrollPercentage {
+			return getScrollPercentage(world, eid);
+		},
+
+		getScroll(): ScrollPosition {
+			return getScroll(world, eid);
+		},
+
+		setViewport(width: number, height: number): LogWidget {
+			setViewport(world, eid, width, height);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		getScrollable(): ScrollableData | undefined {
+			return getScrollable(world, eid);
+		},
+
+		scrollToTop(): LogWidget {
+			scrollToTop(world, eid);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		scrollToBottom(): LogWidget {
+			scrollToBottom(world, eid);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		scrollToLeft(): LogWidget {
+			scrollToLeft(world, eid);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		scrollToRight(): LogWidget {
+			scrollToRight(world, eid);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		canScroll(): boolean {
+			return canScroll(world, eid);
+		},
+
+		canScrollX(): boolean {
+			return canScrollX(world, eid);
+		},
+
+		canScrollY(): boolean {
+			return canScrollY(world, eid);
+		},
+
+		isAtTop(): boolean {
+			return isAtTop(world, eid);
+		},
+
+		isAtBottom(): boolean {
+			return isAtBottom(world, eid);
+		},
+
+		isAtLeft(): boolean {
+			return isAtLeft(world, eid);
+		},
+
+		isAtRight(): boolean {
+			return isAtRight(world, eid);
+		},
+
+		// Lifecycle
+		destroy(): void {
+			Log.isLog[eid] = 0;
+			Log.mouseEnabled[eid] = 0;
+			Log.keysEnabled[eid] = 0;
+			Log.scrollOnInput[eid] = 0;
+			Log.timestamps[eid] = 0;
+			Log.scrollback[eid] = 0;
+			Log.lineCount[eid] = 0;
+			logStateMap.delete(eid);
+			removeEntity(world, eid);
+		},
+	};
+
+	return widget;
+}
+
+// =============================================================================
+// UTILITY FUNCTIONS
+// =============================================================================
+
+/**
+ * Checks if an entity is a log widget.
+ *
+ * @param _world - The ECS world (unused, for API consistency)
+ * @param eid - The entity ID
+ * @returns true if the entity is a log widget
+ *
+ * @example
+ * ```typescript
+ * import { isLog } from 'blecsd/widgets';
+ *
+ * if (isLog(world, entity)) {
+ *   // Handle log-specific logic
+ * }
+ * ```
+ */
+export function isLog(_world: World, eid: Entity): boolean {
+	return Log.isLog[eid] === 1;
+}
+
+/**
+ * Checks if mouse scrolling is enabled for a log widget.
+ *
+ * @param _world - The ECS world (unused, for API consistency)
+ * @param eid - The entity ID
+ * @returns true if mouse scrolling is enabled
+ */
+export function isMouseScrollEnabled(_world: World, eid: Entity): boolean {
+	return Log.mouseEnabled[eid] === 1;
+}
+
+/**
+ * Checks if keyboard scrolling is enabled for a log widget.
+ *
+ * @param _world - The ECS world (unused, for API consistency)
+ * @param eid - The entity ID
+ * @returns true if keyboard scrolling is enabled
+ */
+export function isKeysScrollEnabled(_world: World, eid: Entity): boolean {
+	return Log.keysEnabled[eid] === 1;
+}
+
+/**
+ * Gets the scrollback limit for a log widget.
+ *
+ * @param _world - The ECS world (unused, for API consistency)
+ * @param eid - The entity ID
+ * @returns The scrollback limit, or 0 if no limit
+ */
+export function getScrollback(_world: World, eid: Entity): number {
+	return Log.scrollback[eid] ?? 0;
+}
+
+/**
+ * Resets the Log component store. Useful for testing.
+ * @internal
+ */
+export function resetLogStore(): void {
+	Log.isLog.fill(0);
+	Log.mouseEnabled.fill(0);
+	Log.keysEnabled.fill(0);
+	Log.scrollOnInput.fill(0);
+	Log.timestamps.fill(0);
+	Log.scrollback.fill(0);
+	Log.lineCount.fill(0);
+	logStateMap.clear();
+}


### PR DESCRIPTION
## Summary

- Add Log widget with scrollback limit, auto-scroll, and timestamps
- Add time utilities (formatDate, unixTimestamp) for timestamp formatting
- Support printf-style message formatting with %s, %d, %j tokens
- Include comprehensive test coverage (54 new tests)

## Features

The Log widget provides an append-only scrollable display for log messages:

- **Scrollback limit**: Automatically prunes old lines when exceeding the limit
- **Auto-scroll**: Automatically scrolls to bottom on new content
- **Timestamps**: Optional timestamps with configurable format
- **Printf-style formatting**: Supports %s, %d, %i, %f, %j, %o, %O tokens

## API

```typescript
const log = createLog(world, entity, {
  scrollback: 500,       // Keep last 500 lines
  timestamps: true,       // Add timestamps
  timestampFormat: 'HH:mm:ss.SSS',
  scrollOnInput: true,    // Auto-scroll to bottom
});

log.log('Server started on port %d', 3000);
log.log('Connection from %s', '192.168.1.1');
log.log({ user: 'alice', action: 'login' });
log.clear();
```

## Test plan

- [x] Unit tests for Log widget (34 tests)
- [x] Unit tests for time utilities (20 tests)
- [x] All existing tests pass (8203 tests)
- [x] TypeScript types check
- [x] Build succeeds

Closes #382