### PR TITLE
feat(doom): add player death, respawn, and game over system

### DIFF
--- a/examples/doom/game/death.test.ts
+++ b/examples/doom/game/death.test.ts
@@ -1,0 +1,442 @@
+import { describe, expect, it, beforeAll, beforeEach } from 'vitest';
+import {
+	GamePhase,
+	DEFAULT_LIVES,
+	DEATH_ANIM_TICS,
+	DEATH_VIEW_HEIGHT,
+	createGameState,
+	damagePlayer,
+	tickDeath,
+	respawnPlayer,
+	canPlayerAct,
+	isAwaitingRespawn,
+	isGameOver,
+} from './death.js';
+import { createPlayer } from './player.js';
+import type { PlayerState } from './player.js';
+import { createWeaponState } from './weapons.js';
+import type { WeaponState } from './weapons.js';
+import type { MapData } from '../wad/types.js';
+import { FRACBITS } from '../math/fixed.js';
+import { generateTables } from '../math/angles.js';
+
+beforeAll(() => {
+	generateTables();
+});
+
+// ─── Minimal Mocks ──────────────────────────────────────────────────
+
+function createMockMapData(): MapData {
+	const buf = new ArrayBuffer(4);
+	return {
+		name: 'E1M1',
+		things: [{ x: 100, y: 200, angle: 90, type: 1, flags: 7 }],
+		linedefs: [],
+		sidedefs: [],
+		vertexes: [],
+		segs: [],
+		subsectors: [],
+		nodes: [],
+		sectors: [
+			{
+				floorHeight: 0,
+				ceilingHeight: 128,
+				floorFlat: 'FLOOR4_8',
+				ceilingFlat: 'CEIL3_5',
+				lightLevel: 160,
+				special: 0,
+				tag: 0,
+			},
+		],
+		blockmap: {
+			header: { originX: 0, originY: 0, columns: 1, rows: 1 },
+			offsets: [0],
+			data: new DataView(buf),
+		},
+	};
+}
+
+let map: MapData;
+let player: PlayerState;
+let weaponState: WeaponState;
+
+beforeEach(() => {
+	map = createMockMapData();
+	player = createPlayer(map);
+	weaponState = createWeaponState();
+});
+
+// ─── createGameState ────────────────────────────────────────────────
+
+describe('createGameState', () => {
+	it('starts in PLAYING phase with default lives', () => {
+		const gs = createGameState();
+		expect(gs.phase).toBe(GamePhase.PLAYING);
+		expect(gs.lives).toBe(DEFAULT_LIVES);
+		expect(gs.deathTics).toBe(0);
+		expect(gs.totalDeaths).toBe(0);
+	});
+
+	it('accepts custom lives count', () => {
+		const gs = createGameState(5);
+		expect(gs.lives).toBe(5);
+	});
+});
+
+// ─── damagePlayer ───────────────────────────────────────────────────
+
+describe('damagePlayer', () => {
+	it('reduces player health by damage amount', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 20);
+		expect(player.health).toBe(80);
+		expect(gs.phase).toBe(GamePhase.PLAYING);
+	});
+
+	it('absorbs damage with armor (1/3 absorbed)', () => {
+		const gs = createGameState();
+		player.armor = 100;
+		damagePlayer(gs, player, 30);
+		// 30 / 3 = 10 absorbed by armor, 20 to health
+		expect(player.armor).toBe(90);
+		expect(player.health).toBe(80);
+	});
+
+	it('does not absorb more than available armor', () => {
+		const gs = createGameState();
+		player.armor = 5;
+		damagePlayer(gs, player, 30);
+		// Would absorb 10, but only 5 armor available
+		// 30 - 5 = 25 to health
+		expect(player.armor).toBe(0);
+		expect(player.health).toBe(75);
+	});
+
+	it('triggers death when health drops to zero', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 100);
+		expect(player.health).toBe(0);
+		expect(gs.phase).toBe(GamePhase.DYING);
+	});
+
+	it('triggers death when health drops below zero', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 200);
+		expect(player.health).toBe(0);
+		expect(gs.phase).toBe(GamePhase.DYING);
+	});
+
+	it('zeroes player momentum on death', () => {
+		const gs = createGameState();
+		player.momx = 50000;
+		player.momy = -30000;
+		damagePlayer(gs, player, 100);
+		expect(player.momx).toBe(0);
+		expect(player.momy).toBe(0);
+	});
+
+	it('does nothing when already dying', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 100);
+		expect(gs.phase).toBe(GamePhase.DYING);
+		// Try to damage again while dying
+		const healthBefore = player.health;
+		damagePlayer(gs, player, 50);
+		expect(player.health).toBe(healthBefore);
+	});
+
+	it('does nothing when game is over', () => {
+		const gs = createGameState(0);
+		gs.phase = GamePhase.GAME_OVER;
+		const healthBefore = player.health;
+		damagePlayer(gs, player, 50);
+		expect(player.health).toBe(healthBefore);
+	});
+
+	it('does nothing for zero or negative damage', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 0);
+		expect(player.health).toBe(100);
+		damagePlayer(gs, player, -10);
+		expect(player.health).toBe(100);
+	});
+
+	it('accumulates damage across multiple hits', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 30);
+		damagePlayer(gs, player, 30);
+		damagePlayer(gs, player, 30);
+		expect(player.health).toBe(10);
+		expect(gs.phase).toBe(GamePhase.PLAYING);
+	});
+});
+
+// ─── tickDeath ──────────────────────────────────────────────────────
+
+describe('tickDeath', () => {
+	it('increments deathTics each tic', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 100);
+		tickDeath(gs, player);
+		expect(gs.deathTics).toBe(1);
+		tickDeath(gs, player);
+		expect(gs.deathTics).toBe(2);
+	});
+
+	it('sinks viewheight during death animation', () => {
+		const gs = createGameState();
+		const initialViewheight = player.viewheight;
+		damagePlayer(gs, player, 100);
+		tickDeath(gs, player);
+		expect(player.viewheight).toBeLessThan(initialViewheight);
+	});
+
+	it('does not sink viewheight below DEATH_VIEW_HEIGHT', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 100);
+		// Tick many times
+		for (let i = 0; i < DEATH_ANIM_TICS + 10; i++) {
+			tickDeath(gs, player);
+		}
+		expect(player.viewheight).toBeGreaterThanOrEqual(DEATH_VIEW_HEIGHT);
+	});
+
+	it('transitions to DEAD after animation completes (with lives)', () => {
+		const gs = createGameState(2);
+		damagePlayer(gs, player, 100);
+		for (let i = 0; i < DEATH_ANIM_TICS; i++) {
+			tickDeath(gs, player);
+		}
+		expect(gs.phase).toBe(GamePhase.DEAD);
+	});
+
+	it('transitions to GAME_OVER after animation completes (no lives)', () => {
+		const gs = createGameState(0);
+		gs.phase = GamePhase.DYING;
+		gs.deathTics = 0;
+		for (let i = 0; i < DEATH_ANIM_TICS; i++) {
+			tickDeath(gs, player);
+		}
+		expect(gs.phase).toBe(GamePhase.GAME_OVER);
+	});
+
+	it('does nothing when not in DYING phase', () => {
+		const gs = createGameState();
+		const viewBefore = player.viewheight;
+		tickDeath(gs, player);
+		expect(player.viewheight).toBe(viewBefore);
+		expect(gs.deathTics).toBe(0);
+	});
+
+	it('updates viewz from sinking viewheight', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 100);
+		tickDeath(gs, player);
+		expect(player.viewz).toBe(player.z + player.viewheight);
+	});
+});
+
+// ─── respawnPlayer ──────────────────────────────────────────────────
+
+describe('respawnPlayer', () => {
+	it('resets player to start position', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 100);
+		// Run death animation to completion
+		for (let i = 0; i < DEATH_ANIM_TICS; i++) {
+			tickDeath(gs, player);
+		}
+		expect(gs.phase).toBe(GamePhase.DEAD);
+
+		// Move player away from start
+		player.x = 9999 << FRACBITS;
+		player.y = 9999 << FRACBITS;
+
+		respawnPlayer(gs, player, weaponState, map);
+
+		expect(player.x).toBe(100 << FRACBITS);
+		expect(player.y).toBe(200 << FRACBITS);
+		expect(gs.phase).toBe(GamePhase.PLAYING);
+	});
+
+	it('decrements lives on respawn', () => {
+		const gs = createGameState(3);
+		damagePlayer(gs, player, 100);
+		for (let i = 0; i < DEATH_ANIM_TICS; i++) {
+			tickDeath(gs, player);
+		}
+
+		respawnPlayer(gs, player, weaponState, map);
+		expect(gs.lives).toBe(2);
+		expect(gs.totalDeaths).toBe(1);
+	});
+
+	it('resets player health and armor', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 100);
+		for (let i = 0; i < DEATH_ANIM_TICS; i++) {
+			tickDeath(gs, player);
+		}
+
+		respawnPlayer(gs, player, weaponState, map);
+		expect(player.health).toBe(100);
+		expect(player.armor).toBe(0);
+	});
+
+	it('resets viewheight to normal', () => {
+		const gs = createGameState();
+		damagePlayer(gs, player, 100);
+		for (let i = 0; i < DEATH_ANIM_TICS; i++) {
+			tickDeath(gs, player);
+		}
+
+		respawnPlayer(gs, player, weaponState, map);
+		expect(player.viewheight).toBe(41 << FRACBITS);
+	});
+
+	it('resets weapon state to pistol with 50 bullets', () => {
+		const gs = createGameState();
+		weaponState.current = 2; // shotgun
+		weaponState.ammo = [0, 0, 0]; // no ammo
+
+		damagePlayer(gs, player, 100);
+		for (let i = 0; i < DEATH_ANIM_TICS; i++) {
+			tickDeath(gs, player);
+		}
+
+		respawnPlayer(gs, player, weaponState, map);
+		expect(weaponState.current).toBe(1); // pistol
+		expect(weaponState.ammo[1]).toBe(50); // 50 bullets
+	});
+
+	it('does nothing when not in DEAD phase', () => {
+		const gs = createGameState();
+		const livesBefore = gs.lives;
+		respawnPlayer(gs, player, weaponState, map);
+		expect(gs.lives).toBe(livesBefore);
+		expect(gs.phase).toBe(GamePhase.PLAYING);
+	});
+
+	it('does nothing when no lives remain', () => {
+		const gs = createGameState(0);
+		gs.phase = GamePhase.DEAD;
+		respawnPlayer(gs, player, weaponState, map);
+		// Should not change phase since 0 lives
+		expect(gs.phase).toBe(GamePhase.DEAD);
+	});
+});
+
+// ─── Query Helpers ──────────────────────────────────────────────────
+
+describe('canPlayerAct', () => {
+	it('returns true when PLAYING', () => {
+		const gs = createGameState();
+		expect(canPlayerAct(gs)).toBe(true);
+	});
+
+	it('returns false when DYING', () => {
+		const gs = createGameState();
+		gs.phase = GamePhase.DYING;
+		expect(canPlayerAct(gs)).toBe(false);
+	});
+
+	it('returns false when DEAD', () => {
+		const gs = createGameState();
+		gs.phase = GamePhase.DEAD;
+		expect(canPlayerAct(gs)).toBe(false);
+	});
+
+	it('returns false when GAME_OVER', () => {
+		const gs = createGameState();
+		gs.phase = GamePhase.GAME_OVER;
+		expect(canPlayerAct(gs)).toBe(false);
+	});
+});
+
+describe('isAwaitingRespawn', () => {
+	it('returns true when DEAD', () => {
+		const gs = createGameState();
+		gs.phase = GamePhase.DEAD;
+		expect(isAwaitingRespawn(gs)).toBe(true);
+	});
+
+	it('returns false for other phases', () => {
+		const gs = createGameState();
+		expect(isAwaitingRespawn(gs)).toBe(false);
+		gs.phase = GamePhase.DYING;
+		expect(isAwaitingRespawn(gs)).toBe(false);
+		gs.phase = GamePhase.GAME_OVER;
+		expect(isAwaitingRespawn(gs)).toBe(false);
+	});
+});
+
+describe('isGameOver', () => {
+	it('returns true when GAME_OVER', () => {
+		const gs = createGameState();
+		gs.phase = GamePhase.GAME_OVER;
+		expect(isGameOver(gs)).toBe(true);
+	});
+
+	it('returns false for other phases', () => {
+		const gs = createGameState();
+		expect(isGameOver(gs)).toBe(false);
+		gs.phase = GamePhase.DYING;
+		expect(isGameOver(gs)).toBe(false);
+		gs.phase = GamePhase.DEAD;
+		expect(isGameOver(gs)).toBe(false);
+	});
+});
+
+// ─── Full Lifecycle ─────────────────────────────────────────────────
+
+describe('full death-respawn lifecycle', () => {
+	it('complete cycle: damage -> death animation -> respawn', () => {
+		const gs = createGameState(2);
+
+		// Take damage
+		damagePlayer(gs, player, 50);
+		expect(player.health).toBe(50);
+		expect(canPlayerAct(gs)).toBe(true);
+
+		// Kill player
+		damagePlayer(gs, player, 50);
+		expect(player.health).toBe(0);
+		expect(gs.phase).toBe(GamePhase.DYING);
+		expect(canPlayerAct(gs)).toBe(false);
+
+		// Run death animation
+		for (let i = 0; i < DEATH_ANIM_TICS; i++) {
+			tickDeath(gs, player);
+		}
+		expect(gs.phase).toBe(GamePhase.DEAD);
+		expect(isAwaitingRespawn(gs)).toBe(true);
+
+		// Respawn
+		respawnPlayer(gs, player, weaponState, map);
+		expect(gs.phase).toBe(GamePhase.PLAYING);
+		expect(gs.lives).toBe(1);
+		expect(player.health).toBe(100);
+		expect(canPlayerAct(gs)).toBe(true);
+	});
+
+	it('game over after last life used', () => {
+		const gs = createGameState(1);
+
+		// Kill and respawn (uses last life)
+		damagePlayer(gs, player, 100);
+		for (let i = 0; i < DEATH_ANIM_TICS; i++) {
+			tickDeath(gs, player);
+		}
+		respawnPlayer(gs, player, weaponState, map);
+		expect(gs.lives).toBe(0);
+		expect(gs.phase).toBe(GamePhase.PLAYING);
+
+		// Kill again, now 0 lives
+		damagePlayer(gs, player, 100);
+		for (let i = 0; i < DEATH_ANIM_TICS; i++) {
+			tickDeath(gs, player);
+		}
+		expect(gs.phase).toBe(GamePhase.GAME_OVER);
+		expect(isGameOver(gs)).toBe(true);
+	});
+});

