### PR TITLE
feat(components): add Timer and Delay components (#369)

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1083,6 +1083,29 @@ export {
 	textInputStore,
 	toggleCursorMode,
 } from './textInput';
+// Timer component
+export type { TimerCallback, TimerCompleteCallback, TimerData, TimerOptions } from './timer';
+export {
+	clearTimerCallbacks,
+	getTimer,
+	getTimerProgress,
+	hasTimer,
+	isTimerComplete,
+	isTimerRunning,
+	onTimerComplete,
+	onTimerFire,
+	pauseTimer,
+	removeTimer,
+	resetTimer,
+	resetTimerStore,
+	resumeTimer,
+	setTimer,
+	startTimer,
+	stopTimer,
+	TIMER_INFINITE,
+	Timer,
+	updateTimers,
+} from './timer';
 // Velocity and Acceleration components
 export type { AccelerationData, VelocityData, VelocityOptions } from './velocity';
 export {

--- a/src/components/timer.test.ts
+++ b/src/components/timer.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Tests for Timer and Delay components.
+ * @module components/timer.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { addEntity, createWorld } from '../core/ecs';
+import type { World } from '../core/types';
+import {
+	clearTimerCallbacks,
+	getTimer,
+	getTimerProgress,
+	hasTimer,
+	isTimerComplete,
+	isTimerRunning,
+	onTimerComplete,
+	onTimerFire,
+	pauseTimer,
+	removeTimer,
+	resetTimer,
+	resetTimerStore,
+	resumeTimer,
+	setTimer,
+	startTimer,
+	stopTimer,
+	TIMER_INFINITE,
+	updateTimers,
+} from './timer';
+
+describe('Timer component', () => {
+	let world: World;
+
+	beforeEach(() => {
+		world = createWorld();
+		resetTimerStore();
+	});
+
+	afterEach(() => {
+		resetTimerStore();
+	});
+
+	// =========================================================================
+	// setTimer / getTimer
+	// =========================================================================
+
+	describe('setTimer', () => {
+		it('creates a timer with specified duration', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 3 });
+
+			const timer = getTimer(world, eid);
+			expect(timer).toBeDefined();
+			expect(timer!.duration).toBe(3);
+			expect(timer!.remaining).toBe(3);
+			expect(timer!.elapsed).toBe(0);
+			expect(timer!.active).toBe(true);
+			expect(timer!.paused).toBe(false);
+		});
+
+		it('sets repeat count', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1, repeat: 5 });
+
+			const timer = getTimer(world, eid);
+			expect(timer!.repeat).toBe(5);
+			expect(timer!.repeatCount).toBe(0);
+		});
+
+		it('supports infinite repeat', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1, repeat: TIMER_INFINITE });
+
+			const timer = getTimer(world, eid);
+			expect(timer!.repeat).toBe(TIMER_INFINITE);
+		});
+
+		it('supports autoDestroy option', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1, autoDestroy: true });
+
+			const timer = getTimer(world, eid);
+			expect(timer!.autoDestroy).toBe(true);
+		});
+
+		it('can start inactive', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1, active: false });
+
+			const timer = getTimer(world, eid);
+			expect(timer!.active).toBe(false);
+		});
+
+		it('returns entity for chaining', () => {
+			const eid = addEntity(world);
+			const result = setTimer(world, eid, { duration: 1 });
+			expect(result).toBe(eid);
+		});
+	});
+
+	// =========================================================================
+	// getTimer / hasTimer
+	// =========================================================================
+
+	describe('getTimer / hasTimer', () => {
+		it('returns undefined for entity without timer', () => {
+			const eid = addEntity(world);
+			expect(getTimer(world, eid)).toBeUndefined();
+		});
+
+		it('hasTimer returns false for entity without timer', () => {
+			const eid = addEntity(world);
+			expect(hasTimer(world, eid)).toBe(false);
+		});
+
+		it('hasTimer returns true for entity with timer', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1 });
+			expect(hasTimer(world, eid)).toBe(true);
+		});
+	});
+
+	// =========================================================================
+	// Timer controls
+	// =========================================================================
+
+	describe('startTimer / pauseTimer / resumeTimer / stopTimer / resetTimer', () => {
+		it('pauses and resumes a timer', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 5 });
+
+			pauseTimer(world, eid);
+			expect(getTimer(world, eid)!.paused).toBe(true);
+
+			resumeTimer(world, eid);
+			expect(getTimer(world, eid)!.paused).toBe(false);
+		});
+
+		it('stops a timer and resets it', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 5 });
+
+			updateTimers(world, 2);
+			stopTimer(world, eid);
+
+			const timer = getTimer(world, eid);
+			expect(timer!.active).toBe(false);
+			expect(timer!.elapsed).toBe(0);
+			expect(timer!.remaining).toBe(5);
+		});
+
+		it('resets a timer and starts it', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 5 });
+
+			updateTimers(world, 3);
+			resetTimer(world, eid);
+
+			const timer = getTimer(world, eid);
+			expect(timer!.active).toBe(true);
+			expect(timer!.elapsed).toBe(0);
+			expect(timer!.remaining).toBe(5);
+			expect(timer!.repeatCount).toBe(0);
+		});
+
+		it('startTimer activates an inactive timer', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1, active: false });
+
+			startTimer(world, eid);
+			expect(getTimer(world, eid)!.active).toBe(true);
+		});
+
+		it('control functions are no-ops for entities without timer', () => {
+			const eid = addEntity(world);
+			// Should not throw
+			startTimer(world, eid);
+			pauseTimer(world, eid);
+			resumeTimer(world, eid);
+			stopTimer(world, eid);
+			resetTimer(world, eid);
+		});
+	});
+
+	// =========================================================================
+	// removeTimer
+	// =========================================================================
+
+	describe('removeTimer', () => {
+		it('removes the timer component', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1 });
+			expect(hasTimer(world, eid)).toBe(true);
+
+			removeTimer(world, eid);
+			expect(hasTimer(world, eid)).toBe(false);
+		});
+
+		it('clears callbacks on removal', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1 });
+			const callback = vi.fn();
+			onTimerFire(eid, callback);
+
+			removeTimer(world, eid);
+
+			// Re-add timer and update past duration: callback should not fire
+			setTimer(world, eid, { duration: 1 });
+			updateTimers(world, 2);
+			expect(callback).not.toHaveBeenCalled();
+		});
+	});
+
+	// =========================================================================
+	// isTimerRunning / isTimerComplete / getTimerProgress
+	// =========================================================================
+
+	describe('state queries', () => {
+		it('isTimerRunning is true for active non-paused timers', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1 });
+			expect(isTimerRunning(world, eid)).toBe(true);
+		});
+
+		it('isTimerRunning is false for paused timers', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1 });
+			pauseTimer(world, eid);
+			expect(isTimerRunning(world, eid)).toBe(false);
+		});
+
+		it('isTimerRunning is false for entities without timer', () => {
+			const eid = addEntity(world);
+			expect(isTimerRunning(world, eid)).toBe(false);
+		});
+
+		it('isTimerComplete returns true after timer finishes', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1 });
+			updateTimers(world, 2);
+			expect(isTimerComplete(world, eid)).toBe(true);
+		});
+
+		it('isTimerComplete returns false for entity without timer', () => {
+			const eid = addEntity(world);
+			expect(isTimerComplete(world, eid)).toBe(false);
+		});
+
+		it('getTimerProgress returns 0 to 1 range', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 10 });
+
+			expect(getTimerProgress(world, eid)).toBeCloseTo(0, 2);
+
+			updateTimers(world, 5);
+			expect(getTimerProgress(world, eid)).toBeCloseTo(0.5, 2);
+
+			updateTimers(world, 3);
+			expect(getTimerProgress(world, eid)).toBeCloseTo(0.8, 2);
+		});
+
+		it('getTimerProgress returns 0 for entity without timer', () => {
+			const eid = addEntity(world);
+			expect(getTimerProgress(world, eid)).toBe(0);
+		});
+
+		it('getTimerProgress returns 0 for zero-duration timer', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 0 });
+			expect(getTimerProgress(world, eid)).toBe(0);
+		});
+	});
+
+	// =========================================================================
+	// updateTimers
+	// =========================================================================
+
+	describe('updateTimers', () => {
+		it('counts down active timers', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 5 });
+
+			updateTimers(world, 2);
+
+			const timer = getTimer(world, eid);
+			expect(timer!.elapsed).toBeCloseTo(2);
+			expect(timer!.remaining).toBeCloseTo(3);
+		});
+
+		it('fires one-shot timer when duration reached', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1 });
+
+			const callback = vi.fn();
+			onTimerFire(eid, callback);
+
+			const fired = updateTimers(world, 1.5);
+
+			expect(fired).toHaveLength(1);
+			expect(callback).toHaveBeenCalledTimes(1);
+			expect(getTimer(world, eid)!.active).toBe(false);
+		});
+
+		it('does not count paused timers', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 5 });
+			pauseTimer(world, eid);
+
+			updateTimers(world, 3);
+
+			const timer = getTimer(world, eid);
+			expect(timer!.remaining).toBe(5);
+			expect(timer!.elapsed).toBe(0);
+		});
+
+		it('does not count inactive timers', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 5, active: false });
+
+			updateTimers(world, 3);
+
+			const timer = getTimer(world, eid);
+			expect(timer!.remaining).toBe(5);
+		});
+
+		it('handles repeating timers', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1, repeat: 2 });
+
+			const callback = vi.fn();
+			onTimerFire(eid, callback);
+
+			// First fire
+			updateTimers(world, 1.5);
+			expect(callback).toHaveBeenCalledTimes(1);
+			expect(getTimer(world, eid)!.active).toBe(true);
+			expect(getTimer(world, eid)!.repeatCount).toBe(1);
+
+			// Second fire
+			updateTimers(world, 1.5);
+			expect(callback).toHaveBeenCalledTimes(2);
+			expect(getTimer(world, eid)!.active).toBe(true);
+
+			// Third fire (should complete: 3 fires total, repeat=2 means 1 initial + 2 repeats)
+			updateTimers(world, 1.5);
+			expect(callback).toHaveBeenCalledTimes(3);
+			expect(getTimer(world, eid)!.active).toBe(false);
+		});
+
+		it('handles infinite repeating timers', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 0.5, repeat: TIMER_INFINITE });
+
+			const callback = vi.fn();
+			onTimerFire(eid, callback);
+
+			for (let i = 0; i < 10; i++) {
+				updateTimers(world, 1);
+			}
+
+			expect(callback).toHaveBeenCalledTimes(10);
+			expect(getTimer(world, eid)!.active).toBe(true);
+		});
+
+		it('calls onComplete when timer finishes', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1 });
+
+			const onComplete = vi.fn();
+			onTimerComplete(eid, onComplete);
+
+			updateTimers(world, 2);
+
+			expect(onComplete).toHaveBeenCalledTimes(1);
+		});
+
+		it('auto-destroys timer when autoDestroy is set', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1, autoDestroy: true });
+
+			updateTimers(world, 2);
+
+			expect(hasTimer(world, eid)).toBe(false);
+		});
+
+		it('handles multiple timers simultaneously', () => {
+			const eid1 = addEntity(world);
+			const eid2 = addEntity(world);
+			setTimer(world, eid1, { duration: 1 });
+			setTimer(world, eid2, { duration: 2 });
+
+			const cb1 = vi.fn();
+			const cb2 = vi.fn();
+			onTimerFire(eid1, cb1);
+			onTimerFire(eid2, cb2);
+
+			updateTimers(world, 1.5);
+			expect(cb1).toHaveBeenCalledTimes(1);
+			expect(cb2).not.toHaveBeenCalled();
+
+			updateTimers(world, 1);
+			expect(cb2).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	// =========================================================================
+	// Callbacks
+	// =========================================================================
+
+	describe('callbacks', () => {
+		it('clearTimerCallbacks removes all callbacks', () => {
+			const eid = addEntity(world);
+			setTimer(world, eid, { duration: 1 });
+
+			const callback = vi.fn();
+			onTimerFire(eid, callback);
+			clearTimerCallbacks(eid);
+
+			updateTimers(world, 2);
+			expect(callback).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/components/timer.ts
+++ b/src/components/timer.ts
@@ -1,0 +1,598 @@
+/**
+ * Timer and Delay components for time-based game logic.
+ *
+ * Provides countdown timers, delays, repeating timers, and callback support
+ * for scheduling game events using the ECS pattern.
+ *
+ * @module components/timer
+ */
+
+import { addComponent, hasComponent, query, removeComponent } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+
+/** Default entity capacity for typed arrays */
+const DEFAULT_CAPACITY = 10000;
+
+// =============================================================================
+// TIMER COMPONENT
+// =============================================================================
+
+/**
+ * Timer component store using SoA (Structure of Arrays).
+ *
+ * - `duration`: Total timer duration in seconds
+ * - `elapsed`: Time elapsed since timer started (seconds)
+ * - `remaining`: Time remaining until timer fires (seconds)
+ * - `repeat`: Number of times to repeat (0 = no repeat, 0xFFFF = infinite)
+ * - `repeatCount`: Number of times the timer has fired
+ * - `active`: Whether the timer is currently counting down (0 or 1)
+ * - `paused`: Whether the timer is paused (0 or 1)
+ * - `autoDestroy`: Whether to remove the component when complete (0 or 1)
+ *
+ * @example
+ * ```typescript
+ * import { setTimer, TimerState } from 'blecsd';
+ *
+ * // One-shot 2-second timer
+ * setTimer(world, entity, { duration: 2 });
+ *
+ * // Repeating timer, fires every 0.5 seconds
+ * setTimer(world, entity, { duration: 0.5, repeat: TIMER_INFINITE });
+ *
+ * // 3-second delay that auto-removes when done
+ * setTimer(world, entity, { duration: 3, autoDestroy: true });
+ * ```
+ */
+export const Timer = {
+	/** Total timer duration in seconds */
+	duration: new Float32Array(DEFAULT_CAPACITY),
+	/** Time elapsed since timer started */
+	elapsed: new Float32Array(DEFAULT_CAPACITY),
+	/** Time remaining until next fire */
+	remaining: new Float32Array(DEFAULT_CAPACITY),
+	/** Number of times to repeat (0 = one-shot, 0xFFFF = infinite) */
+	repeat: new Uint16Array(DEFAULT_CAPACITY),
+	/** Number of times the timer has fired */
+	repeatCount: new Uint16Array(DEFAULT_CAPACITY),
+	/** Whether the timer is active (1) or stopped (0) */
+	active: new Uint8Array(DEFAULT_CAPACITY),
+	/** Whether the timer is paused (1) or running (0) */
+	paused: new Uint8Array(DEFAULT_CAPACITY),
+	/** Whether to auto-remove component when complete (1) or keep (0) */
+	autoDestroy: new Uint8Array(DEFAULT_CAPACITY),
+};
+
+/** Value for infinite repeating timers */
+export const TIMER_INFINITE = 0xffff;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Timer data returned by getTimer.
+ */
+export interface TimerData {
+	readonly duration: number;
+	readonly elapsed: number;
+	readonly remaining: number;
+	readonly repeat: number;
+	readonly repeatCount: number;
+	readonly active: boolean;
+	readonly paused: boolean;
+	readonly autoDestroy: boolean;
+}
+
+/**
+ * Options for creating a timer.
+ */
+export interface TimerOptions {
+	/** Duration in seconds */
+	duration: number;
+	/** Number of times to repeat (default: 0, use TIMER_INFINITE for infinite) */
+	repeat?: number;
+	/** Whether to auto-remove component when complete (default: false) */
+	autoDestroy?: boolean;
+	/** Whether to start immediately (default: true) */
+	active?: boolean;
+}
+
+// =============================================================================
+// CALLBACK STORE
+// =============================================================================
+
+/** Callback invoked when a timer fires */
+export type TimerCallback = (world: World, eid: Entity) => void;
+
+/** Callback invoked when a timer completes all repeats */
+export type TimerCompleteCallback = (world: World, eid: Entity) => void;
+
+/** Per-entity callback storage */
+interface TimerCallbacks {
+	onFire?: TimerCallback;
+	onComplete?: TimerCompleteCallback;
+}
+
+/** Store for timer callbacks (keyed by entity) */
+const callbackStore = new Map<number, TimerCallbacks>();
+
+// =============================================================================
+// INITIALIZATION
+// =============================================================================
+
+/**
+ * Initializes timer fields to default values.
+ */
+function initTimer(eid: Entity): void {
+	Timer.duration[eid] = 0;
+	Timer.elapsed[eid] = 0;
+	Timer.remaining[eid] = 0;
+	Timer.repeat[eid] = 0;
+	Timer.repeatCount[eid] = 0;
+	Timer.active[eid] = 0;
+	Timer.paused[eid] = 0;
+	Timer.autoDestroy[eid] = 0;
+}
+
+// =============================================================================
+// SETTERS
+// =============================================================================
+
+/**
+ * Sets a timer on an entity.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity to add the timer to
+ * @param options - Timer configuration
+ * @returns The entity ID for chaining
+ *
+ * @example
+ * ```typescript
+ * import { createWorld, addEntity, setTimer, TIMER_INFINITE } from 'blecsd';
+ *
+ * const world = createWorld();
+ * const eid = addEntity(world);
+ *
+ * // One-shot 3-second timer
+ * setTimer(world, eid, { duration: 3 });
+ *
+ * // Repeating timer
+ * setTimer(world, eid, { duration: 0.5, repeat: TIMER_INFINITE });
+ * ```
+ */
+export function setTimer(world: World, eid: Entity, options: TimerOptions): Entity {
+	if (!hasComponent(world, eid, Timer)) {
+		addComponent(world, eid, Timer);
+		initTimer(eid);
+	}
+
+	Timer.duration[eid] = options.duration;
+	Timer.elapsed[eid] = 0;
+	Timer.remaining[eid] = options.duration;
+	Timer.repeat[eid] = options.repeat ?? 0;
+	Timer.repeatCount[eid] = 0;
+	Timer.active[eid] = options.active !== false ? 1 : 0;
+	Timer.autoDestroy[eid] = options.autoDestroy ? 1 : 0;
+	Timer.paused[eid] = 0;
+
+	return eid;
+}
+
+/**
+ * Starts or resumes a timer.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity with the timer
+ *
+ * @example
+ * ```typescript
+ * import { startTimer } from 'blecsd';
+ *
+ * startTimer(world, entity);
+ * ```
+ */
+export function startTimer(world: World, eid: Entity): void {
+	if (!hasComponent(world, eid, Timer)) {
+		return;
+	}
+	Timer.active[eid] = 1;
+	Timer.paused[eid] = 0;
+}
+
+/**
+ * Pauses a timer, preserving its current state.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity with the timer
+ *
+ * @example
+ * ```typescript
+ * import { pauseTimer } from 'blecsd';
+ *
+ * pauseTimer(world, entity);
+ * ```
+ */
+export function pauseTimer(world: World, eid: Entity): void {
+	if (!hasComponent(world, eid, Timer)) {
+		return;
+	}
+	Timer.paused[eid] = 1;
+}
+
+/**
+ * Resumes a paused timer.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity with the timer
+ *
+ * @example
+ * ```typescript
+ * import { resumeTimer } from 'blecsd';
+ *
+ * resumeTimer(world, entity);
+ * ```
+ */
+export function resumeTimer(world: World, eid: Entity): void {
+	if (!hasComponent(world, eid, Timer)) {
+		return;
+	}
+	Timer.paused[eid] = 0;
+}
+
+/**
+ * Stops a timer and resets it.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity with the timer
+ *
+ * @example
+ * ```typescript
+ * import { stopTimer } from 'blecsd';
+ *
+ * stopTimer(world, entity);
+ * ```
+ */
+export function stopTimer(world: World, eid: Entity): void {
+	if (!hasComponent(world, eid, Timer)) {
+		return;
+	}
+	Timer.active[eid] = 0;
+	Timer.paused[eid] = 0;
+	Timer.elapsed[eid] = 0;
+	Timer.remaining[eid] = Timer.duration[eid] as number;
+	Timer.repeatCount[eid] = 0;
+}
+
+/**
+ * Resets a timer to its initial state and starts it.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity with the timer
+ *
+ * @example
+ * ```typescript
+ * import { resetTimer } from 'blecsd';
+ *
+ * resetTimer(world, entity);
+ * ```
+ */
+export function resetTimer(world: World, eid: Entity): void {
+	if (!hasComponent(world, eid, Timer)) {
+		return;
+	}
+	Timer.elapsed[eid] = 0;
+	Timer.remaining[eid] = Timer.duration[eid] as number;
+	Timer.repeatCount[eid] = 0;
+	Timer.active[eid] = 1;
+	Timer.paused[eid] = 0;
+}
+
+/**
+ * Removes the timer component and callbacks from an entity.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity to remove the timer from
+ *
+ * @example
+ * ```typescript
+ * import { removeTimer } from 'blecsd';
+ *
+ * removeTimer(world, entity);
+ * ```
+ */
+export function removeTimer(world: World, eid: Entity): void {
+	if (hasComponent(world, eid, Timer)) {
+		removeComponent(world, eid, Timer);
+	}
+	callbackStore.delete(eid as number);
+}
+
+// =============================================================================
+// GETTERS
+// =============================================================================
+
+/**
+ * Gets the timer data for an entity.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity to query
+ * @returns Timer data, or undefined if entity has no timer
+ *
+ * @example
+ * ```typescript
+ * import { getTimer } from 'blecsd';
+ *
+ * const timer = getTimer(world, entity);
+ * if (timer) {
+ *   console.log(`Remaining: ${timer.remaining}s`);
+ * }
+ * ```
+ */
+export function getTimer(world: World, eid: Entity): TimerData | undefined {
+	if (!hasComponent(world, eid, Timer)) {
+		return undefined;
+	}
+	return {
+		duration: Timer.duration[eid] as number,
+		elapsed: Timer.elapsed[eid] as number,
+		remaining: Timer.remaining[eid] as number,
+		repeat: Timer.repeat[eid] as number,
+		repeatCount: Timer.repeatCount[eid] as number,
+		active: Timer.active[eid] === 1,
+		paused: Timer.paused[eid] === 1,
+		autoDestroy: Timer.autoDestroy[eid] === 1,
+	};
+}
+
+/**
+ * Checks if an entity has a timer component.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity to check
+ * @returns True if the entity has a Timer component
+ *
+ * @example
+ * ```typescript
+ * import { hasTimer } from 'blecsd';
+ *
+ * if (hasTimer(world, entity)) {
+ *   // entity has a timer
+ * }
+ * ```
+ */
+export function hasTimer(world: World, eid: Entity): boolean {
+	return hasComponent(world, eid, Timer);
+}
+
+/**
+ * Checks if a timer is currently active and not paused.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity to check
+ * @returns True if the timer is running
+ *
+ * @example
+ * ```typescript
+ * import { isTimerRunning } from 'blecsd';
+ *
+ * if (isTimerRunning(world, entity)) {
+ *   // timer is counting down
+ * }
+ * ```
+ */
+export function isTimerRunning(world: World, eid: Entity): boolean {
+	if (!hasComponent(world, eid, Timer)) {
+		return false;
+	}
+	return Timer.active[eid] === 1 && Timer.paused[eid] === 0;
+}
+
+/**
+ * Checks if a timer has completed (all repeats exhausted).
+ *
+ * @param world - The ECS world
+ * @param eid - The entity to check
+ * @returns True if the timer has finished
+ *
+ * @example
+ * ```typescript
+ * import { isTimerComplete } from 'blecsd';
+ *
+ * if (isTimerComplete(world, entity)) {
+ *   // timer finished all cycles
+ * }
+ * ```
+ */
+export function isTimerComplete(world: World, eid: Entity): boolean {
+	if (!hasComponent(world, eid, Timer)) {
+		return false;
+	}
+	return Timer.active[eid] === 0 && (Timer.elapsed[eid] as number) > 0;
+}
+
+/**
+ * Gets the progress of the current timer cycle as a value from 0 to 1.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity to check
+ * @returns Progress from 0 (just started) to 1 (about to fire), or 0 if no timer
+ *
+ * @example
+ * ```typescript
+ * import { getTimerProgress } from 'blecsd';
+ *
+ * const progress = getTimerProgress(world, entity);
+ * console.log(`${Math.round(progress * 100)}% complete`);
+ * ```
+ */
+export function getTimerProgress(world: World, eid: Entity): number {
+	if (!hasComponent(world, eid, Timer)) {
+		return 0;
+	}
+	const duration = Timer.duration[eid] as number;
+	if (duration <= 0) {
+		return 0;
+	}
+	const remaining = Timer.remaining[eid] as number;
+	return Math.max(0, Math.min(1, 1 - remaining / duration));
+}
+
+// =============================================================================
+// CALLBACKS
+// =============================================================================
+
+/**
+ * Registers a callback invoked each time the timer fires.
+ *
+ * @param eid - The entity with the timer
+ * @param callback - Function to call when timer fires
+ *
+ * @example
+ * ```typescript
+ * import { onTimerFire } from 'blecsd';
+ *
+ * onTimerFire(entity, (world, eid) => {
+ *   console.log('Timer fired!');
+ * });
+ * ```
+ */
+export function onTimerFire(eid: Entity, callback: TimerCallback): void {
+	const existing = callbackStore.get(eid as number) ?? {};
+	existing.onFire = callback;
+	callbackStore.set(eid as number, existing);
+}
+
+/**
+ * Registers a callback invoked when the timer completes all repeats.
+ *
+ * @param eid - The entity with the timer
+ * @param callback - Function to call when timer completes
+ *
+ * @example
+ * ```typescript
+ * import { onTimerComplete } from 'blecsd';
+ *
+ * onTimerComplete(entity, (world, eid) => {
+ *   console.log('Timer finished!');
+ * });
+ * ```
+ */
+export function onTimerComplete(eid: Entity, callback: TimerCompleteCallback): void {
+	const existing = callbackStore.get(eid as number) ?? {};
+	existing.onComplete = callback;
+	callbackStore.set(eid as number, existing);
+}
+
+/**
+ * Clears all callbacks for an entity's timer.
+ *
+ * @param eid - The entity to clear callbacks for
+ *
+ * @example
+ * ```typescript
+ * import { clearTimerCallbacks } from 'blecsd';
+ *
+ * clearTimerCallbacks(entity);
+ * ```
+ */
+export function clearTimerCallbacks(eid: Entity): void {
+	callbackStore.delete(eid as number);
+}
+
+/**
+ * Resets the callback store. Useful for testing.
+ */
+export function resetTimerStore(): void {
+	callbackStore.clear();
+}
+
+// =============================================================================
+// TIMER SYSTEM UPDATE
+// =============================================================================
+
+/**
+ * Updates all active timers by the given delta time.
+ *
+ * This is the core timer update function, typically called from a system
+ * registered in the UPDATE phase.
+ *
+ * @param world - The ECS world
+ * @param dt - Delta time in seconds
+ * @returns Entities whose timers fired this frame
+ *
+ * @example
+ * ```typescript
+ * import { updateTimers, getDeltaTime } from 'blecsd';
+ *
+ * const timerSystem: System = (world) => {
+ *   const dt = getDeltaTime();
+ *   updateTimers(world, dt);
+ *   return world;
+ * };
+ * ```
+ */
+export function updateTimers(world: World, dt: number): readonly Entity[] {
+	const fired: Entity[] = [];
+	const toRemove: Entity[] = [];
+
+	const entities = timerQuery(world);
+
+	for (const eid of entities) {
+		if (Timer.active[eid] !== 1 || Timer.paused[eid] === 1) {
+			continue;
+		}
+
+		Timer.elapsed[eid] = (Timer.elapsed[eid] as number) + dt;
+		Timer.remaining[eid] = (Timer.remaining[eid] as number) - dt;
+
+		if ((Timer.remaining[eid] as number) <= 0) {
+			fired.push(eid);
+			handleTimerFired(world, eid, toRemove);
+		}
+	}
+
+	for (const eid of toRemove) {
+		removeTimer(world, eid);
+	}
+
+	return fired;
+}
+
+/**
+ * Handles a timer that has just fired: increments repeat count,
+ * invokes callbacks, and determines whether to restart or complete.
+ */
+function handleTimerFired(world: World, eid: Entity, toRemove: Entity[]): void {
+	Timer.repeatCount[eid] = ((Timer.repeatCount[eid] as number) + 1) as number;
+
+	const callbacks = callbackStore.get(eid as number);
+	if (callbacks?.onFire) {
+		callbacks.onFire(world, eid);
+	}
+
+	const repeat = Timer.repeat[eid] as number;
+	const repeatCount = Timer.repeatCount[eid] as number;
+
+	if (repeat === TIMER_INFINITE || repeatCount <= repeat) {
+		Timer.remaining[eid] = Timer.duration[eid] as number;
+		return;
+	}
+
+	Timer.active[eid] = 0;
+	Timer.remaining[eid] = 0;
+
+	if (callbacks?.onComplete) {
+		callbacks.onComplete(world, eid);
+	}
+
+	if (Timer.autoDestroy[eid] === 1) {
+		toRemove.push(eid);
+	}
+}
+
+/**
+ * Queries for all entities with Timer component.
+ */
+function timerQuery(world: World): readonly Entity[] {
+	return query(world, [Timer]) as unknown as readonly Entity[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,11 @@ export type {
 	TextInputEvent,
 	TextInputState,
 	TextInputStore,
+	// Timer
+	TimerCallback,
+	TimerCompleteCallback,
+	TimerData,
+	TimerOptions,
 	// Velocity & Acceleration
 	VelocityData,
 	VelocityOptions,
@@ -207,6 +212,8 @@ export {
 	clearSliderDisplay,
 	clearTextInputCallbacks,
 	clearTextInputError,
+	// Timer
+	clearTimerCallbacks,
 	closeSelect,
 	// Renderable
 	colorToHex,
@@ -427,6 +434,8 @@ export {
 	getText,
 	getTextInputConfig,
 	getTextInputState,
+	getTimer,
+	getTimerProgress,
 	getTotalCount,
 	getVelocity,
 	getVerticalPadding,
@@ -460,6 +469,7 @@ export {
 	hasSelection,
 	hasShadow,
 	hasStateMachine,
+	hasTimer,
 	hasVelocity,
 	hexToColor,
 	hide,
@@ -550,6 +560,8 @@ export {
 	isTextInputFocused,
 	isTextInputInState,
 	isTextWrapped,
+	isTimerComplete,
+	isTimerRunning,
 	isUnchecked,
 	isVisible,
 	Label,
@@ -586,11 +598,14 @@ export {
 	onTextInputCancel,
 	onTextInputChange,
 	onTextInputSubmit,
+	onTimerComplete,
+	onTimerFire,
 	openSelect,
 	Padding,
 	Position,
 	ProgressOrientation,
 	packColor,
+	pauseTimer,
 	prepend,
 	pressButton,
 	// ProgressBar
@@ -606,6 +621,7 @@ export {
 	removeItem,
 	removeLabel,
 	removeShadow,
+	removeTimer,
 	removeVelocity,
 	// Rendering
 	renderListItems,
@@ -626,6 +642,9 @@ export {
 	resetSelectStore,
 	resetSliderStore,
 	resetTextInputStore,
+	resetTimer,
+	resetTimerStore,
+	resumeTimer,
 	Scrollable,
 	ScrollbarVisibility,
 	// Select
@@ -750,6 +769,7 @@ export {
 	setTextInputError,
 	setTextVAlign,
 	setTextWrap,
+	setTimer,
 	// Virtualization / lazy loading
 	setTotalCount,
 	setVelocity,
@@ -763,13 +783,17 @@ export {
 	startDragging,
 	startEditingTextInput,
 	startListSearch,
+	startTimer,
 	stopDragging,
 	stopEntity,
+	stopTimer,
 	submitForm,
 	// TextInput
 	TEXT_INPUT_STATE_MACHINE_CONFIG,
 	TextAlign,
 	TextVAlign,
+	TIMER_INFINITE,
+	Timer,
 	textInputStore,
 	toggle,
 	toggleCheckbox,
@@ -782,6 +806,7 @@ export {
 	updateEntityMovement,
 	updateItem,
 	updateStateAge,
+	updateTimers,
 	// Velocity & Acceleration
 	Velocity,
 } from './components';


### PR DESCRIPTION
## Summary
- Add Timer component with countdown, repeat, pause/resume, and callback support
- updateTimers() function for system integration with delta time
- Auto-destroy option for one-shot delays
- Progress tracking (0-1 range) for UI integration

## Test plan
- [x] Timer creation with duration, repeat, autoDestroy, active options
- [x] Timer controls: start, pause, resume, stop, reset
- [x] State queries: isTimerRunning, isTimerComplete, getTimerProgress
- [x] updateTimers: countdown, one-shot firing, pause skipping, repeat handling
- [x] Infinite repeating timers
- [x] onFire and onComplete callbacks
- [x] Auto-destroy on completion
- [x] Multiple simultaneous timers

Closes #369