### PR TITLE
feat(systems): add spatial hash for collision optimization (#371)

### DIFF
--- a/src/systems/index.ts
+++ b/src/systems/index.ts
@@ -184,6 +184,31 @@ export {
 	renderText,
 	setRenderBuffer,
 } from './renderSystem';
+// Spatial hash system
+export type {
+	CellCoord,
+	SpatialHashConfig,
+	SpatialHashGrid,
+	SpatialHashStats,
+} from './spatialHash';
+export {
+	clearSpatialHash,
+	createSpatialHash,
+	createSpatialHashSystem,
+	DEFAULT_CELL_SIZE,
+	getEntitiesAtPoint,
+	getEntitiesInCell,
+	getNearbyEntities,
+	getSpatialHashGrid,
+	getSpatialHashStats,
+	insertEntity,
+	queryArea,
+	rebuildSpatialHash,
+	removeEntityFromGrid,
+	setSpatialHashGrid,
+	spatialHashSystem,
+	worldToCell,
+} from './spatialHash';
 // State machine system
 export {
 	createStateMachineSystem,

--- a/src/systems/spatialHash.test.ts
+++ b/src/systems/spatialHash.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for spatial hash grid collision optimization.
+ * @module systems/spatialHash.test
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Collider } from '../components/collision';
+import { Position } from '../components/position';
+import { addComponent, addEntity, createWorld } from '../core/ecs';
+import type { Entity } from '../core/types';
+import {
+	clearSpatialHash,
+	createSpatialHash,
+	DEFAULT_CELL_SIZE,
+	getEntitiesAtPoint,
+	getEntitiesInCell,
+	getNearbyEntities,
+	getSpatialHashStats,
+	insertEntity,
+	queryArea,
+	rebuildSpatialHash,
+	removeEntityFromGrid,
+	type SpatialHashGrid,
+	setSpatialHashGrid,
+	spatialHashSystem,
+	worldToCell,
+} from './spatialHash';
+
+describe('spatialHash', () => {
+	let grid: SpatialHashGrid;
+
+	beforeEach(() => {
+		grid = createSpatialHash({ cellSize: 8 });
+	});
+
+	// =========================================================================
+	// createSpatialHash
+	// =========================================================================
+
+	describe('createSpatialHash', () => {
+		it('creates a grid with specified cell size', () => {
+			const g = createSpatialHash({ cellSize: 4 });
+			expect(g.cellSize).toBe(4);
+			expect(g.cells.size).toBe(0);
+			expect(g.entityCells.size).toBe(0);
+		});
+
+		it('uses default cell size when not specified', () => {
+			const g = createSpatialHash();
+			expect(g.cellSize).toBe(DEFAULT_CELL_SIZE);
+		});
+	});
+
+	// =========================================================================
+	// worldToCell
+	// =========================================================================
+
+	describe('worldToCell', () => {
+		it('maps world coordinates to cell coordinates', () => {
+			const cell = worldToCell(grid, 15, 23);
+			expect(cell.cx).toBe(1); // 15 / 8 = 1.875 -> floor = 1
+			expect(cell.cy).toBe(2); // 23 / 8 = 2.875 -> floor = 2
+		});
+
+		it('handles zero coordinates', () => {
+			const cell = worldToCell(grid, 0, 0);
+			expect(cell.cx).toBe(0);
+			expect(cell.cy).toBe(0);
+		});
+
+		it('handles negative coordinates', () => {
+			const cell = worldToCell(grid, -5, -10);
+			expect(cell.cx).toBe(-1);
+			expect(cell.cy).toBe(-2);
+		});
+	});
+
+	// =========================================================================
+	// insertEntity / removeEntityFromGrid
+	// =========================================================================
+
+	describe('insertEntity', () => {
+		it('inserts an entity into the grid', () => {
+			insertEntity(grid, 1 as Entity, 4, 4, 1, 1);
+
+			const stats = getSpatialHashStats(grid);
+			expect(stats.entityCount).toBe(1);
+			expect(stats.cellCount).toBe(1);
+		});
+
+		it('inserts entity spanning multiple cells', () => {
+			// Entity from (6,6) to (18,18) with cell size 8
+			// Spans cells (0,0), (0,1), (1,0), (1,1), (2,0), (2,1), (0,2), (1,2), (2,2)
+			insertEntity(grid, 1 as Entity, 0, 0, 17, 17);
+
+			const stats = getSpatialHashStats(grid);
+			expect(stats.entityCount).toBe(1);
+			expect(stats.cellCount).toBeGreaterThan(1);
+		});
+
+		it('updates position on re-insert', () => {
+			insertEntity(grid, 1 as Entity, 0, 0, 1, 1);
+			const nearby1 = getEntitiesAtPoint(grid, 0, 0);
+			expect(nearby1.has(1)).toBe(true);
+
+			insertEntity(grid, 1 as Entity, 20, 20, 1, 1);
+			const nearbyOld = getEntitiesAtPoint(grid, 0, 0);
+			expect(nearbyOld.has(1)).toBe(false);
+
+			const nearbyNew = getEntitiesAtPoint(grid, 20, 20);
+			expect(nearbyNew.has(1)).toBe(true);
+		});
+	});
+
+	describe('removeEntityFromGrid', () => {
+		it('removes an entity from the grid', () => {
+			insertEntity(grid, 1 as Entity, 4, 4, 1, 1);
+			removeEntityFromGrid(grid, 1 as Entity);
+
+			const stats = getSpatialHashStats(grid);
+			expect(stats.entityCount).toBe(0);
+			expect(stats.cellCount).toBe(0);
+		});
+
+		it('is a no-op for non-existent entities', () => {
+			removeEntityFromGrid(grid, 999 as Entity);
+			// Should not throw
+		});
+	});
+
+	// =========================================================================
+	// queryArea
+	// =========================================================================
+
+	describe('queryArea', () => {
+		it('finds entities in the queried area', () => {
+			insertEntity(grid, 1 as Entity, 4, 4, 1, 1);
+			insertEntity(grid, 2 as Entity, 20, 20, 1, 1);
+
+			const results = queryArea(grid, 0, 0, 8, 8);
+			expect(results.has(1)).toBe(true);
+			expect(results.has(2)).toBe(false);
+		});
+
+		it('returns empty set for empty area', () => {
+			const results = queryArea(grid, 100, 100, 1, 1);
+			expect(results.size).toBe(0);
+		});
+
+		it('finds entities across multiple cells', () => {
+			insertEntity(grid, 1 as Entity, 4, 4, 1, 1);
+			insertEntity(grid, 2 as Entity, 12, 4, 1, 1);
+
+			// Query area spanning both cells
+			const results = queryArea(grid, 0, 0, 16, 8);
+			expect(results.has(1)).toBe(true);
+			expect(results.has(2)).toBe(true);
+		});
+	});
+
+	// =========================================================================
+	// getNearbyEntities
+	// =========================================================================
+
+	describe('getNearbyEntities', () => {
+		it('finds entities in same cell', () => {
+			insertEntity(grid, 1 as Entity, 4, 4, 1, 1);
+			insertEntity(grid, 2 as Entity, 5, 5, 1, 1);
+			insertEntity(grid, 3 as Entity, 20, 20, 1, 1);
+
+			const nearby = getNearbyEntities(grid, 1 as Entity);
+			expect(nearby.has(2)).toBe(true);
+			expect(nearby.has(3)).toBe(false);
+		});
+
+		it('excludes the queried entity itself', () => {
+			insertEntity(grid, 1 as Entity, 4, 4, 1, 1);
+			const nearby = getNearbyEntities(grid, 1 as Entity);
+			expect(nearby.has(1)).toBe(false);
+		});
+
+		it('returns empty set for unknown entity', () => {
+			const nearby = getNearbyEntities(grid, 999 as Entity);
+			expect(nearby.size).toBe(0);
+		});
+	});
+
+	// =========================================================================
+	// getEntitiesInCell / getEntitiesAtPoint
+	// =========================================================================
+
+	describe('getEntitiesInCell', () => {
+		it('returns entities in a specific cell', () => {
+			insertEntity(grid, 1 as Entity, 4, 4, 1, 1);
+			const entities = getEntitiesInCell(grid, 0, 0);
+			expect(entities.has(1)).toBe(true);
+		});
+
+		it('returns empty set for empty cell', () => {
+			const entities = getEntitiesInCell(grid, 99, 99);
+			expect(entities.size).toBe(0);
+		});
+	});
+
+	describe('getEntitiesAtPoint', () => {
+		it('returns entities at a world point', () => {
+			insertEntity(grid, 1 as Entity, 4, 4, 1, 1);
+			const entities = getEntitiesAtPoint(grid, 4, 4);
+			expect(entities.has(1)).toBe(true);
+		});
+	});
+
+	// =========================================================================
+	// clearSpatialHash / getSpatialHashStats
+	// =========================================================================
+
+	describe('clearSpatialHash', () => {
+		it('removes all entities from the grid', () => {
+			insertEntity(grid, 1 as Entity, 4, 4, 1, 1);
+			insertEntity(grid, 2 as Entity, 20, 20, 1, 1);
+			clearSpatialHash(grid);
+
+			const stats = getSpatialHashStats(grid);
+			expect(stats.entityCount).toBe(0);
+			expect(stats.cellCount).toBe(0);
+		});
+	});
+
+	describe('getSpatialHashStats', () => {
+		it('returns correct statistics', () => {
+			insertEntity(grid, 1 as Entity, 4, 4, 1, 1);
+			insertEntity(grid, 2 as Entity, 5, 5, 1, 1);
+			insertEntity(grid, 3 as Entity, 20, 20, 1, 1);
+
+			const stats = getSpatialHashStats(grid);
+			expect(stats.entityCount).toBe(3);
+			expect(stats.cellCount).toBe(2); // Two different cells
+			expect(stats.maxEntitiesInCell).toBe(2);
+			expect(stats.averageEntitiesPerCell).toBeCloseTo(1.5);
+		});
+
+		it('returns zeros for empty grid', () => {
+			const stats = getSpatialHashStats(grid);
+			expect(stats.entityCount).toBe(0);
+			expect(stats.cellCount).toBe(0);
+			expect(stats.averageEntitiesPerCell).toBe(0);
+			expect(stats.maxEntitiesInCell).toBe(0);
+		});
+	});
+
+	// =========================================================================
+	// rebuildSpatialHash
+	// =========================================================================
+
+	describe('rebuildSpatialHash', () => {
+		it('rebuilds from world entities with Position and Collider', () => {
+			const world = createWorld();
+
+			const eid1 = addEntity(world);
+			addComponent(world, eid1, Position);
+			addComponent(world, eid1, Collider);
+			Position.x[eid1] = 4;
+			Position.y[eid1] = 4;
+			Collider.width[eid1] = 2;
+			Collider.height[eid1] = 2;
+			Collider.offsetX[eid1] = 0;
+			Collider.offsetY[eid1] = 0;
+
+			const eid2 = addEntity(world);
+			addComponent(world, eid2, Position);
+			addComponent(world, eid2, Collider);
+			Position.x[eid2] = 20;
+			Position.y[eid2] = 20;
+			Collider.width[eid2] = 1;
+			Collider.height[eid2] = 1;
+			Collider.offsetX[eid2] = 0;
+			Collider.offsetY[eid2] = 0;
+
+			rebuildSpatialHash(grid, world);
+
+			const stats = getSpatialHashStats(grid);
+			expect(stats.entityCount).toBe(2);
+		});
+	});
+
+	// =========================================================================
+	// spatialHashSystem
+	// =========================================================================
+
+	describe('spatialHashSystem', () => {
+		it('rebuilds the grid when system is run', () => {
+			const world = createWorld();
+
+			const eid = addEntity(world);
+			addComponent(world, eid, Position);
+			addComponent(world, eid, Collider);
+			Position.x[eid] = 4;
+			Position.y[eid] = 4;
+			Collider.width[eid] = 1;
+			Collider.height[eid] = 1;
+			Collider.offsetX[eid] = 0;
+			Collider.offsetY[eid] = 0;
+
+			setSpatialHashGrid(grid);
+			spatialHashSystem(world);
+
+			const stats = getSpatialHashStats(grid);
+			expect(stats.entityCount).toBe(1);
+		});
+	});
+});

--- a/src/systems/spatialHash.ts
+++ b/src/systems/spatialHash.ts
@@ -1,0 +1,516 @@
+/**
+ * Spatial hash grid for O(1) collision lookups.
+ *
+ * Partitions 2D space into a uniform grid where each cell tracks
+ * which entities overlap it. Enables efficient broad-phase collision
+ * detection by only checking entities in the same or adjacent cells.
+ *
+ * @module systems/spatialHash
+ */
+
+import { Collider } from '../components/collision';
+import { Position } from '../components/position';
+import { query } from '../core/ecs';
+import type { Entity, System, World } from '../core/types';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Configuration for the spatial hash grid.
+ */
+export interface SpatialHashConfig {
+	/** Width of each cell in world units (default: 8) */
+	readonly cellSize: number;
+	/** Initial number of cells in the grid (default: 256) */
+	readonly initialCapacity: number;
+}
+
+/**
+ * A cell coordinate in the spatial hash grid.
+ */
+export interface CellCoord {
+	readonly cx: number;
+	readonly cy: number;
+}
+
+/**
+ * Spatial hash grid data structure.
+ */
+export interface SpatialHashGrid {
+	/** Cell size in world units */
+	readonly cellSize: number;
+	/** Map from cell key to set of entity IDs */
+	readonly cells: Map<number, Set<number>>;
+	/** Map from entity ID to set of cell keys it occupies */
+	readonly entityCells: Map<number, Set<number>>;
+}
+
+/**
+ * Statistics about the spatial hash grid.
+ */
+export interface SpatialHashStats {
+	readonly cellCount: number;
+	readonly entityCount: number;
+	readonly averageEntitiesPerCell: number;
+	readonly maxEntitiesInCell: number;
+}
+
+// =============================================================================
+// GRID CREATION
+// =============================================================================
+
+/** Default cell size */
+export const DEFAULT_CELL_SIZE = 8;
+
+/**
+ * Creates a new spatial hash grid.
+ *
+ * @param config - Optional configuration
+ * @returns A new spatial hash grid
+ *
+ * @example
+ * ```typescript
+ * import { createSpatialHash } from 'blecsd';
+ *
+ * const grid = createSpatialHash({ cellSize: 4 });
+ * ```
+ */
+export function createSpatialHash(config?: Partial<SpatialHashConfig>): SpatialHashGrid {
+	return {
+		cellSize: config?.cellSize ?? DEFAULT_CELL_SIZE,
+		cells: new Map(),
+		entityCells: new Map(),
+	};
+}
+
+// =============================================================================
+// CELL KEY UTILITIES
+// =============================================================================
+
+/**
+ * Computes a cell key from cell coordinates.
+ * Uses a Cantor pairing function to hash 2D coords to a single integer.
+ */
+function cellKey(cx: number, cy: number): number {
+	// Shift to handle negatives: map to positive space
+	const ax = cx >= 0 ? cx * 2 : -cx * 2 - 1;
+	const ay = cy >= 0 ? cy * 2 : -cy * 2 - 1;
+	return ((ax + ay) * (ax + ay + 1)) / 2 + ay;
+}
+
+/**
+ * Gets the cell coordinate for a world position.
+ *
+ * @param grid - The spatial hash grid
+ * @param x - World X coordinate
+ * @param y - World Y coordinate
+ * @returns The cell coordinate
+ *
+ * @example
+ * ```typescript
+ * import { createSpatialHash, worldToCell } from 'blecsd';
+ *
+ * const grid = createSpatialHash({ cellSize: 8 });
+ * const cell = worldToCell(grid, 15, 23);
+ * // cell = { cx: 1, cy: 2 }
+ * ```
+ */
+export function worldToCell(grid: SpatialHashGrid, x: number, y: number): CellCoord {
+	return {
+		cx: Math.floor(x / grid.cellSize),
+		cy: Math.floor(y / grid.cellSize),
+	};
+}
+
+// =============================================================================
+// ENTITY MANAGEMENT
+// =============================================================================
+
+/**
+ * Inserts an entity into the spatial hash at the given position and size.
+ *
+ * @param grid - The spatial hash grid
+ * @param eid - Entity ID
+ * @param x - Entity X position
+ * @param y - Entity Y position
+ * @param width - Entity width (default: 1)
+ * @param height - Entity height (default: 1)
+ *
+ * @example
+ * ```typescript
+ * import { createSpatialHash, insertEntity } from 'blecsd';
+ *
+ * const grid = createSpatialHash();
+ * insertEntity(grid, entity, 10, 20, 2, 3);
+ * ```
+ */
+export function insertEntity(
+	grid: SpatialHashGrid,
+	eid: Entity,
+	x: number,
+	y: number,
+	width = 1,
+	height = 1,
+): void {
+	removeEntityFromGrid(grid, eid);
+
+	const entityId = eid as number;
+	const occupiedCells = new Set<number>();
+
+	const minCx = Math.floor(x / grid.cellSize);
+	const minCy = Math.floor(y / grid.cellSize);
+	const maxCx = Math.floor((x + width - 0.001) / grid.cellSize);
+	const maxCy = Math.floor((y + height - 0.001) / grid.cellSize);
+
+	for (let cx = minCx; cx <= maxCx; cx++) {
+		for (let cy = minCy; cy <= maxCy; cy++) {
+			const key = cellKey(cx, cy);
+			occupiedCells.add(key);
+
+			let cellEntities = grid.cells.get(key);
+			if (!cellEntities) {
+				cellEntities = new Set();
+				grid.cells.set(key, cellEntities);
+			}
+			cellEntities.add(entityId);
+		}
+	}
+
+	grid.entityCells.set(entityId, occupiedCells);
+}
+
+/**
+ * Removes an entity from the spatial hash.
+ *
+ * @param grid - The spatial hash grid
+ * @param eid - Entity ID to remove
+ *
+ * @example
+ * ```typescript
+ * import { removeEntityFromGrid } from 'blecsd';
+ *
+ * removeEntityFromGrid(grid, entity);
+ * ```
+ */
+export function removeEntityFromGrid(grid: SpatialHashGrid, eid: Entity): void {
+	const entityId = eid as number;
+	const cells = grid.entityCells.get(entityId);
+	if (!cells) {
+		return;
+	}
+
+	for (const key of cells) {
+		const cellEntities = grid.cells.get(key);
+		if (cellEntities) {
+			cellEntities.delete(entityId);
+			if (cellEntities.size === 0) {
+				grid.cells.delete(key);
+			}
+		}
+	}
+
+	grid.entityCells.delete(entityId);
+}
+
+// =============================================================================
+// QUERIES
+// =============================================================================
+
+/**
+ * Gets all entities in the same cell(s) as the given position/area.
+ * This is the core broad-phase query for collision detection.
+ *
+ * @param grid - The spatial hash grid
+ * @param x - Query X position
+ * @param y - Query Y position
+ * @param width - Query width (default: 1)
+ * @param height - Query height (default: 1)
+ * @returns Set of entity IDs that may overlap the query area
+ *
+ * @example
+ * ```typescript
+ * import { createSpatialHash, queryArea } from 'blecsd';
+ *
+ * const nearby = queryArea(grid, playerX, playerY, 2, 2);
+ * for (const eid of nearby) {
+ *   // Check narrow-phase collision
+ * }
+ * ```
+ */
+export function queryArea(
+	grid: SpatialHashGrid,
+	x: number,
+	y: number,
+	width = 1,
+	height = 1,
+): ReadonlySet<number> {
+	const result = new Set<number>();
+
+	const minCx = Math.floor(x / grid.cellSize);
+	const minCy = Math.floor(y / grid.cellSize);
+	const maxCx = Math.floor((x + width - 0.001) / grid.cellSize);
+	const maxCy = Math.floor((y + height - 0.001) / grid.cellSize);
+
+	for (let cx = minCx; cx <= maxCx; cx++) {
+		for (let cy = minCy; cy <= maxCy; cy++) {
+			const key = cellKey(cx, cy);
+			const cellEntities = grid.cells.get(key);
+			if (cellEntities) {
+				for (const eid of cellEntities) {
+					result.add(eid);
+				}
+			}
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Gets potential collision candidates for an entity.
+ * Returns all entities in the same cells, excluding the entity itself.
+ *
+ * @param grid - The spatial hash grid
+ * @param eid - Entity to find candidates for
+ * @returns Set of entity IDs that may collide with the given entity
+ *
+ * @example
+ * ```typescript
+ * import { getNearbyEntities } from 'blecsd';
+ *
+ * const candidates = getNearbyEntities(grid, player);
+ * for (const other of candidates) {
+ *   // Narrow-phase collision check
+ * }
+ * ```
+ */
+export function getNearbyEntities(grid: SpatialHashGrid, eid: Entity): ReadonlySet<number> {
+	const entityId = eid as number;
+	const result = new Set<number>();
+
+	const cells = grid.entityCells.get(entityId);
+	if (!cells) {
+		return result;
+	}
+
+	for (const key of cells) {
+		const cellEntities = grid.cells.get(key);
+		if (cellEntities) {
+			for (const other of cellEntities) {
+				if (other !== entityId) {
+					result.add(other);
+				}
+			}
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Gets all entities at a specific cell coordinate.
+ *
+ * @param grid - The spatial hash grid
+ * @param cx - Cell X coordinate
+ * @param cy - Cell Y coordinate
+ * @returns Set of entity IDs in that cell
+ *
+ * @example
+ * ```typescript
+ * import { getEntitiesInCell } from 'blecsd';
+ *
+ * const entities = getEntitiesInCell(grid, 3, 5);
+ * ```
+ */
+export function getEntitiesInCell(
+	grid: SpatialHashGrid,
+	cx: number,
+	cy: number,
+): ReadonlySet<number> {
+	const key = cellKey(cx, cy);
+	return grid.cells.get(key) ?? new Set();
+}
+
+/**
+ * Gets all entities at a world position.
+ *
+ * @param grid - The spatial hash grid
+ * @param x - World X coordinate
+ * @param y - World Y coordinate
+ * @returns Set of entity IDs at that position
+ *
+ * @example
+ * ```typescript
+ * import { getEntitiesAtPoint } from 'blecsd';
+ *
+ * const entities = getEntitiesAtPoint(grid, 10, 20);
+ * ```
+ */
+export function getEntitiesAtPoint(
+	grid: SpatialHashGrid,
+	x: number,
+	y: number,
+): ReadonlySet<number> {
+	const cx = Math.floor(x / grid.cellSize);
+	const cy = Math.floor(y / grid.cellSize);
+	return getEntitiesInCell(grid, cx, cy);
+}
+
+// =============================================================================
+// GRID OPERATIONS
+// =============================================================================
+
+/**
+ * Clears all entities from the spatial hash grid.
+ *
+ * @param grid - The spatial hash grid to clear
+ *
+ * @example
+ * ```typescript
+ * import { clearSpatialHash } from 'blecsd';
+ *
+ * clearSpatialHash(grid);
+ * ```
+ */
+export function clearSpatialHash(grid: SpatialHashGrid): void {
+	grid.cells.clear();
+	grid.entityCells.clear();
+}
+
+/**
+ * Gets statistics about the spatial hash grid.
+ *
+ * @param grid - The spatial hash grid
+ * @returns Grid statistics
+ *
+ * @example
+ * ```typescript
+ * import { getSpatialHashStats } from 'blecsd';
+ *
+ * const stats = getSpatialHashStats(grid);
+ * console.log(`Cells: ${stats.cellCount}, Entities: ${stats.entityCount}`);
+ * ```
+ */
+export function getSpatialHashStats(grid: SpatialHashGrid): SpatialHashStats {
+	let maxEntities = 0;
+	let totalEntities = 0;
+
+	for (const cellEntities of grid.cells.values()) {
+		totalEntities += cellEntities.size;
+		if (cellEntities.size > maxEntities) {
+			maxEntities = cellEntities.size;
+		}
+	}
+
+	const cellCount = grid.cells.size;
+
+	return {
+		cellCount,
+		entityCount: grid.entityCells.size,
+		averageEntitiesPerCell: cellCount > 0 ? totalEntities / cellCount : 0,
+		maxEntitiesInCell: maxEntities,
+	};
+}
+
+// =============================================================================
+// REBUILD FROM WORLD
+// =============================================================================
+
+/**
+ * Rebuilds the spatial hash from all entities with Position and Collider components.
+ *
+ * @param grid - The spatial hash grid to rebuild
+ * @param world - The ECS world
+ *
+ * @example
+ * ```typescript
+ * import { createSpatialHash, rebuildSpatialHash } from 'blecsd';
+ *
+ * const grid = createSpatialHash({ cellSize: 4 });
+ * rebuildSpatialHash(grid, world);
+ * ```
+ */
+export function rebuildSpatialHash(grid: SpatialHashGrid, world: World): void {
+	clearSpatialHash(grid);
+
+	const entities = query(world, [Position, Collider]) as unknown as readonly Entity[];
+
+	for (const eid of entities) {
+		const x = Position.x[eid] as number;
+		const y = Position.y[eid] as number;
+		const w = Collider.width[eid] as number;
+		const h = Collider.height[eid] as number;
+		const ox = Collider.offsetX[eid] as number;
+		const oy = Collider.offsetY[eid] as number;
+
+		insertEntity(grid, eid, x + ox, y + oy, w, h);
+	}
+}
+
+// =============================================================================
+// SYSTEM
+// =============================================================================
+
+/** Module-level grid reference for the system */
+let systemGrid: SpatialHashGrid | null = null;
+
+/**
+ * Sets the spatial hash grid for the system to use.
+ *
+ * @param grid - The spatial hash grid
+ *
+ * @example
+ * ```typescript
+ * import { createSpatialHash, setSpatialHashGrid } from 'blecsd';
+ *
+ * const grid = createSpatialHash({ cellSize: 4 });
+ * setSpatialHashGrid(grid);
+ * ```
+ */
+export function setSpatialHashGrid(grid: SpatialHashGrid): void {
+	systemGrid = grid;
+}
+
+/**
+ * Gets the current system spatial hash grid.
+ *
+ * @returns The grid, or null if not set
+ */
+export function getSpatialHashGrid(): SpatialHashGrid | null {
+	return systemGrid;
+}
+
+/**
+ * Spatial hash system that rebuilds the grid each frame.
+ *
+ * Register this in the EARLY_UPDATE phase to ensure collision queries
+ * use up-to-date spatial data.
+ *
+ * @example
+ * ```typescript
+ * import { createSpatialHash, setSpatialHashGrid, spatialHashSystem, createScheduler, LoopPhase } from 'blecsd';
+ *
+ * const grid = createSpatialHash({ cellSize: 4 });
+ * setSpatialHashGrid(grid);
+ *
+ * const scheduler = createScheduler();
+ * scheduler.registerSystem(LoopPhase.EARLY_UPDATE, spatialHashSystem);
+ * ```
+ */
+export const spatialHashSystem: System = (world: World): World => {
+	if (systemGrid) {
+		rebuildSpatialHash(systemGrid, world);
+	}
+	return world;
+};
+
+/**
+ * Creates a new spatial hash system.
+ *
+ * @returns The system function
+ */
+export function createSpatialHashSystem(): System {
+	return spatialHashSystem;
+}


### PR DESCRIPTION
## Summary
- Grid-based spatial partitioning with configurable cell size
- O(1) broad-phase collision lookups via queryArea() and getNearbyEntities()
- Insert/remove entities, rebuild from world, point and area queries
- spatialHashSystem for automatic per-frame rebuild in scheduler
- Grid statistics for performance debugging

## Test plan
- [x] Grid creation with custom and default cell sizes
- [x] World-to-cell coordinate mapping (positive, zero, negative)
- [x] Entity insert, re-insert (update position), and removal
- [x] Area queries finding correct entities
- [x] Nearby entity queries excluding self
- [x] Cell and point queries
- [x] Clear and statistics
- [x] Rebuild from ECS world with Position+Collider
- [x] System integration with setSpatialHashGrid

Closes #371