### PR TITLE
Remove dead code in doom example (#790)

### DIFF
--- a/examples/doom/math/tables.ts
+++ b/examples/doom/math/tables.ts
@@ -10,11 +10,9 @@ import {
 	ANGLETOFINESHIFT,
 	FINEANGLES,
 	FINEMASK,
-	SLOPERANGE,
 	finecosine,
 	finesine,
 	finetangent,
-	tantoangle,
 } from './angles.js';
 import { FRACBITS, FRACUNIT, fixedDiv, fixedMul } from './fixed.js';
 

--- a/examples/doom/render/planes.ts
+++ b/examples/doom/render/planes.ts
@@ -209,11 +209,6 @@ function drawFloorCeilingPlane(rs: RenderState, plane: Visplane): void {
 		(plane.lightLevel >> 4) + rs.extralight));
 	const lightTable = zlight[lightIdx];
 
-	// Per-frame view angle trig
-	const viewAngleFine = (rs.viewangle >> ANGLETOFINESHIFT) & FINEMASK;
-	const viewcos = finecosine[viewAngleFine] ?? FRACUNIT;
-	const viewsin = finesine[viewAngleFine] ?? 0;
-
 	// Column-based span extraction matching Doom's R_MakeSpans.
 	// Tracks previous column top/bottom and only processes delta rows.
 	// O(columns + total_span_boundary_changes) instead of O(width * height).


### PR DESCRIPTION
## Summary
- Remove unused `tantoangle` and `SLOPERANGE` imports from `examples/doom/math/tables.ts`
- Remove unused `viewcos`/`viewsin` local variables and `viewAngleFine` computation from `examples/doom/render/planes.ts` `drawFloorCeilingPlane` function
- Kept `momx`/`momy` fields in `PlayerState` as they are referenced by `weapons.ts` (weapon bobbing) and needed by the upcoming momentum system (#721)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] `pnpm test` passes (8609 tests)
- [x] `pnpm build` succeeds

Closes #790