### PR TITLE
feat(widgets): add FileManager widget for file browsing

### DIFF
--- a/src/widgets/fileManager.test.ts
+++ b/src/widgets/fileManager.test.ts
@@ -1,0 +1,765 @@
+/**
+ * Tests for the FileManager widget.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getPosition } from '../components/position';
+import { getRenderable } from '../components/renderable';
+import { addEntity, createWorld } from '../core/ecs';
+import type { World } from '../core/types';
+import type { FileEntry } from './fileManager';
+import {
+	createFileManager,
+	FileManager,
+	FileManagerConfigSchema,
+	fileManagerStateMap,
+	handleFileManagerKey,
+	isFileManager,
+	resetFileManagerStore,
+	setReadDirFn,
+} from './fileManager';
+
+// =============================================================================
+// Mock data
+// =============================================================================
+
+function createMockEntries(dir: string): FileEntry[] {
+	return [
+		{ name: 'src', path: `${dir}/src`, isDirectory: true, size: 0 },
+		{ name: 'docs', path: `${dir}/docs`, isDirectory: true, size: 0 },
+		{ name: 'README.md', path: `${dir}/README.md`, isDirectory: false, size: 500 },
+		{ name: 'package.json', path: `${dir}/package.json`, isDirectory: false, size: 200 },
+		{ name: 'index.ts', path: `${dir}/index.ts`, isDirectory: false, size: 100 },
+	];
+}
+
+function createMockEntriesWithHidden(dir: string): FileEntry[] {
+	return [
+		...createMockEntries(dir),
+		{ name: '.gitignore', path: `${dir}/.gitignore`, isDirectory: false, size: 50 },
+		{ name: '.env', path: `${dir}/.env`, isDirectory: false, size: 30 },
+		{ name: '.config', path: `${dir}/.config`, isDirectory: true, size: 0 },
+	];
+}
+
+function createSubdirEntries(dir: string): FileEntry[] {
+	return [
+		{ name: 'components', path: `${dir}/components`, isDirectory: true, size: 0 },
+		{ name: 'utils', path: `${dir}/utils`, isDirectory: true, size: 0 },
+		{ name: 'main.ts', path: `${dir}/main.ts`, isDirectory: false, size: 300 },
+	];
+}
+
+function mockReadDir(dir: string): FileEntry[] {
+	if (dir.endsWith('/src')) return createSubdirEntries(dir);
+	return createMockEntries(dir);
+}
+
+function mockReadDirWithHidden(dir: string): FileEntry[] {
+	if (dir.endsWith('/src')) return createSubdirEntries(dir);
+	return createMockEntriesWithHidden(dir);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('FileManager widget', () => {
+	let world: World;
+
+	beforeEach(() => {
+		world = createWorld();
+		resetFileManagerStore();
+	});
+
+	afterEach(() => {
+		resetFileManagerStore();
+	});
+
+	// =========================================================================
+	// Schema validation
+	// =========================================================================
+
+	describe('FileManagerConfigSchema', () => {
+		it('validates empty config with defaults', () => {
+			const result = FileManagerConfigSchema.safeParse({});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.showHidden).toBe(false);
+			}
+		});
+
+		it('validates all config options', () => {
+			const result = FileManagerConfigSchema.safeParse({
+				cwd: '/home/user',
+				showHidden: true,
+				filePattern: '*.ts',
+				width: 50,
+				height: 25,
+				left: 10,
+				top: 5,
+				fg: '#ffffff',
+				bg: '#333333',
+				border: { type: 'line', fg: '#888888' },
+				padding: 1,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it('validates numeric colors', () => {
+			const result = FileManagerConfigSchema.safeParse({
+				fg: 0xffffffff,
+				bg: 0x333333ff,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it('validates padding as object', () => {
+			const result = FileManagerConfigSchema.safeParse({
+				padding: { left: 1, top: 2, right: 1, bottom: 0 },
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it('rejects negative padding', () => {
+			const result = FileManagerConfigSchema.safeParse({ padding: -5 });
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects non-positive width', () => {
+			const result = FileManagerConfigSchema.safeParse({ width: 0 });
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects non-positive height', () => {
+			const result = FileManagerConfigSchema.safeParse({ height: -1 });
+			expect(result.success).toBe(false);
+		});
+	});
+
+	// =========================================================================
+	// Creation
+	// =========================================================================
+
+	describe('createFileManager', () => {
+		it('creates a file manager with default config', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			expect(fm.eid).toBeDefined();
+			expect(isFileManager(world, fm.eid)).toBe(true);
+		});
+
+		it('creates a file manager with custom config', () => {
+			const fm = createFileManager(world, {
+				cwd: '/test',
+				width: 60,
+				height: 30,
+				left: 10,
+				top: 5,
+			});
+			setReadDirFn(fm.eid, mockReadDir);
+
+			expect(fm.getCwd()).toContain('test');
+			const pos = getPosition(world, fm.eid);
+			expect(pos?.x).toBe(10);
+			expect(pos?.y).toBe(5);
+		});
+
+		it('marks entity as file manager in component', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			expect(FileManager.isFileManager[fm.eid]).toBe(1);
+		});
+
+		it('starts visible by default', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			const renderable = getRenderable(world, fm.eid);
+			expect(renderable?.visible).toBe(true);
+		});
+	});
+
+	// =========================================================================
+	// setCwd / getCwd
+	// =========================================================================
+
+	describe('setCwd / getCwd', () => {
+		it('setCwd changes the current directory', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+
+			fm.setCwd('/other');
+
+			expect(fm.getCwd()).toContain('other');
+		});
+
+		it('setCwd refreshes entries', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			const readFn = vi.fn(mockReadDir);
+			setReadDirFn(fm.eid, readFn);
+
+			fm.setCwd('/test/src');
+
+			expect(readFn).toHaveBeenCalled();
+			const entries = fm.getEntries();
+			expect(entries.length).toBeGreaterThan(0);
+		});
+
+		it('setCwd resets selected index to 0', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			// Move selection down
+			handleFileManagerKey(world, fm.eid, 'down');
+			expect(FileManager.selectedIndex[fm.eid]).toBe(1);
+
+			// Change directory
+			fm.setCwd('/test/src');
+			expect(FileManager.selectedIndex[fm.eid]).toBe(0);
+		});
+
+		it('setCwd returns widget for chaining', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+
+			const result = fm.setCwd('/test/src');
+			expect(result).toBe(fm);
+		});
+	});
+
+	// =========================================================================
+	// getSelected
+	// =========================================================================
+
+	describe('getSelected', () => {
+		it('returns the first entry by default', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			const selected = fm.getSelected();
+			expect(selected).toBeDefined();
+			// Directories come first when sorted
+			expect(selected?.isDirectory).toBe(true);
+		});
+
+		it('returns the entry at the current selected index', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			handleFileManagerKey(world, fm.eid, 'down');
+			handleFileManagerKey(world, fm.eid, 'down');
+
+			const selected = fm.getSelected();
+			expect(selected).toBeDefined();
+		});
+
+		it('returns undefined when no entries exist', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, () => []);
+			fm.refresh();
+
+			expect(fm.getSelected()).toBeUndefined();
+		});
+	});
+
+	// =========================================================================
+	// getEntries (sorted: dirs first)
+	// =========================================================================
+
+	describe('getEntries', () => {
+		it('returns sorted entries with directories first', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			const entries = fm.getEntries();
+			// Find the index where files start
+			let firstFileIndex = entries.length;
+			for (let i = 0; i < entries.length; i++) {
+				if (!entries[i]?.isDirectory) {
+					firstFileIndex = i;
+					break;
+				}
+			}
+
+			// All entries before firstFileIndex should be directories
+			for (let i = 0; i < firstFileIndex; i++) {
+				expect(entries[i]?.isDirectory).toBe(true);
+			}
+			// All entries from firstFileIndex onward should be files
+			for (let i = firstFileIndex; i < entries.length; i++) {
+				expect(entries[i]?.isDirectory).toBe(false);
+			}
+		});
+
+		it('sorts directories alphabetically', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			const entries = fm.getEntries();
+			const dirs = entries.filter((e) => e.isDirectory);
+			for (let i = 1; i < dirs.length; i++) {
+				const prev = dirs[i - 1] as FileEntry;
+				const curr = dirs[i] as FileEntry;
+				expect(prev.name.localeCompare(curr.name)).toBeLessThanOrEqual(0);
+			}
+		});
+
+		it('sorts files alphabetically', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			const entries = fm.getEntries();
+			const files = entries.filter((e) => !e.isDirectory);
+			for (let i = 1; i < files.length; i++) {
+				const prev = files[i - 1] as FileEntry;
+				const curr = files[i] as FileEntry;
+				expect(prev.name.localeCompare(curr.name)).toBeLessThanOrEqual(0);
+			}
+		});
+
+		it('hides hidden files by default', () => {
+			const fm = createFileManager(world, { cwd: '/test', showHidden: false });
+			setReadDirFn(fm.eid, mockReadDirWithHidden);
+			fm.refresh();
+
+			const entries = fm.getEntries();
+			const hiddenEntries = entries.filter((e) => e.name.startsWith('.'));
+			expect(hiddenEntries).toHaveLength(0);
+		});
+
+		it('shows hidden files when showHidden is true', () => {
+			const fm = createFileManager(world, { cwd: '/test', showHidden: true });
+			setReadDirFn(fm.eid, mockReadDirWithHidden);
+			fm.refresh();
+
+			const entries = fm.getEntries();
+			const hiddenEntries = entries.filter((e) => e.name.startsWith('.'));
+			expect(hiddenEntries.length).toBeGreaterThan(0);
+		});
+
+		it('filters by file pattern (directories always shown)', () => {
+			const fm = createFileManager(world, { cwd: '/test', filePattern: '*.ts' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			const entries = fm.getEntries();
+			const files = entries.filter((e) => !e.isDirectory);
+			for (const file of files) {
+				expect(file.name.endsWith('.ts')).toBe(true);
+			}
+			// Directories should still be present
+			const dirs = entries.filter((e) => e.isDirectory);
+			expect(dirs.length).toBeGreaterThan(0);
+		});
+
+		it('returns empty array when directory read fails', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, () => {
+				throw new Error('Permission denied');
+			});
+			fm.refresh();
+
+			expect(fm.getEntries()).toHaveLength(0);
+		});
+	});
+
+	// =========================================================================
+	// show / hide
+	// =========================================================================
+
+	describe('show / hide', () => {
+		it('show() makes the widget visible', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			fm.hide().show();
+
+			const renderable = getRenderable(world, fm.eid);
+			expect(renderable?.visible).toBe(true);
+		});
+
+		it('hide() makes the widget invisible', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			fm.hide();
+
+			const renderable = getRenderable(world, fm.eid);
+			expect(renderable?.visible).toBe(false);
+		});
+
+		it('show() returns widget for chaining', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			expect(fm.show()).toBe(fm);
+		});
+
+		it('hide() returns widget for chaining', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			expect(fm.hide()).toBe(fm);
+		});
+	});
+
+	// =========================================================================
+	// center / move / setPosition
+	// =========================================================================
+
+	describe('position', () => {
+		it('center() centers the widget', () => {
+			const fm = createFileManager(world, { cwd: '/test', width: 40, height: 20 });
+
+			fm.center(80, 24);
+
+			const pos = getPosition(world, fm.eid);
+			expect(pos?.x).toBe(20); // (80 - 40) / 2
+			expect(pos?.y).toBe(2); // (24 - 20) / 2
+		});
+
+		it('move() changes position by delta', () => {
+			const fm = createFileManager(world, { cwd: '/test', left: 10, top: 5 });
+
+			fm.move(5, -3);
+
+			const pos = getPosition(world, fm.eid);
+			expect(pos?.x).toBe(15);
+			expect(pos?.y).toBe(2);
+		});
+
+		it('setPosition() sets absolute position', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+
+			fm.setPosition(50, 30);
+
+			const pos = getPosition(world, fm.eid);
+			expect(pos?.x).toBe(50);
+			expect(pos?.y).toBe(30);
+		});
+
+		it('center() returns widget for chaining', () => {
+			const fm = createFileManager(world, { cwd: '/test', width: 40, height: 20 });
+			expect(fm.center(80, 24)).toBe(fm);
+		});
+
+		it('move() returns widget for chaining', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			expect(fm.move(1, 1)).toBe(fm);
+		});
+
+		it('setPosition() returns widget for chaining', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			expect(fm.setPosition(1, 1)).toBe(fm);
+		});
+	});
+
+	// =========================================================================
+	// Key handling
+	// =========================================================================
+
+	describe('handleFileManagerKey', () => {
+		it('up moves selection up', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			handleFileManagerKey(world, fm.eid, 'down');
+			handleFileManagerKey(world, fm.eid, 'down');
+			handleFileManagerKey(world, fm.eid, 'up');
+
+			expect(FileManager.selectedIndex[fm.eid]).toBe(1);
+		});
+
+		it('down moves selection down', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			handleFileManagerKey(world, fm.eid, 'down');
+
+			expect(FileManager.selectedIndex[fm.eid]).toBe(1);
+		});
+
+		it('up does not go below 0', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			handleFileManagerKey(world, fm.eid, 'up');
+
+			expect(FileManager.selectedIndex[fm.eid]).toBe(0);
+		});
+
+		it('down does not exceed entry count', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			const entryCount = fm.getEntries().length;
+			for (let i = 0; i < entryCount + 5; i++) {
+				handleFileManagerKey(world, fm.eid, 'down');
+			}
+
+			expect(FileManager.selectedIndex[fm.eid]).toBe(entryCount - 1);
+		});
+
+		it('enter on directory navigates into it', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			const navCb = vi.fn();
+			fm.onNavigate(navCb);
+
+			// First entry should be a directory (dirs sorted first)
+			handleFileManagerKey(world, fm.eid, 'enter');
+
+			expect(navCb).toHaveBeenCalledOnce();
+			expect(fm.getCwd()).toContain('docs'); // 'docs' is alphabetically first dir
+		});
+
+		it('enter on file fires onSelect callback', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			const selectCb = vi.fn();
+			fm.onSelect(selectCb);
+
+			// Navigate past directories to first file
+			const dirs = fm.getEntries().filter((e) => e.isDirectory);
+			for (let i = 0; i < dirs.length; i++) {
+				handleFileManagerKey(world, fm.eid, 'down');
+			}
+
+			handleFileManagerKey(world, fm.eid, 'enter');
+
+			expect(selectCb).toHaveBeenCalledOnce();
+			expect(selectCb.mock.calls[0]?.[0]?.isDirectory).toBe(false);
+		});
+
+		it('backspace navigates to parent directory', () => {
+			const fm = createFileManager(world, { cwd: '/test/nested' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			const navCb = vi.fn();
+			fm.onNavigate(navCb);
+
+			handleFileManagerKey(world, fm.eid, 'backspace');
+
+			expect(fm.getCwd()).toContain('test');
+			expect(navCb).toHaveBeenCalledOnce();
+		});
+
+		it('returns false for non-file-manager entities', () => {
+			const eid = addEntity(world);
+			expect(handleFileManagerKey(world, eid, 'enter')).toBe(false);
+		});
+
+		it('returns false for unhandled keys', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			expect(handleFileManagerKey(world, fm.eid, 'tab')).toBe(false);
+		});
+	});
+
+	// =========================================================================
+	// Callbacks
+	// =========================================================================
+
+	describe('callbacks', () => {
+		it('onSelect returns widget for chaining', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			expect(fm.onSelect(() => {})).toBe(fm);
+		});
+
+		it('onNavigate returns widget for chaining', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			expect(fm.onNavigate(() => {})).toBe(fm);
+		});
+
+		it('supports multiple onSelect callbacks', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			const cb1 = vi.fn();
+			const cb2 = vi.fn();
+			fm.onSelect(cb1).onSelect(cb2);
+
+			// Navigate to first file
+			const dirs = fm.getEntries().filter((e) => e.isDirectory);
+			for (let i = 0; i < dirs.length; i++) {
+				handleFileManagerKey(world, fm.eid, 'down');
+			}
+			handleFileManagerKey(world, fm.eid, 'enter');
+
+			expect(cb1).toHaveBeenCalledOnce();
+			expect(cb2).toHaveBeenCalledOnce();
+		});
+
+		it('supports multiple onNavigate callbacks', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			const cb1 = vi.fn();
+			const cb2 = vi.fn();
+			fm.onNavigate(cb1).onNavigate(cb2);
+
+			// Enter first directory
+			handleFileManagerKey(world, fm.eid, 'enter');
+
+			expect(cb1).toHaveBeenCalledOnce();
+			expect(cb2).toHaveBeenCalledOnce();
+		});
+	});
+
+	// =========================================================================
+	// refresh
+	// =========================================================================
+
+	describe('refresh', () => {
+		it('reloads entries from the filesystem', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			let callCount = 0;
+			setReadDirFn(fm.eid, (dir) => {
+				callCount++;
+				return mockReadDir(dir);
+			});
+
+			fm.refresh();
+			fm.refresh();
+
+			expect(callCount).toBe(2);
+		});
+
+		it('clamps selected index when entries shrink', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			fm.refresh();
+
+			// Move to last entry
+			const entries = fm.getEntries();
+			for (let i = 0; i < entries.length - 1; i++) {
+				handleFileManagerKey(world, fm.eid, 'down');
+			}
+
+			// Replace with fewer entries
+			setReadDirFn(fm.eid, () => [
+				{ name: 'only.txt', path: '/test/only.txt', isDirectory: false, size: 10 },
+			]);
+			fm.refresh();
+
+			expect(FileManager.selectedIndex[fm.eid]).toBe(0);
+		});
+
+		it('returns widget for chaining', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, mockReadDir);
+			expect(fm.refresh()).toBe(fm);
+		});
+	});
+
+	// =========================================================================
+	// destroy
+	// =========================================================================
+
+	describe('destroy', () => {
+		it('removes file manager marker', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			const eid = fm.eid;
+
+			expect(isFileManager(world, eid)).toBe(true);
+			fm.destroy();
+			expect(isFileManager(world, eid)).toBe(false);
+		});
+
+		it('clears typed array data', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			const eid = fm.eid;
+
+			fm.destroy();
+
+			expect(FileManager.isFileManager[eid]).toBe(0);
+			expect(FileManager.selectedIndex[eid]).toBe(0);
+		});
+
+		it('removes state from map', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			const eid = fm.eid;
+
+			fm.destroy();
+
+			expect(fileManagerStateMap.has(eid)).toBe(false);
+		});
+	});
+
+	// =========================================================================
+	// isFileManager utility
+	// =========================================================================
+
+	describe('isFileManager', () => {
+		it('returns true for file manager entities', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			expect(isFileManager(world, fm.eid)).toBe(true);
+		});
+
+		it('returns false for non-file-manager entities', () => {
+			const eid = addEntity(world);
+			expect(isFileManager(world, eid)).toBe(false);
+		});
+	});
+
+	// =========================================================================
+	// resetFileManagerStore
+	// =========================================================================
+
+	describe('resetFileManagerStore', () => {
+		it('clears all file manager state', () => {
+			const fm1 = createFileManager(world, { cwd: '/test' });
+			const fm2 = createFileManager(world, { cwd: '/test' });
+
+			resetFileManagerStore();
+
+			expect(FileManager.isFileManager[fm1.eid]).toBe(0);
+			expect(FileManager.isFileManager[fm2.eid]).toBe(0);
+			expect(fileManagerStateMap.size).toBe(0);
+		});
+	});
+
+	// =========================================================================
+	// Method chaining
+	// =========================================================================
+
+	describe('method chaining', () => {
+		it('supports full method chaining', () => {
+			const fm = createFileManager(world, { cwd: '/test', width: 40, height: 20 });
+			setReadDirFn(fm.eid, mockReadDir);
+
+			fm.show().setPosition(10, 10).move(5, 5).setCwd('/test').refresh().center(80, 24);
+
+			const pos = getPosition(world, fm.eid);
+			expect(pos?.x).toBe(20); // (80 - 40) / 2
+			expect(pos?.y).toBe(2); // (24 - 20) / 2
+		});
+	});
+
+	// =========================================================================
+	// Error handling
+	// =========================================================================
+
+	describe('error handling', () => {
+		it('handles readDir errors gracefully', () => {
+			const fm = createFileManager(world, { cwd: '/test' });
+			setReadDirFn(fm.eid, () => {
+				throw new Error('EACCES: permission denied');
+			});
+
+			expect(() => fm.refresh()).not.toThrow();
+			expect(fm.getEntries()).toHaveLength(0);
+		});
+	});
+});

--- a/src/widgets/fileManager.ts
+++ b/src/widgets/fileManager.ts
@@ -1,0 +1,801 @@
+/**
+ * FileManager Widget
+ *
+ * A file browser widget for navigating directories and selecting files.
+ * Supports directory navigation, sorted entries (directories first),
+ * hidden file toggle, and glob-based file filtering.
+ *
+ * @module widgets/fileManager
+ */
+
+import { readdirSync, statSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { z } from 'zod';
+import {
+	BORDER_SINGLE,
+	type BorderCharset,
+	BorderType,
+	setBorder,
+	setBorderChars,
+} from '../components/border';
+import { setContent, TextAlign, TextVAlign } from '../components/content';
+import { setDimensions } from '../components/dimensions';
+import { setPadding } from '../components/padding';
+import { moveBy, setPosition } from '../components/position';
+import { hexToColor, markDirty, setStyle, setVisible } from '../components/renderable';
+import { addEntity, removeEntity } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Represents a single file or directory entry.
+ */
+export interface FileEntry {
+	/** File or directory name */
+	readonly name: string;
+	/** Full absolute path */
+	readonly path: string;
+	/** Whether this entry is a directory */
+	readonly isDirectory: boolean;
+	/** File size in bytes (0 for directories) */
+	readonly size: number;
+}
+
+/**
+ * Border configuration for the file manager.
+ */
+export interface FileManagerBorderConfig {
+	/** Border type */
+	readonly type?: 'line' | 'bg' | 'none';
+	/** Foreground color for border (hex string or packed number) */
+	readonly fg?: string | number;
+	/** Background color for border (hex string or packed number) */
+	readonly bg?: string | number;
+	/** Border charset ('single', 'double', 'rounded', 'bold', 'ascii', or custom) */
+	readonly ch?: 'single' | 'double' | 'rounded' | 'bold' | 'ascii' | BorderCharset;
+}
+
+/**
+ * Padding configuration (all sides, or individual sides).
+ */
+export type FileManagerPaddingConfig =
+	| number
+	| {
+			readonly left?: number;
+			readonly top?: number;
+			readonly right?: number;
+			readonly bottom?: number;
+	  };
+
+/**
+ * Configuration for creating a FileManager widget.
+ */
+export interface FileManagerConfig {
+	/** Initial working directory (default: process.cwd()) */
+	readonly cwd?: string;
+	/** Whether to show hidden files (default: false) */
+	readonly showHidden?: boolean;
+	/** Simple glob pattern for filtering files (e.g., '*.ts', '*.js') */
+	readonly filePattern?: string;
+	/** Width of the widget */
+	readonly width?: number;
+	/** Height of the widget */
+	readonly height?: number;
+	/** Left position (absolute) */
+	readonly left?: number;
+	/** Top position (absolute) */
+	readonly top?: number;
+	/** Foreground color (hex string or packed number) */
+	readonly fg?: string | number;
+	/** Background color (hex string or packed number) */
+	readonly bg?: string | number;
+	/** Border configuration */
+	readonly border?: FileManagerBorderConfig;
+	/** Padding configuration for content area */
+	readonly padding?: FileManagerPaddingConfig;
+}
+
+/**
+ * FileManager widget interface providing chainable methods.
+ */
+export interface FileManagerWidget {
+	/** The underlying entity ID */
+	readonly eid: Entity;
+
+	// Visibility
+	/** Shows the file manager */
+	show(): FileManagerWidget;
+	/** Hides the file manager */
+	hide(): FileManagerWidget;
+
+	// Position
+	/** Moves the widget by dx, dy */
+	move(dx: number, dy: number): FileManagerWidget;
+	/** Sets the absolute position */
+	setPosition(x: number, y: number): FileManagerWidget;
+	/** Centers the widget (requires terminal width/height) */
+	center(termWidth: number, termHeight: number): FileManagerWidget;
+
+	// Navigation
+	/** Sets the current working directory */
+	setCwd(path: string): FileManagerWidget;
+	/** Gets the current working directory */
+	getCwd(): string;
+	/** Gets the currently selected entry (by cursor index) */
+	getSelected(): FileEntry | undefined;
+	/** Refreshes the directory listing */
+	refresh(): FileManagerWidget;
+	/** Gets all current directory entries */
+	getEntries(): readonly FileEntry[];
+
+	// Callbacks
+	/** Registers a callback for when a file is selected (Enter on a file) */
+	onSelect(cb: (entry: FileEntry) => void): FileManagerWidget;
+	/** Registers a callback for when navigating to a directory */
+	onNavigate(cb: (path: string) => void): FileManagerWidget;
+
+	// Lifecycle
+	/** Destroys the widget and removes it from the world */
+	destroy(): void;
+}
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/** Default entity capacity for typed arrays */
+const DEFAULT_CAPACITY = 10000;
+
+/** Default widget width */
+const DEFAULT_FILE_MANAGER_WIDTH = 40;
+
+/** Default widget height */
+const DEFAULT_FILE_MANAGER_HEIGHT = 20;
+
+/** Icon for directories */
+const DIR_ICON = '/';
+
+/** Icon for parent directory */
+const PARENT_DIR_ENTRY = '..';
+
+// =============================================================================
+// SCHEMAS
+// =============================================================================
+
+/**
+ * Zod schema for file manager border configuration.
+ */
+const FileManagerBorderConfigSchema = z.object({
+	type: z.enum(['line', 'bg', 'none']).optional(),
+	fg: z.union([z.string(), z.number()]).optional(),
+	bg: z.union([z.string(), z.number()]).optional(),
+	ch: z
+		.union([z.enum(['single', 'double', 'rounded', 'bold', 'ascii']), z.object({}).passthrough()])
+		.optional(),
+});
+
+/**
+ * Zod schema for file manager padding configuration.
+ */
+const FileManagerPaddingSchema = z.union([
+	z.number().nonnegative(),
+	z.object({
+		left: z.number().nonnegative().optional(),
+		top: z.number().nonnegative().optional(),
+		right: z.number().nonnegative().optional(),
+		bottom: z.number().nonnegative().optional(),
+	}),
+]);
+
+/**
+ * Zod schema for FileManager widget configuration.
+ *
+ * @example
+ * ```typescript
+ * import { FileManagerConfigSchema } from 'blecsd';
+ *
+ * const result = FileManagerConfigSchema.safeParse({
+ *   cwd: '/home/user',
+ *   showHidden: false,
+ *   width: 50,
+ *   height: 25,
+ * });
+ * ```
+ */
+export const FileManagerConfigSchema = z.object({
+	cwd: z.string().optional(),
+	showHidden: z.boolean().optional().default(false),
+	filePattern: z.string().optional(),
+	width: z.number().int().positive().optional(),
+	height: z.number().int().positive().optional(),
+	left: z.number().int().optional(),
+	top: z.number().int().optional(),
+	fg: z.union([z.string(), z.number()]).optional(),
+	bg: z.union([z.string(), z.number()]).optional(),
+	border: FileManagerBorderConfigSchema.optional(),
+	padding: FileManagerPaddingSchema.optional(),
+});
+
+// =============================================================================
+// COMPONENT TAG
+// =============================================================================
+
+/**
+ * FileManager component marker for identifying file manager entities.
+ *
+ * @example
+ * ```typescript
+ * import { FileManager } from 'blecsd';
+ *
+ * if (FileManager.isFileManager[eid] === 1) {
+ *   // Entity is a file manager
+ * }
+ * ```
+ */
+export const FileManager = {
+	/** Tag indicating this is a file manager widget (1 = yes) */
+	isFileManager: new Uint8Array(DEFAULT_CAPACITY),
+	/** Currently selected index */
+	selectedIndex: new Uint32Array(DEFAULT_CAPACITY),
+};
+
+// =============================================================================
+// INTERNAL STATE
+// =============================================================================
+
+/**
+ * Complex state for file manager entities.
+ */
+interface FileManagerState {
+	cwd: string;
+	showHidden: boolean;
+	filePattern: string | undefined;
+	width: number;
+	height: number;
+	entries: FileEntry[];
+	onSelectCallbacks: Array<(entry: FileEntry) => void>;
+	onNavigateCallbacks: Array<(path: string) => void>;
+	/** Injected readDir function (for testing) */
+	readDirFn: (dirPath: string) => FileEntry[];
+}
+
+/**
+ * Store for complex file manager state.
+ */
+export const fileManagerStateMap = new Map<Entity, FileManagerState>();
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+/**
+ * Parses a color value to a packed 32-bit color.
+ */
+function parseColor(color: string | number): number {
+	if (typeof color === 'string') {
+		return hexToColor(color);
+	}
+	return color;
+}
+
+/**
+ * Converts border charset name to actual charset.
+ */
+function getBorderCharset(ch: string | object | undefined): BorderCharset {
+	if (typeof ch === 'object') return ch as BorderCharset;
+	if (ch === undefined || ch === 'single') return BORDER_SINGLE;
+	return BORDER_SINGLE;
+}
+
+/**
+ * Matches a filename against a simple glob pattern.
+ * Supports only '*' wildcards (e.g., '*.ts', 'README.*', '*test*').
+ */
+function matchGlob(filename: string, pattern: string): boolean {
+	const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+	const regex = escaped.replace(/\*/g, '.*');
+	return new RegExp(`^${regex}$`, 'i').test(filename);
+}
+
+/**
+ * Reads directory entries, handling permission errors gracefully.
+ */
+function defaultReadDir(dirPath: string): FileEntry[] {
+	try {
+		const names = readdirSync(dirPath);
+		const entries: FileEntry[] = [];
+		for (const name of names) {
+			const fullPath = join(dirPath, name);
+			try {
+				const stat = statSync(fullPath);
+				entries.push({
+					name,
+					path: fullPath,
+					isDirectory: stat.isDirectory(),
+					size: stat.isDirectory() ? 0 : stat.size,
+				});
+			} catch {
+				// Skip entries we can't stat (permission denied, broken symlinks, etc.)
+			}
+		}
+		return entries;
+	} catch {
+		// Permission denied or directory doesn't exist
+		return [];
+	}
+}
+
+/**
+ * Sorts entries: directories first (alphabetically), then files (alphabetically).
+ */
+function sortEntries(entries: readonly FileEntry[]): FileEntry[] {
+	return [...entries].sort((a, b) => {
+		if (a.isDirectory !== b.isDirectory) {
+			return a.isDirectory ? -1 : 1;
+		}
+		return a.name.localeCompare(b.name);
+	});
+}
+
+/**
+ * Filters entries based on showHidden and filePattern settings.
+ */
+function filterEntries(
+	entries: readonly FileEntry[],
+	showHidden: boolean,
+	filePattern: string | undefined,
+): FileEntry[] {
+	return entries.filter((entry) => {
+		if (!showHidden && entry.name.startsWith('.')) return false;
+		if (filePattern && !entry.isDirectory && !matchGlob(entry.name, filePattern)) return false;
+		return true;
+	});
+}
+
+/**
+ * Loads and processes directory entries for a file manager state.
+ */
+function loadEntries(state: FileManagerState): FileEntry[] {
+	let raw: FileEntry[];
+	try {
+		raw = state.readDirFn(state.cwd);
+	} catch {
+		return [];
+	}
+	const filtered = filterEntries(raw, state.showHidden, state.filePattern);
+	return sortEntries(filtered);
+}
+
+/**
+ * Builds display content string from entries.
+ */
+function buildContent(state: FileManagerState): string {
+	const lines: string[] = [];
+	const dirName = basename(state.cwd) || state.cwd;
+	lines.push(`[${dirName}]`);
+	lines.push(PARENT_DIR_ENTRY);
+
+	for (let i = 0; i < state.entries.length; i++) {
+		const entry = state.entries[i] as FileEntry;
+		const prefix = i === FileManager.selectedIndex[0] ? '> ' : '  ';
+		const suffix = entry.isDirectory ? DIR_ICON : '';
+		lines.push(`${prefix}${entry.name}${suffix}`);
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Applies style colors to an entity.
+ */
+function applyStyle(
+	world: World,
+	eid: Entity,
+	fg: string | number | undefined,
+	bg: string | number | undefined,
+): void {
+	if (fg === undefined && bg === undefined) return;
+	setStyle(world, eid, {
+		fg: fg !== undefined ? parseColor(fg) : undefined,
+		bg: bg !== undefined ? parseColor(bg) : undefined,
+	});
+}
+
+/**
+ * Applies border configuration to an entity.
+ */
+function applyBorder(
+	world: World,
+	eid: Entity,
+	borderConfig:
+		| { type?: string; fg?: string | number; bg?: string | number; ch?: string | object }
+		| undefined,
+): void {
+	if (borderConfig?.type === 'none') return;
+	const borderType = borderConfig?.type === 'bg' ? BorderType.Background : BorderType.Line;
+	setBorder(world, eid, {
+		type: borderType,
+		fg: borderConfig?.fg !== undefined ? parseColor(borderConfig.fg) : undefined,
+		bg: borderConfig?.bg !== undefined ? parseColor(borderConfig.bg) : undefined,
+	});
+	setBorderChars(world, eid, getBorderCharset(borderConfig?.ch));
+}
+
+/**
+ * Applies padding to an entity from config.
+ */
+function applyPadding(
+	world: World,
+	eid: Entity,
+	padding: number | { left?: number; top?: number; right?: number; bottom?: number } | undefined,
+): void {
+	if (typeof padding === 'number') {
+		setPadding(world, eid, { left: padding, top: padding, right: padding, bottom: padding });
+		return;
+	}
+	if (padding) {
+		setPadding(world, eid, {
+			left: padding.left ?? 0,
+			top: padding.top ?? 0,
+			right: padding.right ?? 0,
+			bottom: padding.bottom ?? 0,
+		});
+	}
+}
+
+/**
+ * Updates the content display for a file manager entity.
+ */
+function updateDisplay(world: World, eid: Entity, state: FileManagerState): void {
+	const content = buildContent(state);
+	setContent(world, eid, content, { align: TextAlign.Left, valign: TextVAlign.Top });
+	markDirty(world, eid);
+}
+
+// =============================================================================
+// FACTORY
+// =============================================================================
+
+/**
+ * Creates a FileManager widget with the given configuration.
+ *
+ * The file manager lists directory contents, supports navigation, and
+ * fires callbacks when files are selected or directories are entered.
+ *
+ * @param world - The ECS world
+ * @param config - FileManager configuration
+ * @returns The FileManagerWidget instance
+ *
+ * @example
+ * ```typescript
+ * import { createWorld } from 'blecsd';
+ * import { createFileManager } from 'blecsd';
+ *
+ * const world = createWorld();
+ * const fm = createFileManager(world, {
+ *   cwd: '/home/user',
+ *   showHidden: false,
+ *   width: 50,
+ *   height: 25,
+ * });
+ *
+ * fm.onSelect((entry) => {
+ *   console.log('Selected:', entry.name);
+ * });
+ *
+ * fm.show();
+ * ```
+ */
+export function createFileManager(world: World, config: FileManagerConfig = {}): FileManagerWidget {
+	const validated = FileManagerConfigSchema.parse(config);
+	const eid = addEntity(world);
+
+	const width = validated.width ?? DEFAULT_FILE_MANAGER_WIDTH;
+	const height = validated.height ?? DEFAULT_FILE_MANAGER_HEIGHT;
+	const cwd = validated.cwd ? resolve(validated.cwd) : process.cwd();
+
+	// Mark as file manager
+	FileManager.isFileManager[eid] = 1;
+	FileManager.selectedIndex[eid] = 0;
+
+	// Build state
+	const state: FileManagerState = {
+		cwd,
+		showHidden: validated.showHidden,
+		filePattern: validated.filePattern,
+		width,
+		height,
+		entries: [],
+		onSelectCallbacks: [],
+		onNavigateCallbacks: [],
+		readDirFn: defaultReadDir,
+	};
+	fileManagerStateMap.set(eid, state);
+
+	// Load initial entries
+	state.entries = loadEntries(state);
+
+	// Set position and dimensions
+	setPosition(world, eid, validated.left ?? 0, validated.top ?? 0);
+	setDimensions(world, eid, width, height);
+
+	// Apply visual properties
+	applyStyle(world, eid, validated.fg, validated.bg);
+	applyBorder(world, eid, validated.border);
+	applyPadding(world, eid, validated.padding);
+
+	// Set initial content
+	updateDisplay(world, eid, state);
+
+	// Default to visible
+	setVisible(world, eid, true);
+
+	return createFileManagerWidgetInterface(world, eid);
+}
+
+/**
+ * Creates the FileManagerWidget interface for an entity.
+ */
+function createFileManagerWidgetInterface(world: World, eid: Entity): FileManagerWidget {
+	const widget: FileManagerWidget = {
+		eid,
+
+		show(): FileManagerWidget {
+			setVisible(world, eid, true);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		hide(): FileManagerWidget {
+			setVisible(world, eid, false);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		move(dx: number, dy: number): FileManagerWidget {
+			moveBy(world, eid, dx, dy);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		setPosition(newX: number, newY: number): FileManagerWidget {
+			setPosition(world, eid, newX, newY);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		center(termWidth: number, termHeight: number): FileManagerWidget {
+			const state = fileManagerStateMap.get(eid);
+			if (!state) return widget;
+			const cx = Math.max(0, Math.floor((termWidth - state.width) / 2));
+			const cy = Math.max(0, Math.floor((termHeight - state.height) / 2));
+			setPosition(world, eid, cx, cy);
+			markDirty(world, eid);
+			return widget;
+		},
+
+		setCwd(path: string): FileManagerWidget {
+			const state = fileManagerStateMap.get(eid);
+			if (!state) return widget;
+			state.cwd = resolve(path);
+			state.entries = loadEntries(state);
+			FileManager.selectedIndex[eid] = 0;
+			updateDisplay(world, eid, state);
+			return widget;
+		},
+
+		getCwd(): string {
+			return fileManagerStateMap.get(eid)?.cwd ?? '';
+		},
+
+		getSelected(): FileEntry | undefined {
+			const state = fileManagerStateMap.get(eid);
+			if (!state) return undefined;
+			const idx = FileManager.selectedIndex[eid] ?? 0;
+			return state.entries[idx];
+		},
+
+		refresh(): FileManagerWidget {
+			const state = fileManagerStateMap.get(eid);
+			if (!state) return widget;
+			state.entries = loadEntries(state);
+			const maxIdx = Math.max(0, state.entries.length - 1);
+			if ((FileManager.selectedIndex[eid] ?? 0) > maxIdx) {
+				FileManager.selectedIndex[eid] = maxIdx;
+			}
+			updateDisplay(world, eid, state);
+			return widget;
+		},
+
+		getEntries(): readonly FileEntry[] {
+			return fileManagerStateMap.get(eid)?.entries ?? [];
+		},
+
+		onSelect(cb: (entry: FileEntry) => void): FileManagerWidget {
+			const state = fileManagerStateMap.get(eid);
+			if (state) {
+				state.onSelectCallbacks.push(cb);
+			}
+			return widget;
+		},
+
+		onNavigate(cb: (path: string) => void): FileManagerWidget {
+			const state = fileManagerStateMap.get(eid);
+			if (state) {
+				state.onNavigateCallbacks.push(cb);
+			}
+			return widget;
+		},
+
+		destroy(): void {
+			FileManager.isFileManager[eid] = 0;
+			FileManager.selectedIndex[eid] = 0;
+			fileManagerStateMap.delete(eid);
+			removeEntity(world, eid);
+		},
+	};
+
+	return widget;
+}
+
+// =============================================================================
+// KEY HANDLING
+// =============================================================================
+
+/**
+ * Handles the 'enter' key: opens a file (fires onSelect) or navigates into a directory.
+ */
+function handleEnterKey(world: World, eid: Entity, state: FileManagerState): void {
+	const idx = FileManager.selectedIndex[eid] ?? 0;
+	const entry = state.entries[idx];
+	if (!entry) return;
+
+	if (entry.isDirectory) {
+		navigateToDir(world, eid, state, entry.path);
+	} else {
+		for (const cb of state.onSelectCallbacks) {
+			cb(entry);
+		}
+	}
+}
+
+/**
+ * Navigates to a directory, reloads entries, resets selection, and fires callbacks.
+ */
+function navigateToDir(world: World, eid: Entity, state: FileManagerState, dirPath: string): void {
+	state.cwd = dirPath;
+	state.entries = loadEntries(state);
+	FileManager.selectedIndex[eid] = 0;
+	updateDisplay(world, eid, state);
+	for (const cb of state.onNavigateCallbacks) {
+		cb(dirPath);
+	}
+}
+
+/**
+ * Handles a key event for a file manager widget.
+ *
+ * Supported keys:
+ * - `up`: Move selection up
+ * - `down`: Move selection down
+ * - `enter`: Open file (fires onSelect) or navigate into directory (fires onNavigate)
+ * - `backspace`: Navigate to parent directory
+ *
+ * @param world - The ECS world
+ * @param eid - The file manager entity ID
+ * @param key - The key name
+ * @returns true if the key was handled
+ *
+ * @example
+ * ```typescript
+ * import { handleFileManagerKey } from 'blecsd';
+ *
+ * // In an input handler:
+ * handleFileManagerKey(world, fmEid, 'enter');
+ * ```
+ */
+export function handleFileManagerKey(world: World, eid: Entity, key: string): boolean {
+	if (FileManager.isFileManager[eid] !== 1) return false;
+	const state = fileManagerStateMap.get(eid);
+	if (!state) return false;
+
+	switch (key) {
+		case 'up': {
+			const current = FileManager.selectedIndex[eid] ?? 0;
+			if (current > 0) {
+				FileManager.selectedIndex[eid] = current - 1;
+				updateDisplay(world, eid, state);
+			}
+			return true;
+		}
+
+		case 'down': {
+			const current = FileManager.selectedIndex[eid] ?? 0;
+			if (current < state.entries.length - 1) {
+				FileManager.selectedIndex[eid] = current + 1;
+				updateDisplay(world, eid, state);
+			}
+			return true;
+		}
+
+		case 'enter':
+			handleEnterKey(world, eid, state);
+			return true;
+
+		case 'backspace': {
+			const parentDir = dirname(state.cwd);
+			if (parentDir !== state.cwd) {
+				navigateToDir(world, eid, state, parentDir);
+			}
+			return true;
+		}
+
+		default:
+			return false;
+	}
+}
+
+// =============================================================================
+// UTILITY FUNCTIONS
+// =============================================================================
+
+/**
+ * Checks if an entity is a file manager widget.
+ *
+ * @param _world - The ECS world (unused, for API consistency)
+ * @param eid - The entity ID
+ * @returns true if the entity is a file manager widget
+ *
+ * @example
+ * ```typescript
+ * import { isFileManager } from 'blecsd';
+ *
+ * if (isFileManager(world, entity)) {
+ *   // Handle file manager logic
+ * }
+ * ```
+ */
+export function isFileManager(_world: World, eid: Entity): boolean {
+	return FileManager.isFileManager[eid] === 1;
+}
+
+/**
+ * Resets the FileManager component store and state. Useful for testing.
+ *
+ * @internal
+ */
+export function resetFileManagerStore(): void {
+	FileManager.isFileManager.fill(0);
+	FileManager.selectedIndex.fill(0);
+	fileManagerStateMap.clear();
+}
+
+// =============================================================================
+// TESTING HELPERS
+// =============================================================================
+
+/**
+ * Sets a custom readDir function for a file manager entity.
+ * Primarily used for testing to mock filesystem operations.
+ *
+ * @param eid - The file manager entity ID
+ * @param fn - The custom readDir function
+ *
+ * @example
+ * ```typescript
+ * import { setReadDirFn } from 'blecsd';
+ *
+ * setReadDirFn(eid, (dir) => [
+ *   { name: 'file.ts', path: dir + '/file.ts', isDirectory: false, size: 100 },
+ * ]);
+ * ```
+ */
+export function setReadDirFn(eid: Entity, fn: (dirPath: string) => FileEntry[]): void {
+	const state = fileManagerStateMap.get(eid);
+	if (state) {
+		state.readDirFn = fn;
+	}
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -59,6 +59,24 @@ export {
 	spliceLines,
 	unshiftLine,
 } from './contentManipulation';
+// FileManager widget
+export type {
+	FileEntry,
+	FileManagerBorderConfig,
+	FileManagerConfig,
+	FileManagerPaddingConfig,
+	FileManagerWidget,
+} from './fileManager';
+export {
+	createFileManager,
+	FileManager,
+	FileManagerConfigSchema,
+	fileManagerStateMap,
+	handleFileManagerKey,
+	isFileManager,
+	resetFileManagerStore,
+	setReadDirFn,
+} from './fileManager';
 // Fonts
 export type {
 	BitmapFont,


### PR DESCRIPTION
## Summary

- Adds `FileManager` widget for browsing directories and selecting files
- Supports directory navigation (Enter/Backspace), sorted entries (dirs first), hidden file toggle, and glob-based file filtering
- Includes chainable API (`show`, `hide`, `move`, `setCwd`, `onSelect`, `onNavigate`, etc.)
- Full Zod schema validation for config
- 59 tests covering creation, navigation, key handling, callbacks, error handling, and method chaining
- Injectable `readDirFn` for test mockability without global fs mocks

Closes #723

## Test plan

- [x] `pnpm test -- src/widgets/fileManager.test.ts` (59 tests pass)
- [x] `pnpm lint` (no new warnings, only pre-existing terminal.ts/terminalBuffer.ts)
- [x] `pnpm typecheck` (passes)
- [x] `pnpm build` (passes)