--- a/examples/doom/game/death.ts
+++ b/examples/doom/game/death.ts
@@ -1,0 +1,273 @@
+/**
+ * Player death, respawn, and game over logic.
+ *
+ * Manages the game phase (playing, dying, dead, game over) and handles
+ * player damage with armor absorption. When health drops to zero, the
+ * player enters a death animation where the viewheight sinks. After the
+ * animation, the player can press USE to respawn (losing a life) or
+ * see the game over screen if no lives remain.
+ *
+ * Matches Doom's P_DeathThink from p_user.c and G_DoReborn from g_game.c.
+ *
+ * @module game/death
+ */
+
+import { FRACBITS } from '../math/fixed.js';
+import type { MapData } from '../wad/types.js';
+import type { PlayerState } from './player.js';
+import { createPlayer } from './player.js';
+import { createWeaponState, type WeaponState } from './weapons.js';
+
+// ─── Game Phase ─────────────────────────────────────────────────
+
+/** Game phases for the player lifecycle. */
+export const GamePhase = {
+	/** Normal gameplay: player can move, shoot, interact. */
+	PLAYING: 0,
+	/** Death animation in progress: viewheight sinking. */
+	DYING: 1,
+	/** Death animation complete: waiting for USE to respawn. */
+	DEAD: 2,
+	/** No lives remaining: game is over. */
+	GAME_OVER: 3,
+} as const;
+
+// ─── Constants ──────────────────────────────────────────────────
+
+/** Starting number of lives. */
+export const DEFAULT_LIVES = 3;
+
+/** Number of tics for the death animation (viewheight sinking). */
+export const DEATH_ANIM_TICS = 35;
+
+/** Minimum viewheight during death (10 map units, fixed-point). */
+export const DEATH_VIEW_HEIGHT = 10 << FRACBITS;
+
+/** Amount viewheight decreases per tic during death animation (fixed-point). */
+const VIEW_SINK_SPEED = Math.floor(((41 - 10) << FRACBITS) / DEATH_ANIM_TICS);
+
+/** Armor absorption percentage (green armor absorbs 1/3 of damage). */
+const ARMOR_ABSORB_FRACTION = 3;
+
+// ─── Game State ─────────────────────────────────────────────────
+
+/** Mutable game state tracking the player lifecycle. */
+export interface GameState {
+	/** Current game phase. */
+	phase: number;
+	/** Remaining lives (decremented on respawn). */
+	lives: number;
+	/** Tics elapsed since death began. */
+	deathTics: number;
+	/** Total deaths this session. */
+	totalDeaths: number;
+}
+
+/**
+ * Create initial game state.
+ *
+ * @param lives - Starting number of lives (defaults to DEFAULT_LIVES)
+ * @returns Fresh game state in PLAYING phase
+ */
+export function createGameState(lives?: number): GameState {
+	return {
+		phase: GamePhase.PLAYING,
+		lives: lives ?? DEFAULT_LIVES,
+		deathTics: 0,
+		totalDeaths: 0,
+	};
+}
+
+// ─── Player Damage ──────────────────────────────────────────────
+
+/**
+ * Apply damage to the player with armor absorption.
+ *
+ * Armor absorbs 1/3 of incoming damage (matching Doom's green armor).
+ * If health drops to zero or below, the player enters the DYING phase.
+ *
+ * Does nothing if the player is already dead or the game is over.
+ *
+ * @param gs - Mutable game state
+ * @param player - Mutable player state
+ * @param damage - Raw damage amount before armor
+ */
+export function damagePlayer(
+	gs: GameState,
+	player: PlayerState,
+	damage: number,
+): void {
+	if (gs.phase !== GamePhase.PLAYING) return;
+	if (damage <= 0) return;
+
+	// Armor absorption: armor absorbs 1/3 of damage
+	let saved = 0;
+	if (player.armor > 0) {
+		saved = Math.floor(damage / ARMOR_ABSORB_FRACTION);
+		if (saved > player.armor) {
+			saved = player.armor;
+		}
+		player.armor -= saved;
+	}
+
+	const actualDamage = damage - saved;
+	player.health -= actualDamage;
+
+	if (player.health <= 0) {
+		player.health = 0;
+		killPlayer(gs, player);
+	}
+}
+
+/**
+ * Transition the player into the DYING phase.
+ * Zeroes momentum so the player stops moving.
+ */
+function killPlayer(gs: GameState, player: PlayerState): void {
+	gs.phase = GamePhase.DYING;
+	gs.deathTics = 0;
+
+	// Stop all movement
+	player.momx = 0;
+	player.momy = 0;
+}
+
+// ─── Death Animation ────────────────────────────────────────────
+
+/**
+ * Advance the death animation by one tic.
+ *
+ * During the DYING phase, the player's viewheight sinks toward the
+ * floor over DEATH_ANIM_TICS. When the animation completes, the
+ * phase transitions to DEAD (waiting for respawn) or GAME_OVER.
+ *
+ * Does nothing if the game phase is not DYING.
+ *
+ * @param gs - Mutable game state
+ * @param player - Mutable player state (viewheight modified)
+ */
+export function tickDeath(gs: GameState, player: PlayerState): void {
+	if (gs.phase !== GamePhase.DYING) return;
+
+	gs.deathTics++;
+
+	// Sink viewheight toward floor
+	if (player.viewheight > DEATH_VIEW_HEIGHT) {
+		player.viewheight -= VIEW_SINK_SPEED;
+		if (player.viewheight < DEATH_VIEW_HEIGHT) {
+			player.viewheight = DEATH_VIEW_HEIGHT;
+		}
+	}
+
+	// Update viewz from sinking viewheight
+	player.viewz = player.z + player.viewheight;
+
+	// Check if death animation is complete
+	if (gs.deathTics >= DEATH_ANIM_TICS) {
+		if (gs.lives > 0) {
+			gs.phase = GamePhase.DEAD;
+		} else {
+			gs.phase = GamePhase.GAME_OVER;
+		}
+	}
+}
+
+// ─── Respawn ────────────────────────────────────────────────────
+
+/**
+ * Respawn the player at the map start position.
+ *
+ * Decrements lives, resets player state (position, health, ammo, momentum),
+ * and resets weapon state to pistol with 50 bullets. Transitions back to
+ * the PLAYING phase.
+ *
+ * Does nothing if the phase is not DEAD, or if no lives remain.
+ *
+ * @param gs - Mutable game state
+ * @param player - Mutable player state (fully reset)
+ * @param weaponState - Mutable weapon state (reset to defaults)
+ * @param map - Map data (for finding player start position)
+ */
+export function respawnPlayer(
+	gs: GameState,
+	player: PlayerState,
+	weaponState: WeaponState,
+	map: MapData,
+): void {
+	if (gs.phase !== GamePhase.DEAD) return;
+	if (gs.lives <= 0) return;
+
+	gs.lives--;
+	gs.totalDeaths++;
+
+	// Create a fresh player at the map start
+	const fresh = createPlayer(map);
+
+	// Copy fresh values into existing player state
+	player.x = fresh.x;
+	player.y = fresh.y;
+	player.z = fresh.z;
+	player.angle = fresh.angle;
+	player.viewz = fresh.viewz;
+	player.viewheight = fresh.viewheight;
+	player.deltaviewheight = fresh.deltaviewheight;
+	player.momx = fresh.momx;
+	player.momy = fresh.momy;
+	player.health = fresh.health;
+	player.armor = fresh.armor;
+	player.ammo = fresh.ammo;
+	player.maxAmmo = fresh.maxAmmo;
+	player.forwardSpeed = fresh.forwardSpeed;
+	player.sideSpeed = fresh.sideSpeed;
+	player.turnSpeed = fresh.turnSpeed;
+	player.sectorIndex = fresh.sectorIndex;
+
+	// Reset weapon state to defaults
+	const freshWeapon = createWeaponState();
+	weaponState.current = freshWeapon.current;
+	weaponState.pendingWeapon = freshWeapon.pendingWeapon;
+	weaponState.state = freshWeapon.state;
+	weaponState.tics = freshWeapon.tics;
+	weaponState.frame = freshWeapon.frame;
+	weaponState.ready = freshWeapon.ready;
+	weaponState.owned = freshWeapon.owned;
+	weaponState.ammo = freshWeapon.ammo;
+	weaponState.maxAmmo = freshWeapon.maxAmmo;
+	weaponState.bobX = freshWeapon.bobX;
+	weaponState.bobY = freshWeapon.bobY;
+	weaponState.flashTics = freshWeapon.flashTics;
+
+	gs.phase = GamePhase.PLAYING;
+}
+
+// ─── Query Helpers ──────────────────────────────────────────────
+
+/**
+ * Check whether the player can receive input (movement, shooting).
+ *
+ * @param gs - Game state
+ * @returns true if the player is alive and playing
+ */
+export function canPlayerAct(gs: GameState): boolean {
+	return gs.phase === GamePhase.PLAYING;
+}
+
+/**
+ * Check whether the respawn prompt should be shown.
+ *
+ * @param gs - Game state
+ * @returns true if the player is dead and waiting for respawn input
+ */
+export function isAwaitingRespawn(gs: GameState): boolean {
+	return gs.phase === GamePhase.DEAD;
+}
+
+/**
+ * Check whether the game is over (no lives remaining).
+ *
+ * @param gs - Game state
+ * @returns true if the game is over
+ */
+export function isGameOver(gs: GameState): boolean {
+	return gs.phase === GamePhase.GAME_OVER;
+}

--- a/examples/doom/game/enemyAI.ts
+++ b/examples/doom/game/enemyAI.ts
@@ -21,6 +21,7 @@ import {
 } from '../math/angles.js';
 import { FRACBITS, FRACUNIT, fixedMul } from '../math/fixed.js';
 import type { MapData } from '../wad/types.js';
+import { damagePlayer } from './death.js';
 import { type Mobj, MobjFlags, MobjType, damageMobj } from './mobj.js';
 import type { PlayerState } from './player.js';
 import { findSectorAt } from './player.js';
@@ -197,7 +198,7 @@ function actionFaceTarget(ctx: ActionContext): void {
 
 /** Zombieman hitscan attack: single bullet. */
 function actionPosAttack(ctx: ActionContext): void {
-	const { mobj, player } = ctx;
+	const { mobj, player, gameState } = ctx;
 	if (!mobj.target) return;
 
 	actionFaceTarget(ctx);
@@ -205,7 +206,7 @@ function actionPosAttack(ctx: ActionContext): void {
 	// Hitscan: damage player directly if in line of sight
 	if (checkSight(mobj, player, ctx.map)) {
 		const damage = ((Math.random() * 5 | 0) + 1) * 3;
-		player.health -= damage;
+		damagePlayer(gameState, player, damage);
 	}
 
 	mobj.flags |= MobjFlags.MF_JUSTATTACKED;
@@ -213,7 +214,7 @@ function actionPosAttack(ctx: ActionContext): void {
 
 /** Shotgun Guy attack: 3 pellets. */
 function actionSPosAttack(ctx: ActionContext): void {
-	const { mobj, player } = ctx;
+	const { mobj, player, gameState } = ctx;
 	if (!mobj.target) return;
 
 	actionFaceTarget(ctx);
@@ -221,7 +222,7 @@ function actionSPosAttack(ctx: ActionContext): void {
 	if (checkSight(mobj, player, ctx.map)) {
 		for (let i = 0; i < 3; i++) {
 			const damage = ((Math.random() * 5 | 0) + 1) * 3;
-			player.health -= damage;
+			damagePlayer(gameState, player, damage);
 		}
 	}
 
@@ -230,7 +231,7 @@ function actionSPosAttack(ctx: ActionContext): void {
 
 /** Imp attack: melee claw if close, otherwise fireball (simplified as hitscan). */
 function actionTroopAttack(ctx: ActionContext): void {
-	const { mobj, player } = ctx;
+	const { mobj, player, gameState } = ctx;
 	if (!mobj.target) return;
 
 	actionFaceTarget(ctx);
@@ -240,11 +241,11 @@ function actionTroopAttack(ctx: ActionContext): void {
 	if (dist < MELEERANGE) {
 		// Melee: claw attack
 		const damage = ((Math.random() * 8 | 0) + 1) * 3;
-		player.health -= damage;
+		damagePlayer(gameState, player, damage);
 	} else if (checkSight(mobj, player, ctx.map)) {
 		// Ranged: fireball (simplified as direct damage for now)
 		const damage = ((Math.random() * 8 | 0) + 1) * 3;
-		player.health -= damage;
+		damagePlayer(gameState, player, damage);
 	}
 
 	mobj.flags |= MobjFlags.MF_JUSTATTACKED;
@@ -252,7 +253,7 @@ function actionTroopAttack(ctx: ActionContext): void {
 
 /** Demon melee bite attack. */
 function actionSargAttack(ctx: ActionContext): void {
-	const { mobj, player } = ctx;
+	const { mobj, player, gameState } = ctx;
 	if (!mobj.target) return;
 
 	actionFaceTarget(ctx);
@@ -261,7 +262,7 @@ function actionSargAttack(ctx: ActionContext): void {
 
 	if (dist < MELEERANGE) {
 		const damage = ((Math.random() * 10 | 0) + 1) * 4;
-		player.health -= damage;
+		damagePlayer(gameState, player, damage);
 	}
 
 	mobj.flags |= MobjFlags.MF_JUSTATTACKED;

--- a/examples/doom/game/states.ts
+++ b/examples/doom/game/states.ts
@@ -11,6 +11,7 @@
 import type { Mobj } from './mobj.js';
 import type { MapData } from '../wad/types.js';
 import type { PlayerState } from './player.js';
+import type { GameState } from './death.js';
 
 // ─── Action Function Type ─────────────────────────────────────────
 
@@ -18,6 +19,7 @@ import type { PlayerState } from './player.js';
 export interface ActionContext {
 	readonly mobj: Mobj;
 	readonly player: PlayerState;
+	readonly gameState: GameState;
 	readonly map: MapData;
 	readonly mobjs: readonly Mobj[];
 }

--- a/examples/doom/game/thinkers.ts
+++ b/examples/doom/game/thinkers.ts
@@ -9,6 +9,7 @@
  */
 
 import type { MapData } from '../wad/types.js';
+import type { GameState } from './death.js';
 import type { Mobj } from './mobj.js';
 import { MobjFlags } from './mobj.js';
 import type { PlayerState } from './player.js';
@@ -67,11 +68,13 @@ export function initThinkers(mobjs: Mobj[]): void {
  *
  * @param mobjs - All map objects
  * @param player - Current player state
+ * @param gameState - Game state for player damage handling
  * @param map - Map data for collision and sight checks
  */
 export function runThinkers(
 	mobjs: Mobj[],
 	player: PlayerState,
+	gameState: GameState,
 	map: MapData,
 ): void {
 	for (const mobj of mobjs) {
@@ -85,7 +88,7 @@ export function runThinkers(
 		if (mobj.tics === -1) {
 			// Infinite tics: call action every tic if present
 			if (currentState.action) {
-				callAction(currentState.action, mobj, player, map, mobjs);
+				callAction(currentState.action, mobj, player, gameState, map, mobjs);
 			}
 			continue;
 		}
@@ -106,7 +109,7 @@ export function runThinkers(
 
 		// Call the new state's action function
 		if (state.action) {
-			callAction(state.action, mobj, player, map, mobjs);
+			callAction(state.action, mobj, player, gameState, map, mobjs);
 		}
 	}
 }
@@ -118,13 +121,14 @@ function callAction(
 	name: string,
 	mobj: Mobj,
 	player: PlayerState,
+	gameState: GameState,
 	map: MapData,
 	mobjs: readonly Mobj[],
 ): void {
 	const fn = actionRegistry[name];
 	if (!fn) return;
 
-	const ctx: ActionContext = { mobj, player, map, mobjs };
+	const ctx: ActionContext = { mobj, player, gameState, map, mobjs };
 	fn(ctx);
 }
 


### PR DESCRIPTION
## Summary
- Add game phase management (PLAYING, DYING, DEAD, GAME_OVER) with life counter
- Implement `damagePlayer()` with armor absorption (1/3 absorbed by green armor)
- Death animation sinks viewheight from 41 to 10 map units over 35 tics
- Respawn resets player to map start with full health, pistol, and 50 bullets
- Red-tinted overlay screens for "YOU DIED" (with respawn prompt) and "GAME OVER"
- Route all enemy attacks through `damagePlayer()` instead of direct `player.health -=`
- Player input and weapon firing disabled during death/game over phases

Closes #717

## Test plan
- [x] 36 new tests covering damage, armor, death animation, respawn, game over, query helpers, and full lifecycle
- [x] All 251 doom tests pass
- [x] All 8734 root tests pass
- [x] Lint, typecheck, and build pass