### PR TITLE
feat(media): add GIF parser with LZW decompression (#711)

### DIFF
--- a/src/media/gif/index.ts
+++ b/src/media/gif/index.ts
@@ -1,0 +1,38 @@
+/**
+ * GIF parsing utilities for blECSd.
+ *
+ * @module media/gif
+ */
+
+export type {
+	LZWError,
+	LZWOutput,
+	LZWResult,
+} from './lzw';
+export {
+	createBitReader,
+	decompressLZW,
+	readCode,
+} from './lzw';
+export type {
+	GIFColor,
+	GIFFrame,
+	GIFHeader,
+	GIFParseError,
+	GIFParseOutput,
+	GIFParseResult,
+	GIFVersion,
+} from './parser';
+export {
+	DisposalMethod,
+	deinterlace,
+	frameToRGBA,
+	GIF87A_MAGIC,
+	GIF89A_MAGIC,
+	GIFHeaderSchema,
+	parseColorTable,
+	parseGIF,
+	parseGIFHeader,
+	readSubBlocks,
+	validateGIFSignature,
+} from './parser';

--- a/src/media/gif/lzw.test.ts
+++ b/src/media/gif/lzw.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for GIF LZW decompression.
+ *
+ * @module media/gif/lzw.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createBitReader, decompressLZW, readCode } from './lzw';
+
+// =============================================================================
+// TEST HELPERS
+// =============================================================================
+
+/**
+ * Encodes pixel data into LZW compressed format for testing.
+ * Correctly tracks code size increases to match the decompressor.
+ * Uses simple encoding (no actual LZW compression, just individual codes).
+ */
+function lzwEncode(pixels: number[], minCodeSize: number): Uint8Array {
+	const clearCode = 1 << minCodeSize;
+	const eoiCode = clearCode + 1;
+	let codeSize = minCodeSize + 1;
+	let nextCode = eoiCode + 1;
+	let isFirstAfterClear = true;
+
+	const buffer: number[] = [];
+	let currentByte = 0;
+	let bitsInByte = 0;
+
+	function writeCode(code: number, size: number): void {
+		let c = code;
+		let remaining = size;
+		while (remaining > 0) {
+			const available = 8 - bitsInByte;
+			const toWrite = Math.min(available, remaining);
+			const mask = (1 << toWrite) - 1;
+			currentByte |= (c & mask) << bitsInByte;
+			c >>= toWrite;
+			bitsInByte += toWrite;
+			remaining -= toWrite;
+			if (bitsInByte === 8) {
+				buffer.push(currentByte);
+				currentByte = 0;
+				bitsInByte = 0;
+			}
+		}
+	}
+
+	writeCode(clearCode, codeSize);
+
+	for (const pixel of pixels) {
+		writeCode(pixel, codeSize);
+		if (!isFirstAfterClear) {
+			nextCode++;
+			if (nextCode >= 1 << codeSize && codeSize < 12) {
+				codeSize++;
+			}
+		}
+		isFirstAfterClear = false;
+	}
+
+	writeCode(eoiCode, codeSize);
+
+	if (bitsInByte > 0) {
+		buffer.push(currentByte);
+	}
+
+	return new Uint8Array(buffer);
+}
+
+// =============================================================================
+// BIT READER
+// =============================================================================
+
+describe('createBitReader', () => {
+	it('creates a reader at position 0', () => {
+		const reader = createBitReader(new Uint8Array([0xff]));
+		expect(reader.byteOffset).toBe(0);
+		expect(reader.bitOffset).toBe(0);
+	});
+});
+
+describe('readCode', () => {
+	it('reads a 3-bit code from the first byte', () => {
+		const reader = createBitReader(new Uint8Array([0b00000101]));
+		expect(readCode(reader, 3)).toBe(5);
+	});
+
+	it('reads multiple codes from the same byte', () => {
+		const reader = createBitReader(new Uint8Array([0b10110100]));
+		expect(readCode(reader, 4)).toBe(0b0100); // 4
+		expect(readCode(reader, 4)).toBe(0b1011); // 11
+	});
+
+	it('reads codes spanning byte boundaries', () => {
+		const reader = createBitReader(new Uint8Array([0xff, 0x01]));
+		expect(readCode(reader, 9)).toBe(0x1ff);
+	});
+
+	it('returns -1 when data is exhausted', () => {
+		const reader = createBitReader(new Uint8Array([0xff]));
+		readCode(reader, 8);
+		expect(readCode(reader, 1)).toBe(-1);
+	});
+
+	it('reads 12-bit codes correctly', () => {
+		// 0xab = 10101011, 0xcd = 11001101, 0xef = 11101111
+		// First 12 bits (LSB first from bytes): bits 0-7 from 0xab, bits 8-11 from low nibble of 0xcd
+		// code1 = 0xab | ((0xcd & 0x0f) << 8) = 0xab | (0xd << 8) = 0xdab
+		const reader = createBitReader(new Uint8Array([0xab, 0xcd, 0xef]));
+		const code1 = readCode(reader, 12);
+		expect(code1).toBe(0xdab);
+
+		// Next 12 bits: upper nibble of 0xcd (bits 12-15) + all of 0xef (bits 16-23)
+		// code2 = (0xcd >> 4) | (0xef << 4) = 0x0c | 0xef0 = 0xefc
+		const code2 = readCode(reader, 12);
+		expect(code2).toBe(0xefc);
+	});
+});
+
+// =============================================================================
+// LZW DECOMPRESSION
+// =============================================================================
+
+describe('decompressLZW', () => {
+	it('rejects invalid minimum code size < 2', () => {
+		const result = decompressLZW(new Uint8Array([]), 1, 10);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('Invalid minimum code size');
+		}
+	});
+
+	it('rejects invalid minimum code size > 11', () => {
+		const result = decompressLZW(new Uint8Array([]), 12, 10);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('Invalid minimum code size');
+		}
+	});
+
+	it('handles empty data gracefully', () => {
+		const result = decompressLZW(new Uint8Array([]), 2, 0);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data.length).toBe(0);
+		}
+	});
+
+	it('decompresses a simple 2-color stream', () => {
+		const compressed = lzwEncode([0, 1, 0, 1], 2);
+		const result = decompressLZW(compressed, 2, 4);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(Array.from(result.data)).toEqual([0, 1, 0, 1]);
+		}
+	});
+
+	it('decompresses repeated values', () => {
+		const compressed = lzwEncode([1, 1, 1, 1], 2);
+		const result = decompressLZW(compressed, 2, 4);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(Array.from(result.data)).toEqual([1, 1, 1, 1]);
+		}
+	});
+
+	it('decompresses all zeros', () => {
+		const compressed = lzwEncode([0, 0, 0, 0], 2);
+		const result = decompressLZW(compressed, 2, 4);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(Array.from(result.data)).toEqual([0, 0, 0, 0]);
+		}
+	});
+
+	it('decompresses a single pixel', () => {
+		const compressed = lzwEncode([3], 2);
+		const result = decompressLZW(compressed, 2, 1);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(Array.from(result.data)).toEqual([3]);
+		}
+	});
+
+	it('decompresses with code size increase', () => {
+		// With minCodeSize=2, code size starts at 3 (8 possible codes).
+		// After adding a few table entries, code size should increase to 4.
+		const pixels = [0, 1, 2, 3, 0, 1, 2, 3];
+		const compressed = lzwEncode(pixels, 2);
+		const result = decompressLZW(compressed, 2, 8);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(Array.from(result.data)).toEqual(pixels);
+		}
+	});
+
+	it('handles minimum code size of 8 (256 colors)', () => {
+		const compressed = lzwEncode([42], 8);
+		const result = decompressLZW(compressed, 8, 1);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data[0]).toBe(42);
+		}
+	});
+
+	it('decompresses 256-color sequential data', () => {
+		const pixels = Array.from({ length: 16 }, (_, i) => i);
+		const compressed = lzwEncode(pixels, 8);
+		const result = decompressLZW(compressed, 8, 16);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(Array.from(result.data)).toEqual(pixels);
+		}
+	});
+
+	it('limits output to expectedPixels', () => {
+		const compressed = lzwEncode([0, 1, 2, 3], 2);
+		const result = decompressLZW(compressed, 2, 2);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data.length).toBe(2);
+			expect(Array.from(result.data)).toEqual([0, 1]);
+		}
+	});
+
+	it('decompresses larger data sets', () => {
+		const pixels = Array.from({ length: 100 }, (_, i) => i % 4);
+		const compressed = lzwEncode(pixels, 2);
+		const result = decompressLZW(compressed, 2, 100);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(Array.from(result.data)).toEqual(pixels);
+		}
+	});
+
+	it('decompresses with minCodeSize 3 (8 colors)', () => {
+		const pixels = [0, 1, 2, 3, 4, 5, 6, 7];
+		const compressed = lzwEncode(pixels, 3);
+		const result = decompressLZW(compressed, 3, 8);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(Array.from(result.data)).toEqual(pixels);
+		}
+	});
+});

--- a/src/media/gif/lzw.ts
+++ b/src/media/gif/lzw.ts
@@ -1,0 +1,338 @@
+/**
+ * LZW decompression for GIF images.
+ *
+ * Implements the variable-width LZW decompression algorithm used in GIF files,
+ * with support for clear codes, EOI codes, and dynamic code table management.
+ *
+ * @module media/gif/lzw
+ */
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Result of successful LZW decompression.
+ */
+export interface LZWResult {
+	readonly ok: true;
+	/** Decompressed pixel indices */
+	readonly data: Uint8Array;
+}
+
+/**
+ * Error result from LZW decompression.
+ */
+export interface LZWError {
+	readonly ok: false;
+	readonly error: string;
+}
+
+/**
+ * Result type for LZW decompression.
+ */
+export type LZWOutput = LZWResult | LZWError;
+
+// =============================================================================
+// BIT READER
+// =============================================================================
+
+/**
+ * State for reading variable-width codes from a byte stream.
+ */
+interface BitReader {
+	/** Source data bytes */
+	readonly data: Uint8Array;
+	/** Current byte offset */
+	byteOffset: number;
+	/** Current bit offset within the current byte */
+	bitOffset: number;
+}
+
+/**
+ * Creates a bit reader for the given data.
+ *
+ * @param data - Source byte array
+ * @returns A new bit reader
+ *
+ * @example
+ * ```typescript
+ * import { createBitReader } from 'blecsd';
+ *
+ * const reader = createBitReader(new Uint8Array([0xff, 0x00]));
+ * ```
+ */
+export function createBitReader(data: Uint8Array): BitReader {
+	return { data, byteOffset: 0, bitOffset: 0 };
+}
+
+/**
+ * Reads a variable-width code from the bit stream.
+ *
+ * @param reader - Bit reader state
+ * @param codeSize - Number of bits to read
+ * @returns The code value, or -1 if insufficient data
+ *
+ * @example
+ * ```typescript
+ * import { createBitReader, readCode } from 'blecsd';
+ *
+ * const reader = createBitReader(new Uint8Array([0b10110100]));
+ * const code = readCode(reader, 4); // reads first 4 bits
+ * ```
+ */
+export function readCode(reader: BitReader, codeSize: number): number {
+	let result = 0;
+	let bitsRead = 0;
+
+	while (bitsRead < codeSize) {
+		if (reader.byteOffset >= reader.data.length) {
+			return -1;
+		}
+
+		const currentByte = reader.data[reader.byteOffset] ?? 0;
+		const bitsAvailable = 8 - reader.bitOffset;
+		const bitsNeeded = codeSize - bitsRead;
+		const bitsToRead = Math.min(bitsAvailable, bitsNeeded);
+
+		const mask = (1 << bitsToRead) - 1;
+		const bits = (currentByte >> reader.bitOffset) & mask;
+		result |= bits << bitsRead;
+
+		bitsRead += bitsToRead;
+		reader.bitOffset += bitsToRead;
+
+		if (reader.bitOffset >= 8) {
+			reader.bitOffset = 0;
+			reader.byteOffset++;
+		}
+	}
+
+	return result;
+}
+
+// =============================================================================
+// CODE TABLE
+// =============================================================================
+
+/** Maximum code size in bits for GIF LZW */
+const MAX_CODE_SIZE = 12;
+/** Maximum number of entries in the code table */
+const MAX_TABLE_SIZE = 1 << MAX_CODE_SIZE;
+
+/**
+ * Initializes the LZW code table with single-character entries.
+ *
+ * @param minCodeSize - Minimum code size (typically the color table size exponent)
+ * @returns Array of code table entries (each entry is an array of pixel indices)
+ */
+function initCodeTable(minCodeSize: number): Array<readonly number[]> {
+	const tableSize = 1 << minCodeSize;
+	const table: Array<readonly number[]> = [];
+	for (let i = 0; i < tableSize; i++) {
+		table.push([i]);
+	}
+	// Clear code and EOI code entries (placeholders)
+	table.push([]);
+	table.push([]);
+	return table;
+}
+
+// =============================================================================
+// LZW DECOMPRESSION
+// =============================================================================
+
+/**
+ * Decompresses LZW-encoded GIF image data.
+ *
+ * Implements the GIF variant of LZW decompression with variable code widths
+ * from `minCodeSize + 1` up to 12 bits. Handles clear codes for table resets
+ * and EOI codes for stream termination.
+ *
+ * @param compressedData - LZW compressed byte stream (sub-blocks already concatenated)
+ * @param minCodeSize - Minimum LZW code size (from image descriptor)
+ * @param expectedPixels - Expected number of output pixels
+ * @returns Decompressed pixel indices or an error
+ *
+ * @example
+ * ```typescript
+ * import { decompressLZW } from 'blecsd';
+ *
+ * const result = decompressLZW(compressedBytes, 8, width * height);
+ * if (result.ok) {
+ *   // result.data contains palette indices
+ * }
+ * ```
+ */
+/**
+ * Mutable decompression state passed between helper functions.
+ */
+interface DecompressState {
+	readonly reader: BitReader;
+	readonly output: Uint8Array;
+	readonly expectedPixels: number;
+	readonly minCodeSize: number;
+	readonly clearCode: number;
+	readonly eoiCode: number;
+	table: Array<readonly number[]>;
+	codeSize: number;
+	nextCode: number;
+	outputPos: number;
+	prevCode: number;
+}
+
+/**
+ * Handles a clear code by resetting the table and reading the next code.
+ * Returns the next code to process, -1 for EOI/end, or an error string.
+ */
+function handleClearCode(state: DecompressState): number | string {
+	state.codeSize = state.minCodeSize + 1;
+	state.table = initCodeTable(state.minCodeSize);
+	state.nextCode = state.eoiCode + 1;
+
+	const code = readCode(state.reader, state.codeSize);
+	if (code === -1 || code === state.eoiCode) return -1;
+	if (code >= state.table.length) return `Code ${code} out of range after clear`;
+
+	const entry = state.table[code];
+	if (entry) {
+		state.outputPos = writePixels(state.output, state.outputPos, entry, state.expectedPixels);
+	}
+	state.prevCode = code;
+	return code;
+}
+
+/**
+ * Processes a regular (non-clear, non-EOI) code.
+ * Returns null on success, or an error string.
+ */
+function processCode(state: DecompressState, code: number): string | null {
+	const prevEntry = state.table[state.prevCode];
+	if (!prevEntry) return `Missing table entry for previous code ${state.prevCode}`;
+
+	if (code < state.table.length) {
+		const entry = state.table[code];
+		if (entry) {
+			state.outputPos = writePixels(state.output, state.outputPos, entry, state.expectedPixels);
+			if (state.nextCode < MAX_TABLE_SIZE) {
+				state.table.push([...prevEntry, entry[0] ?? 0]);
+				state.nextCode++;
+			}
+		}
+	} else if (code === state.nextCode) {
+		const newEntry = [...prevEntry, prevEntry[0] ?? 0];
+		state.outputPos = writePixels(state.output, state.outputPos, newEntry, state.expectedPixels);
+		if (state.nextCode < MAX_TABLE_SIZE) {
+			state.table.push(newEntry);
+			state.nextCode++;
+		}
+	} else {
+		return `Code ${code} out of range (next: ${state.nextCode})`;
+	}
+
+	state.prevCode = code;
+	if (state.nextCode >= 1 << state.codeSize && state.codeSize < MAX_CODE_SIZE) {
+		state.codeSize++;
+	}
+	return null;
+}
+
+/**
+ * Reads and processes the first code after initialization or clear.
+ * Returns null for end/empty, an error string, or the first code value.
+ */
+function readFirstCode(state: DecompressState): number | string {
+	let code = readCode(state.reader, state.codeSize);
+	if (code === state.clearCode) {
+		code = readCode(state.reader, state.codeSize);
+	}
+	if (code === -1 || code === state.eoiCode) return -1;
+	if (code >= state.table.length) return `First code ${code} out of range`;
+
+	const entry = state.table[code];
+	if (entry) {
+		state.outputPos = writePixels(state.output, state.outputPos, entry, state.expectedPixels);
+	}
+	state.prevCode = code;
+	return code;
+}
+
+/**
+ * Runs the main decompression loop, processing codes until done.
+ * Returns null on success or an error string.
+ */
+function decompressLoop(state: DecompressState): string | null {
+	while (state.outputPos < state.expectedPixels) {
+		const code = readCode(state.reader, state.codeSize);
+		if (code === -1 || code === state.eoiCode) break;
+
+		if (code === state.clearCode) {
+			const result = handleClearCode(state);
+			if (typeof result === 'string') return result;
+			if (result === -1) break;
+			continue;
+		}
+
+		const error = processCode(state, code);
+		if (error) return error;
+	}
+	return null;
+}
+
+export function decompressLZW(
+	compressedData: Uint8Array,
+	minCodeSize: number,
+	expectedPixels: number,
+): LZWOutput {
+	if (minCodeSize < 2 || minCodeSize > 11) {
+		return { ok: false, error: `Invalid minimum code size: ${minCodeSize}` };
+	}
+
+	const clearCode = 1 << minCodeSize;
+	const eoiCode = clearCode + 1;
+
+	const state: DecompressState = {
+		reader: createBitReader(compressedData),
+		output: new Uint8Array(expectedPixels),
+		expectedPixels,
+		minCodeSize,
+		clearCode,
+		eoiCode,
+		table: initCodeTable(minCodeSize),
+		codeSize: minCodeSize + 1,
+		nextCode: eoiCode + 1,
+		outputPos: 0,
+		prevCode: 0,
+	};
+
+	const firstResult = readFirstCode(state);
+	if (firstResult === -1) return { ok: true, data: state.output.subarray(0, state.outputPos) };
+	if (typeof firstResult === 'string') return { ok: false, error: firstResult };
+
+	const loopError = decompressLoop(state);
+	if (loopError) return { ok: false, error: loopError };
+
+	return { ok: true, data: state.output.subarray(0, state.outputPos) };
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Writes pixel indices to the output buffer, respecting the maximum size.
+ */
+function writePixels(
+	output: Uint8Array,
+	pos: number,
+	pixels: readonly number[],
+	maxPixels: number,
+): number {
+	let writePos = pos;
+	for (const pixel of pixels) {
+		if (writePos >= maxPixels) break;
+		output[writePos] = pixel;
+		writePos++;
+	}
+	return writePos;
+}

--- a/src/media/gif/parser.test.ts
+++ b/src/media/gif/parser.test.ts
@@ -1,0 +1,628 @@
+/**
+ * Tests for GIF parser.
+ *
+ * @module media/gif/parser.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	DisposalMethod,
+	deinterlace,
+	frameToRGBA,
+	GIF87A_MAGIC,
+	GIF89A_MAGIC,
+	GIFHeaderSchema,
+	parseColorTable,
+	parseGIF,
+	parseGIFHeader,
+	readSubBlocks,
+	validateGIFSignature,
+} from './parser';
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Builds a minimal GIF87a file with a single 1x1 frame.
+ */
+interface GIFBuildOptions {
+	version?: '87a' | '89a';
+	width?: number;
+	height?: number;
+	colorTableSize?: number;
+	pixels?: number[];
+	backgroundColor?: number;
+	transparent?: number;
+	delay?: number;
+	disposal?: number;
+	loopCount?: number;
+	interlaced?: boolean;
+}
+
+function writeNetscapeExtension(parts: number[], loopCount: number): void {
+	parts.push(0x21, 0xff, 11);
+	// "NETSCAPE2.0"
+	parts.push(78, 69, 84, 83, 67, 65, 80, 69, 50, 46, 48);
+	parts.push(3, 1);
+	parts.push(loopCount & 0xff, (loopCount >> 8) & 0xff);
+	parts.push(0);
+}
+
+function writeGraphicsControlExtension(parts: number[], options: GIFBuildOptions): void {
+	parts.push(0x21, 0xf9, 4);
+	const disposalBits = ((options.disposal ?? 0) & 0x07) << 2;
+	const transparentFlag = options.transparent !== undefined ? 1 : 0;
+	parts.push(disposalBits | transparentFlag);
+	const delayCS = Math.round((options.delay ?? 0) / 10);
+	parts.push(delayCS & 0xff, (delayCS >> 8) & 0xff);
+	parts.push(options.transparent ?? 0);
+	parts.push(0);
+}
+
+function writeImageData(parts: number[], compressed: Uint8Array): void {
+	let compOffset = 0;
+	while (compOffset < compressed.length) {
+		const blockSize = Math.min(255, compressed.length - compOffset);
+		parts.push(blockSize);
+		for (let i = 0; i < blockSize; i++) {
+			parts.push(compressed[compOffset + i] ?? 0);
+		}
+		compOffset += blockSize;
+	}
+	parts.push(0);
+}
+
+function buildMinimalGIF(options: GIFBuildOptions = {}): Uint8Array {
+	const version = options.version ?? '87a';
+	const width = options.width ?? 1;
+	const height = options.height ?? 1;
+	const colorTableSizeExp = options.colorTableSize ?? 1;
+	const numColors = 1 << (colorTableSizeExp + 1);
+
+	const parts: number[] = [];
+
+	// Signature
+	parts.push(...(version === '87a' ? GIF87A_MAGIC : GIF89A_MAGIC));
+
+	// Logical Screen Descriptor
+	parts.push(width & 0xff, (width >> 8) & 0xff);
+	parts.push(height & 0xff, (height >> 8) & 0xff);
+	parts.push(0x80 | (colorTableSizeExp & 0x07));
+	parts.push(options.backgroundColor ?? 0, 0);
+
+	// Global Color Table
+	for (let i = 0; i < numColors; i++) {
+		parts.push((i * 37) % 256, (i * 73) % 256, (i * 113) % 256);
+	}
+
+	if (options.loopCount !== undefined) writeNetscapeExtension(parts, options.loopCount);
+
+	const hasGCE =
+		options.transparent !== undefined ||
+		options.delay !== undefined ||
+		options.disposal !== undefined;
+	if (hasGCE) writeGraphicsControlExtension(parts, options);
+
+	// Image Descriptor
+	parts.push(0x2c, 0, 0, 0, 0);
+	parts.push(width & 0xff, (width >> 8) & 0xff);
+	parts.push(height & 0xff, (height >> 8) & 0xff);
+	parts.push(options.interlaced ? 0x40 : 0x00);
+
+	// Image Data
+	const minCodeSize = colorTableSizeExp + 1;
+	parts.push(minCodeSize);
+	const pixelData = options.pixels ?? Array.from({ length: width * height }, () => 0);
+	writeImageData(parts, lzwCompress(pixelData, minCodeSize));
+
+	parts.push(0x3b); // Trailer
+	return new Uint8Array(parts);
+}
+
+/**
+ * LZW compressor for test data.
+ * Correctly tracks code size increases to match the decompressor.
+ * Emits individual pixel codes (no dictionary compression).
+ */
+function lzwCompress(pixels: number[], minCodeSize: number): Uint8Array {
+	const clearCode = 1 << minCodeSize;
+	const eoiCode = clearCode + 1;
+	let codeSize = minCodeSize + 1;
+	let nextCode = eoiCode + 1;
+	let isFirstAfterClear = true;
+
+	const buffer: number[] = [];
+	let currentByte = 0;
+	let bitsInByte = 0;
+
+	function writeCode(code: number, size: number): void {
+		let c = code;
+		let remaining = size;
+		while (remaining > 0) {
+			const available = 8 - bitsInByte;
+			const toWrite = Math.min(available, remaining);
+			const mask = (1 << toWrite) - 1;
+			currentByte |= (c & mask) << bitsInByte;
+			c >>= toWrite;
+			bitsInByte += toWrite;
+			remaining -= toWrite;
+			if (bitsInByte === 8) {
+				buffer.push(currentByte);
+				currentByte = 0;
+				bitsInByte = 0;
+			}
+		}
+	}
+
+	writeCode(clearCode, codeSize);
+
+	for (const pixel of pixels) {
+		writeCode(pixel, codeSize);
+		if (!isFirstAfterClear) {
+			nextCode++;
+			if (nextCode >= 1 << codeSize && codeSize < 12) {
+				codeSize++;
+			}
+		}
+		isFirstAfterClear = false;
+	}
+
+	writeCode(eoiCode, codeSize);
+
+	if (bitsInByte > 0) {
+		buffer.push(currentByte);
+	}
+
+	return new Uint8Array(buffer);
+}
+
+// =============================================================================
+// SIGNATURE VALIDATION
+// =============================================================================
+
+describe('validateGIFSignature', () => {
+	it('detects GIF87a', () => {
+		expect(validateGIFSignature(GIF87A_MAGIC)).toBe('87a');
+	});
+
+	it('detects GIF89a', () => {
+		expect(validateGIFSignature(GIF89A_MAGIC)).toBe('89a');
+	});
+
+	it('returns null for non-GIF data', () => {
+		expect(validateGIFSignature(new Uint8Array([0, 1, 2, 3, 4, 5]))).toBeNull();
+	});
+
+	it('returns null for too-short data', () => {
+		expect(validateGIFSignature(new Uint8Array([0x47, 0x49]))).toBeNull();
+	});
+
+	it('returns null for PNG data', () => {
+		expect(validateGIFSignature(new Uint8Array([137, 80, 78, 71, 13, 10]))).toBeNull();
+	});
+});
+
+// =============================================================================
+// HEADER PARSING
+// =============================================================================
+
+describe('parseGIFHeader', () => {
+	it('parses a GIF87a header', () => {
+		const gif = buildMinimalGIF({ version: '87a', width: 100, height: 50 });
+		const result = parseGIFHeader(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.header.version).toBe('87a');
+			expect(result.header.width).toBe(100);
+			expect(result.header.height).toBe(50);
+			expect(result.header.hasGlobalColorTable).toBe(true);
+		}
+	});
+
+	it('parses a GIF89a header', () => {
+		const gif = buildMinimalGIF({ version: '89a', width: 320, height: 240 });
+		const result = parseGIFHeader(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.header.version).toBe('89a');
+			expect(result.header.width).toBe(320);
+			expect(result.header.height).toBe(240);
+		}
+	});
+
+	it('rejects data that is too short', () => {
+		const result = parseGIFHeader(new Uint8Array(10));
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('too short');
+		}
+	});
+
+	it('rejects invalid signature', () => {
+		const data = new Uint8Array(13);
+		const result = parseGIFHeader(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('Invalid GIF signature');
+		}
+	});
+
+	it('passes Zod schema validation', () => {
+		const gif = buildMinimalGIF({ width: 640, height: 480 });
+		const result = parseGIFHeader(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			const validated = GIFHeaderSchema.safeParse(result.header);
+			expect(validated.success).toBe(true);
+		}
+	});
+});
+
+// =============================================================================
+// COLOR TABLE
+// =============================================================================
+
+describe('parseColorTable', () => {
+	it('parses a 4-entry color table', () => {
+		const data = new Uint8Array([
+			255,
+			0,
+			0, // Red
+			0,
+			255,
+			0, // Green
+			0,
+			0,
+			255, // Blue
+			255,
+			255,
+			255, // White
+		]);
+		const colors = parseColorTable(data, 0, 4);
+		expect(colors).toHaveLength(4);
+		expect(colors[0]).toEqual({ r: 255, g: 0, b: 0 });
+		expect(colors[1]).toEqual({ r: 0, g: 255, b: 0 });
+		expect(colors[2]).toEqual({ r: 0, g: 0, b: 255 });
+		expect(colors[3]).toEqual({ r: 255, g: 255, b: 255 });
+	});
+
+	it('handles offset correctly', () => {
+		const data = new Uint8Array([0, 0, 0, 128, 64, 32]);
+		const colors = parseColorTable(data, 3, 1);
+		expect(colors[0]).toEqual({ r: 128, g: 64, b: 32 });
+	});
+});
+
+// =============================================================================
+// SUB-BLOCKS
+// =============================================================================
+
+describe('readSubBlocks', () => {
+	it('reads a single sub-block', () => {
+		const data = new Uint8Array([3, 10, 20, 30, 0]);
+		const { blockData, nextOffset } = readSubBlocks(data, 0);
+		expect(Array.from(blockData)).toEqual([10, 20, 30]);
+		expect(nextOffset).toBe(5);
+	});
+
+	it('reads multiple sub-blocks', () => {
+		const data = new Uint8Array([2, 10, 20, 3, 30, 40, 50, 0]);
+		const { blockData, nextOffset } = readSubBlocks(data, 0);
+		expect(Array.from(blockData)).toEqual([10, 20, 30, 40, 50]);
+		expect(nextOffset).toBe(8);
+	});
+
+	it('handles empty sub-block (immediate terminator)', () => {
+		const data = new Uint8Array([0]);
+		const { blockData, nextOffset } = readSubBlocks(data, 0);
+		expect(blockData.length).toBe(0);
+		expect(nextOffset).toBe(1);
+	});
+});
+
+// =============================================================================
+// DEINTERLACE
+// =============================================================================
+
+describe('deinterlace', () => {
+	it('deinterlaces a 1x8 image', () => {
+		// Interlaced order for 8 rows:
+		// Pass 1 (every 8, start 0): row 0
+		// Pass 2 (every 8, start 4): row 4
+		// Pass 3 (every 4, start 2): row 2, 6
+		// Pass 4 (every 2, start 1): row 1, 3, 5, 7
+		// So interlaced input order: row0, row4, row2, row6, row1, row3, row5, row7
+		const interlaced = new Uint8Array([0, 4, 2, 6, 1, 3, 5, 7]);
+		const result = deinterlace(interlaced, 1, 8);
+		expect(Array.from(result)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+	});
+
+	it('deinterlaces a 2x4 image', () => {
+		// 4 rows:
+		// Pass 1 (every 8, start 0): row 0
+		// Pass 2 (every 8, start 4): (none, height < 5)
+		// Pass 3 (every 4, start 2): row 2
+		// Pass 4 (every 2, start 1): row 1, row 3
+		// Interlaced order: row0, row2, row1, row3
+		const interlaced = new Uint8Array([
+			10,
+			11, // row 0
+			30,
+			31, // row 2
+			20,
+			21, // row 1
+			40,
+			41, // row 3
+		]);
+		const result = deinterlace(interlaced, 2, 4);
+		expect(Array.from(result)).toEqual([
+			10,
+			11, // row 0
+			20,
+			21, // row 1
+			30,
+			31, // row 2
+			40,
+			41, // row 3
+		]);
+	});
+});
+
+// =============================================================================
+// FRAME TO RGBA
+// =============================================================================
+
+describe('frameToRGBA', () => {
+	it('converts a single pixel frame to RGBA', () => {
+		const globalColorTable = [
+			{ r: 255, g: 0, b: 0 },
+			{ r: 0, g: 255, b: 0 },
+		];
+		const frame = {
+			x: 0,
+			y: 0,
+			width: 1,
+			height: 1,
+			pixels: new Uint8Array([0]),
+			delay: 0,
+			disposal: DisposalMethod.None,
+			transparentIndex: undefined,
+			localColorTable: undefined,
+			interlaced: false,
+		};
+
+		const rgba = frameToRGBA(frame, globalColorTable);
+		expect(rgba[0]).toBe(255); // R
+		expect(rgba[1]).toBe(0); // G
+		expect(rgba[2]).toBe(0); // B
+		expect(rgba[3]).toBe(255); // A
+	});
+
+	it('handles transparency', () => {
+		const globalColorTable = [{ r: 255, g: 0, b: 0 }];
+		const frame = {
+			x: 0,
+			y: 0,
+			width: 1,
+			height: 1,
+			pixels: new Uint8Array([0]),
+			delay: 0,
+			disposal: DisposalMethod.None,
+			transparentIndex: 0,
+			localColorTable: undefined,
+			interlaced: false,
+		};
+
+		const rgba = frameToRGBA(frame, globalColorTable);
+		expect(rgba[0]).toBe(0);
+		expect(rgba[1]).toBe(0);
+		expect(rgba[2]).toBe(0);
+		expect(rgba[3]).toBe(0); // Transparent
+	});
+
+	it('uses local color table over global', () => {
+		const globalColorTable = [{ r: 255, g: 0, b: 0 }];
+		const localColorTable = [{ r: 0, g: 0, b: 255 }];
+		const frame = {
+			x: 0,
+			y: 0,
+			width: 1,
+			height: 1,
+			pixels: new Uint8Array([0]),
+			delay: 0,
+			disposal: DisposalMethod.None,
+			transparentIndex: undefined,
+			localColorTable,
+			interlaced: false,
+		};
+
+		const rgba = frameToRGBA(frame, globalColorTable);
+		expect(rgba[0]).toBe(0); // R (from local, not global)
+		expect(rgba[1]).toBe(0); // G
+		expect(rgba[2]).toBe(255); // B (blue from local table)
+		expect(rgba[3]).toBe(255); // A
+	});
+});
+
+// =============================================================================
+// FULL PARSER
+// =============================================================================
+
+describe('parseGIF', () => {
+	it('parses a minimal 1x1 GIF87a', () => {
+		const gif = buildMinimalGIF({ version: '87a', width: 1, height: 1 });
+		const result = parseGIF(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.header.version).toBe('87a');
+			expect(result.header.width).toBe(1);
+			expect(result.header.height).toBe(1);
+			expect(result.frames).toHaveLength(1);
+			expect(result.frames[0]?.pixels.length).toBe(1);
+		}
+	});
+
+	it('parses a 2x2 GIF with specific colors', () => {
+		const gif = buildMinimalGIF({
+			width: 2,
+			height: 2,
+			pixels: [0, 1, 2, 3],
+			colorTableSize: 1, // 4 colors
+		});
+		const result = parseGIF(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.frames).toHaveLength(1);
+			const frame = result.frames[0];
+			expect(frame).toBeDefined();
+			if (frame) {
+				expect(frame.width).toBe(2);
+				expect(frame.height).toBe(2);
+				expect(Array.from(frame.pixels)).toEqual([0, 1, 2, 3]);
+			}
+		}
+	});
+
+	it('parses a GIF89a with transparency', () => {
+		const gif = buildMinimalGIF({
+			version: '89a',
+			width: 2,
+			height: 1,
+			pixels: [0, 1],
+			transparent: 1,
+			colorTableSize: 1,
+		});
+		const result = parseGIF(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.frames).toHaveLength(1);
+			expect(result.frames[0]?.transparentIndex).toBe(1);
+		}
+	});
+
+	it('parses a GIF with frame delay', () => {
+		const gif = buildMinimalGIF({
+			version: '89a',
+			delay: 100, // 100ms
+		});
+		const result = parseGIF(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.frames[0]?.delay).toBe(100);
+		}
+	});
+
+	it('parses a GIF with disposal method', () => {
+		const gif = buildMinimalGIF({
+			version: '89a',
+			disposal: DisposalMethod.RestoreBackground,
+			delay: 50,
+		});
+		const result = parseGIF(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.frames[0]?.disposal).toBe(DisposalMethod.RestoreBackground);
+		}
+	});
+
+	it('parses a GIF with Netscape loop extension', () => {
+		const gif = buildMinimalGIF({
+			version: '89a',
+			loopCount: 0, // Infinite loop
+		});
+		const result = parseGIF(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.loopCount).toBe(0);
+		}
+	});
+
+	it('parses a GIF with finite loop count', () => {
+		const gif = buildMinimalGIF({
+			version: '89a',
+			loopCount: 3,
+		});
+		const result = parseGIF(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.loopCount).toBe(3);
+		}
+	});
+
+	it('extracts global color table', () => {
+		const gif = buildMinimalGIF({ colorTableSize: 1 }); // 4 colors
+		const result = parseGIF(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.globalColorTable).toHaveLength(4);
+			// Verify the colors match our generation formula
+			expect(result.globalColorTable[0]).toEqual({ r: 0, g: 0, b: 0 });
+		}
+	});
+
+	it('rejects invalid data', () => {
+		const result = parseGIF(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]));
+		expect(result.ok).toBe(false);
+	});
+
+	it('rejects too-short data', () => {
+		const result = parseGIF(new Uint8Array([0x47, 0x49, 0x46]));
+		expect(result.ok).toBe(false);
+	});
+
+	it('handles larger image dimensions', () => {
+		const gif = buildMinimalGIF({ width: 100, height: 50 });
+		const result = parseGIF(gif);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.header.width).toBe(100);
+			expect(result.header.height).toBe(50);
+			expect(result.frames).toHaveLength(1);
+			const frame = result.frames[0];
+			expect(frame?.width).toBe(100);
+			expect(frame?.height).toBe(50);
+		}
+	});
+});
+
+// =============================================================================
+// DISPOSAL METHOD ENUM
+// =============================================================================
+
+describe('DisposalMethod', () => {
+	it('has correct values', () => {
+		expect(DisposalMethod.Unspecified).toBe(0);
+		expect(DisposalMethod.None).toBe(1);
+		expect(DisposalMethod.RestoreBackground).toBe(2);
+		expect(DisposalMethod.RestorePrevious).toBe(3);
+	});
+});
+
+// =============================================================================
+// MAGIC BYTES
+// =============================================================================
+
+describe('GIF magic bytes', () => {
+	it('GIF87A_MAGIC matches "GIF87a"', () => {
+		const expected = new Uint8Array([71, 73, 70, 56, 55, 97]);
+		expect(Array.from(GIF87A_MAGIC)).toEqual(Array.from(expected));
+	});
+
+	it('GIF89A_MAGIC matches "GIF89a"', () => {
+		const expected = new Uint8Array([71, 73, 70, 56, 57, 97]);
+		expect(Array.from(GIF89A_MAGIC)).toEqual(Array.from(expected));
+	});
+});

--- a/src/media/gif/parser.ts
+++ b/src/media/gif/parser.ts
@@ -1,0 +1,842 @@
+/**
+ * GIF file parser.
+ *
+ * Parses GIF87a and GIF89a files into structured data: header info, global
+ * and local color tables, frame data with timing and disposal, and extension
+ * blocks (graphics control, Netscape looping).
+ *
+ * @module media/gif/parser
+ */
+
+import { z } from 'zod';
+import type { LZWOutput } from './lzw';
+import { decompressLZW } from './lzw';
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/**
+ * GIF87a signature bytes.
+ *
+ * @example
+ * ```typescript
+ * import { GIF87A_MAGIC } from 'blecsd';
+ *
+ * const isGif87a = arrayStartsWith(data, GIF87A_MAGIC);
+ * ```
+ */
+export const GIF87A_MAGIC = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x37, 0x61]);
+
+/**
+ * GIF89a signature bytes.
+ *
+ * @example
+ * ```typescript
+ * import { GIF89A_MAGIC } from 'blecsd';
+ *
+ * const isGif89a = arrayStartsWith(data, GIF89A_MAGIC);
+ * ```
+ */
+export const GIF89A_MAGIC = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+
+/** GIF trailer byte marking end of file */
+const GIF_TRAILER = 0x3b;
+/** GIF extension introducer */
+const EXTENSION_INTRODUCER = 0x21;
+/** GIF image separator */
+const IMAGE_SEPARATOR = 0x2c;
+/** Graphics control extension label */
+const GRAPHICS_CONTROL_LABEL = 0xf9;
+/** Application extension label */
+const APPLICATION_EXTENSION_LABEL = 0xff;
+/** Comment extension label */
+const COMMENT_EXTENSION_LABEL = 0xfe;
+/** Plain text extension label */
+const PLAIN_TEXT_LABEL = 0x01;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * GIF version identifier.
+ */
+export type GIFVersion = '87a' | '89a';
+
+/**
+ * Frame disposal method.
+ *
+ * Controls how the frame area is treated before rendering the next frame.
+ *
+ * @example
+ * ```typescript
+ * import { DisposalMethod } from 'blecsd';
+ *
+ * if (frame.disposal === DisposalMethod.RestoreBackground) {
+ *   // Clear frame area before next frame
+ * }
+ * ```
+ */
+export enum DisposalMethod {
+	/** No disposal specified (leave as-is) */
+	Unspecified = 0,
+	/** Do not dispose (leave frame in place) */
+	None = 1,
+	/** Restore to background color */
+	RestoreBackground = 2,
+	/** Restore to previous frame */
+	RestorePrevious = 3,
+}
+
+/**
+ * A single color entry in a GIF color table.
+ */
+export interface GIFColor {
+	readonly r: number;
+	readonly g: number;
+	readonly b: number;
+}
+
+/**
+ * GIF logical screen descriptor.
+ */
+export interface GIFHeader {
+	/** GIF version */
+	readonly version: GIFVersion;
+	/** Logical screen width */
+	readonly width: number;
+	/** Logical screen height */
+	readonly height: number;
+	/** Whether a global color table is present */
+	readonly hasGlobalColorTable: boolean;
+	/** Bits per primary color minus 1 (color resolution) */
+	readonly colorResolution: number;
+	/** Whether the global color table is sorted */
+	readonly sortFlag: boolean;
+	/** Size of the global color table (number of entries) */
+	readonly globalColorTableSize: number;
+	/** Background color index in the global color table */
+	readonly backgroundColorIndex: number;
+	/** Pixel aspect ratio byte */
+	readonly pixelAspectRatio: number;
+}
+
+/**
+ * Zod schema for GIF header validation.
+ */
+export const GIFHeaderSchema = z.object({
+	version: z.enum(['87a', '89a']),
+	width: z.number().int().min(1).max(65535),
+	height: z.number().int().min(1).max(65535),
+	hasGlobalColorTable: z.boolean(),
+	colorResolution: z.number().int().min(0).max(7),
+	sortFlag: z.boolean(),
+	globalColorTableSize: z.number().int().min(0),
+	backgroundColorIndex: z.number().int().min(0).max(255),
+	pixelAspectRatio: z.number().int().min(0).max(255),
+});
+
+/**
+ * A single frame from a GIF image.
+ *
+ * @example
+ * ```typescript
+ * import { parseGIF } from 'blecsd';
+ *
+ * const result = parseGIF(gifData);
+ * if (result.ok) {
+ *   for (const frame of result.frames) {
+ *     console.log(`Frame: ${frame.width}x${frame.height}, delay: ${frame.delay}ms`);
+ *   }
+ * }
+ * ```
+ */
+export interface GIFFrame {
+	/** X offset of this frame within the logical screen */
+	readonly x: number;
+	/** Y offset of this frame within the logical screen */
+	readonly y: number;
+	/** Frame width in pixels */
+	readonly width: number;
+	/** Frame height in pixels */
+	readonly height: number;
+	/** Pixel data as palette indices */
+	readonly pixels: Uint8Array;
+	/** Frame delay in milliseconds */
+	readonly delay: number;
+	/** Disposal method for this frame */
+	readonly disposal: DisposalMethod;
+	/** Transparent color index, or undefined if none */
+	readonly transparentIndex: number | undefined;
+	/** Local color table, or undefined to use global */
+	readonly localColorTable: readonly GIFColor[] | undefined;
+	/** Whether the frame is interlaced */
+	readonly interlaced: boolean;
+}
+
+/**
+ * Result of successful GIF parsing.
+ */
+export interface GIFParseResult {
+	readonly ok: true;
+	/** GIF header info */
+	readonly header: GIFHeader;
+	/** Global color table (empty array if none) */
+	readonly globalColorTable: readonly GIFColor[];
+	/** Parsed frames */
+	readonly frames: readonly GIFFrame[];
+	/** Number of loop iterations (0 = infinite) */
+	readonly loopCount: number;
+}
+
+/**
+ * Error result from GIF parsing.
+ */
+export interface GIFParseError {
+	readonly ok: false;
+	readonly error: string;
+}
+
+/**
+ * Result type for GIF parsing.
+ */
+export type GIFParseOutput = GIFParseResult | GIFParseError;
+
+// =============================================================================
+// SIGNATURE VALIDATION
+// =============================================================================
+
+/**
+ * Validates GIF magic bytes and returns the version.
+ *
+ * @param data - Raw file data
+ * @returns The GIF version or null if invalid
+ *
+ * @example
+ * ```typescript
+ * import { validateGIFSignature } from 'blecsd';
+ *
+ * const version = validateGIFSignature(data);
+ * if (version) {
+ *   console.log(`GIF ${version}`);
+ * }
+ * ```
+ */
+export function validateGIFSignature(data: Uint8Array): GIFVersion | null {
+	if (data.length < 6) return null;
+	if (matchesSignature(data, GIF87A_MAGIC)) return '87a';
+	if (matchesSignature(data, GIF89A_MAGIC)) return '89a';
+	return null;
+}
+
+/**
+ * Checks if data starts with the given signature bytes.
+ */
+function matchesSignature(data: Uint8Array, signature: Uint8Array): boolean {
+	for (let i = 0; i < signature.length; i++) {
+		if (data[i] !== signature[i]) return false;
+	}
+	return true;
+}
+
+// =============================================================================
+// HEADER PARSING
+// =============================================================================
+
+/**
+ * Parses the GIF logical screen descriptor.
+ *
+ * @param data - Raw GIF file data (starting from byte 0)
+ * @returns Parsed header or an error
+ *
+ * @example
+ * ```typescript
+ * import { parseGIFHeader } from 'blecsd';
+ *
+ * const result = parseGIFHeader(gifData);
+ * if (result.ok) {
+ *   console.log(`${result.header.width}x${result.header.height}`);
+ * }
+ * ```
+ */
+export function parseGIFHeader(data: Uint8Array): { ok: true; header: GIFHeader } | GIFParseError {
+	if (data.length < 13) {
+		return { ok: false, error: 'Data too short for GIF header' };
+	}
+
+	const version = validateGIFSignature(data);
+	if (!version) {
+		return { ok: false, error: 'Invalid GIF signature' };
+	}
+
+	const width = readUint16LE(data, 6);
+	const height = readUint16LE(data, 8);
+	const packed = data[10] ?? 0;
+	const backgroundColorIndex = data[11] ?? 0;
+	const pixelAspectRatio = data[12] ?? 0;
+
+	const hasGlobalColorTable = (packed & 0x80) !== 0;
+	const colorResolution = (packed >> 4) & 0x07;
+	const sortFlag = (packed & 0x08) !== 0;
+	const gctSizeField = packed & 0x07;
+	const globalColorTableSize = hasGlobalColorTable ? 1 << (gctSizeField + 1) : 0;
+
+	const header: GIFHeader = {
+		version,
+		width,
+		height,
+		hasGlobalColorTable,
+		colorResolution,
+		sortFlag,
+		globalColorTableSize,
+		backgroundColorIndex,
+		pixelAspectRatio,
+	};
+
+	return { ok: true, header };
+}
+
+// =============================================================================
+// COLOR TABLE PARSING
+// =============================================================================
+
+/**
+ * Parses a GIF color table from the data.
+ *
+ * @param data - Raw data containing the color table
+ * @param offset - Byte offset where the color table starts
+ * @param numEntries - Number of color entries to read
+ * @returns Array of color entries
+ *
+ * @example
+ * ```typescript
+ * import { parseColorTable } from 'blecsd';
+ *
+ * const colors = parseColorTable(data, 13, 256);
+ * ```
+ */
+export function parseColorTable(
+	data: Uint8Array,
+	offset: number,
+	numEntries: number,
+): readonly GIFColor[] {
+	const table: GIFColor[] = [];
+	for (let i = 0; i < numEntries; i++) {
+		const idx = offset + i * 3;
+		table.push({
+			r: data[idx] ?? 0,
+			g: data[idx + 1] ?? 0,
+			b: data[idx + 2] ?? 0,
+		});
+	}
+	return table;
+}
+
+// =============================================================================
+// SUB-BLOCK READING
+// =============================================================================
+
+/**
+ * Reads concatenated sub-block data from the GIF stream.
+ *
+ * GIF uses a sub-block structure where each block starts with a size byte
+ * (1-255), followed by that many data bytes. A zero-size block terminates.
+ *
+ * @param data - Raw GIF data
+ * @param offset - Offset of the first sub-block size byte
+ * @returns The concatenated data and the offset after the block terminator
+ *
+ * @example
+ * ```typescript
+ * import { readSubBlocks } from 'blecsd';
+ *
+ * const { blockData, nextOffset } = readSubBlocks(data, offset);
+ * ```
+ */
+export function readSubBlocks(
+	data: Uint8Array,
+	offset: number,
+): { blockData: Uint8Array; nextOffset: number } {
+	const chunks: Uint8Array[] = [];
+	let pos = offset;
+	let totalSize = 0;
+
+	while (pos < data.length) {
+		const blockSize = data[pos] ?? 0;
+		pos++;
+		if (blockSize === 0) break;
+		if (pos + blockSize > data.length) break;
+		chunks.push(data.slice(pos, pos + blockSize));
+		totalSize += blockSize;
+		pos += blockSize;
+	}
+
+	const blockData = new Uint8Array(totalSize);
+	let writePos = 0;
+	for (const chunk of chunks) {
+		blockData.set(chunk, writePos);
+		writePos += chunk.length;
+	}
+
+	return { blockData, nextOffset: pos };
+}
+
+// =============================================================================
+// EXTENSION PARSING
+// =============================================================================
+
+/**
+ * Graphics control extension data.
+ */
+interface GraphicsControl {
+	readonly disposal: DisposalMethod;
+	readonly delay: number;
+	readonly transparentIndex: number | undefined;
+}
+
+/**
+ * Parses a graphics control extension.
+ */
+function parseGraphicsControl(
+	data: Uint8Array,
+	offset: number,
+): {
+	control: GraphicsControl;
+	nextOffset: number;
+} {
+	// Block size should be 4
+	const blockSize = data[offset] ?? 0;
+	const packed = data[offset + 1] ?? 0;
+	const delay = readUint16LE(data, offset + 2);
+	const transparentIdx = data[offset + 4] ?? 0;
+	const hasTransparent = (packed & 0x01) !== 0;
+
+	const disposal = ((packed >> 2) & 0x07) as DisposalMethod;
+	const validDisposal = disposal <= 3 ? disposal : DisposalMethod.Unspecified;
+
+	return {
+		control: {
+			disposal: validDisposal,
+			delay: delay * 10, // Convert centiseconds to milliseconds
+			transparentIndex: hasTransparent ? transparentIdx : undefined,
+		},
+		nextOffset: offset + 1 + blockSize + 1, // +1 for size byte, +1 for block terminator
+	};
+}
+
+// =============================================================================
+// INTERLACING
+// =============================================================================
+
+/**
+ * De-interlaces GIF frame pixel data.
+ *
+ * GIF interlacing stores rows in four passes:
+ * - Pass 1: rows 0, 8, 16, ... (every 8th row starting at 0)
+ * - Pass 2: rows 4, 12, 20, ... (every 8th row starting at 4)
+ * - Pass 3: rows 2, 6, 10, ... (every 4th row starting at 2)
+ * - Pass 4: rows 1, 3, 5, ... (every 2nd row starting at 1)
+ *
+ * @param pixels - Interlaced pixel data
+ * @param width - Frame width
+ * @param height - Frame height
+ * @returns De-interlaced pixel data
+ *
+ * @example
+ * ```typescript
+ * import { deinterlace } from 'blecsd';
+ *
+ * const sequential = deinterlace(interlacedPixels, width, height);
+ * ```
+ */
+export function deinterlace(pixels: Uint8Array, width: number, height: number): Uint8Array {
+	const output = new Uint8Array(width * height);
+	let sourceRow = 0;
+
+	// Pass 1: every 8th row starting from row 0
+	for (let y = 0; y < height; y += 8) {
+		copyRow(pixels, output, sourceRow, y, width);
+		sourceRow++;
+	}
+	// Pass 2: every 8th row starting from row 4
+	for (let y = 4; y < height; y += 8) {
+		copyRow(pixels, output, sourceRow, y, width);
+		sourceRow++;
+	}
+	// Pass 3: every 4th row starting from row 2
+	for (let y = 2; y < height; y += 4) {
+		copyRow(pixels, output, sourceRow, y, width);
+		sourceRow++;
+	}
+	// Pass 4: every 2nd row starting from row 1
+	for (let y = 1; y < height; y += 2) {
+		copyRow(pixels, output, sourceRow, y, width);
+		sourceRow++;
+	}
+
+	return output;
+}
+
+/**
+ * Copies a single row from source to destination position.
+ */
+function copyRow(
+	source: Uint8Array,
+	dest: Uint8Array,
+	sourceRow: number,
+	destRow: number,
+	width: number,
+): void {
+	const srcOffset = sourceRow * width;
+	const dstOffset = destRow * width;
+	for (let x = 0; x < width; x++) {
+		dest[dstOffset + x] = source[srcOffset + x] ?? 0;
+	}
+}
+
+// =============================================================================
+// IMAGE DATA PARSING
+// =============================================================================
+
+/**
+ * Parses a single image descriptor and its pixel data.
+ */
+function parseImageData(
+	data: Uint8Array,
+	offset: number,
+	control: GraphicsControl | null,
+): { ok: true; frame: GIFFrame; nextOffset: number } | GIFParseError {
+	if (offset + 9 > data.length) {
+		return { ok: false, error: 'Data too short for image descriptor' };
+	}
+
+	const x = readUint16LE(data, offset);
+	const y = readUint16LE(data, offset + 2);
+	const width = readUint16LE(data, offset + 4);
+	const height = readUint16LE(data, offset + 6);
+	const packed = data[offset + 8] ?? 0;
+
+	const hasLocalColorTable = (packed & 0x80) !== 0;
+	const interlaced = (packed & 0x40) !== 0;
+	const localColorTableSize = hasLocalColorTable ? 1 << ((packed & 0x07) + 1) : 0;
+
+	let pos = offset + 9;
+	let localColorTable: readonly GIFColor[] | undefined;
+
+	if (hasLocalColorTable) {
+		const tableBytes = localColorTableSize * 3;
+		if (pos + tableBytes > data.length) {
+			return { ok: false, error: 'Data too short for local color table' };
+		}
+		localColorTable = parseColorTable(data, pos, localColorTableSize);
+		pos += tableBytes;
+	}
+
+	// LZW minimum code size
+	if (pos >= data.length) {
+		return { ok: false, error: 'Missing LZW minimum code size' };
+	}
+	const minCodeSize = data[pos] ?? 0;
+	pos++;
+
+	// Read sub-blocks of compressed data
+	const { blockData, nextOffset } = readSubBlocks(data, pos);
+
+	// Decompress LZW data
+	const expectedPixels = width * height;
+	const lzwResult: LZWOutput = decompressLZW(blockData, minCodeSize, expectedPixels);
+
+	if (!lzwResult.ok) {
+		return { ok: false, error: `LZW decompression failed: ${lzwResult.error}` };
+	}
+
+	let pixels = lzwResult.data;
+	if (interlaced && width > 0 && height > 0) {
+		pixels = deinterlace(pixels, width, height);
+	}
+
+	const frame: GIFFrame = {
+		x,
+		y,
+		width,
+		height,
+		pixels,
+		delay: control?.delay ?? 0,
+		disposal: control?.disposal ?? DisposalMethod.Unspecified,
+		transparentIndex: control?.transparentIndex,
+		localColorTable,
+		interlaced,
+	};
+
+	return { ok: true, frame, nextOffset };
+}
+
+// =============================================================================
+// FRAME RENDERING TO RGBA
+// =============================================================================
+
+/**
+ * Converts a GIF frame to RGBA pixel data.
+ *
+ * Resolves palette indices to full RGBA colors using the appropriate color
+ * table (local or global). Transparent pixels are rendered with alpha 0.
+ *
+ * @param frame - GIF frame to convert
+ * @param globalColorTable - Global color table to use if no local table
+ * @returns RGBA pixel data (4 bytes per pixel: R, G, B, A)
+ *
+ * @example
+ * ```typescript
+ * import { parseGIF, frameToRGBA } from 'blecsd';
+ *
+ * const gif = parseGIF(data);
+ * if (gif.ok) {
+ *   const rgba = frameToRGBA(gif.frames[0], gif.globalColorTable);
+ *   // rgba is Uint8Array with width * height * 4 bytes
+ * }
+ * ```
+ */
+export function frameToRGBA(frame: GIFFrame, globalColorTable: readonly GIFColor[]): Uint8Array {
+	const colorTable = frame.localColorTable ?? globalColorTable;
+	const rgba = new Uint8Array(frame.width * frame.height * 4);
+
+	for (let i = 0; i < frame.pixels.length; i++) {
+		const index = frame.pixels[i] ?? 0;
+		const outPos = i * 4;
+
+		if (frame.transparentIndex !== undefined && index === frame.transparentIndex) {
+			rgba[outPos] = 0;
+			rgba[outPos + 1] = 0;
+			rgba[outPos + 2] = 0;
+			rgba[outPos + 3] = 0;
+			continue;
+		}
+
+		const color = colorTable[index];
+		if (color) {
+			rgba[outPos] = color.r;
+			rgba[outPos + 1] = color.g;
+			rgba[outPos + 2] = color.b;
+			rgba[outPos + 3] = 255;
+		}
+	}
+
+	return rgba;
+}
+
+// =============================================================================
+// MAIN PARSER
+// =============================================================================
+
+/**
+ * Parses a GIF file into structured data.
+ *
+ * Supports both GIF87a and GIF89a formats, including animated GIFs
+ * with multiple frames, transparency, and Netscape looping extensions.
+ *
+ * @param data - Raw GIF file bytes
+ * @returns Parsed GIF data or an error
+ *
+ * @example
+ * ```typescript
+ * import { parseGIF } from 'blecsd';
+ *
+ * const result = parseGIF(gifData);
+ * if (result.ok) {
+ *   console.log(`GIF ${result.header.version}: ${result.header.width}x${result.header.height}`);
+ *   console.log(`Frames: ${result.frames.length}, loops: ${result.loopCount}`);
+ *   for (const frame of result.frames) {
+ *     console.log(`  ${frame.width}x${frame.height} @ (${frame.x},${frame.y}), delay: ${frame.delay}ms`);
+ *   }
+ * }
+ * ```
+ */
+/**
+ * Parses the global color table from the data.
+ */
+function parseGlobalColorTable(
+	data: Uint8Array,
+	header: GIFHeader,
+	offset: number,
+): { table: readonly GIFColor[]; nextOffset: number } | GIFParseError {
+	if (!header.hasGlobalColorTable) {
+		return { table: [], nextOffset: offset };
+	}
+	const tableBytes = header.globalColorTableSize * 3;
+	if (offset + tableBytes > data.length) {
+		return { ok: false, error: 'Data too short for global color table' };
+	}
+	return {
+		table: parseColorTable(data, offset, header.globalColorTableSize),
+		nextOffset: offset + tableBytes,
+	};
+}
+
+/**
+ * Processes a single block in the GIF data stream.
+ */
+function processBlock(
+	data: Uint8Array,
+	pos: number,
+	state: { frames: GIFFrame[]; loopCount: number; currentControl: GraphicsControl | null },
+): { nextPos: number; done: boolean } | GIFParseError {
+	const blockType = data[pos] ?? 0;
+	const afterType = pos + 1;
+
+	if (blockType === GIF_TRAILER) {
+		return { nextPos: afterType, done: true };
+	}
+
+	if (blockType === EXTENSION_INTRODUCER) {
+		const result = parseExtension(data, afterType, state.currentControl);
+		if (!result) return { nextPos: afterType, done: true };
+		if (result.control !== undefined) state.currentControl = result.control;
+		if (result.loopCount !== undefined) state.loopCount = result.loopCount;
+		return { nextPos: result.nextOffset, done: false };
+	}
+
+	if (blockType === IMAGE_SEPARATOR) {
+		const result = parseImageData(data, afterType, state.currentControl);
+		if (!result.ok) return result;
+		state.frames.push(result.frame);
+		state.currentControl = null;
+		return { nextPos: result.nextOffset, done: false };
+	}
+
+	return { nextPos: afterType, done: true };
+}
+
+export function parseGIF(data: Uint8Array): GIFParseOutput {
+	const headerResult = parseGIFHeader(data);
+	if (!headerResult.ok) return headerResult;
+
+	const { header } = headerResult;
+
+	const gctResult = parseGlobalColorTable(data, header, 13);
+	if ('ok' in gctResult && !gctResult.ok) return gctResult as GIFParseError;
+	const { table: globalColorTable, nextOffset: startPos } = gctResult as {
+		table: readonly GIFColor[];
+		nextOffset: number;
+	};
+
+	const state = {
+		frames: [] as GIFFrame[],
+		loopCount: 1,
+		currentControl: null as GraphicsControl | null,
+	};
+	let pos = startPos;
+
+	while (pos < data.length) {
+		const result = processBlock(data, pos, state);
+		if ('ok' in result && !result.ok) return result;
+		const blockResult = result as { nextPos: number; done: boolean };
+		pos = blockResult.nextPos;
+		if (blockResult.done) break;
+	}
+
+	return { ok: true, header, globalColorTable, frames: state.frames, loopCount: state.loopCount };
+}
+
+// =============================================================================
+// EXTENSION PARSING DISPATCHER
+// =============================================================================
+
+/**
+ * Result of parsing an extension block.
+ */
+interface ExtensionResult {
+	nextOffset: number;
+	control?: GraphicsControl | null;
+	loopCount?: number;
+}
+
+/**
+ * Parses a GIF extension block.
+ */
+function parseExtension(
+	data: Uint8Array,
+	offset: number,
+	_currentControl: GraphicsControl | null,
+): ExtensionResult | null {
+	if (offset >= data.length) return null;
+	const label = data[offset] ?? 0;
+	const pos = offset + 1;
+
+	if (label === GRAPHICS_CONTROL_LABEL) {
+		const { control, nextOffset } = parseGraphicsControl(data, pos);
+		return { nextOffset, control };
+	}
+
+	if (label === APPLICATION_EXTENSION_LABEL) {
+		return parseApplicationExtension(data, pos);
+	}
+
+	// Comment or plain text extension: skip sub-blocks
+	if (label === COMMENT_EXTENSION_LABEL || label === PLAIN_TEXT_LABEL) {
+		const { nextOffset } = readSubBlocks(data, pos);
+		return { nextOffset };
+	}
+
+	// Unknown extension: skip sub-blocks
+	const { nextOffset } = readSubBlocks(data, pos);
+	return { nextOffset };
+}
+
+/**
+ * Parses an application extension (e.g., Netscape looping).
+ */
+/**
+ * Checks if the application extension is a Netscape/ANIMEXTS looping extension.
+ */
+function isNetscapeExtension(appId: string): boolean {
+	return appId === 'NETSCAPE2.0' || appId === 'ANIMEXTS1.0';
+}
+
+/**
+ * Tries to extract a loop count from a Netscape-style looping sub-block.
+ */
+function tryParseLoopCount(
+	data: Uint8Array,
+	pos: number,
+): { loopCount: number; nextPos: number } | null {
+	const subBlockSize = data[pos] ?? 0;
+	if (subBlockSize < 3) return null;
+	const subId = data[pos + 1] ?? 0;
+	if (subId !== 1) return null;
+	const loopCount = readUint16LE(data, pos + 2);
+	return { loopCount: loopCount === 0 ? 0 : loopCount, nextPos: pos + subBlockSize + 1 };
+}
+
+function parseApplicationExtension(data: Uint8Array, offset: number): ExtensionResult {
+	const blockSize = data[offset] ?? 0;
+	const pos = offset + 1 + blockSize;
+
+	if (blockSize === 11) {
+		const appId = String.fromCharCode(
+			...(Array.from(data.slice(offset + 1, offset + 1 + 11)) as number[]),
+		);
+
+		if (isNetscapeExtension(appId)) {
+			const loopResult = tryParseLoopCount(data, pos);
+			if (loopResult) {
+				const { nextOffset } = readSubBlocks(data, loopResult.nextPos);
+				return { nextOffset, loopCount: loopResult.loopCount };
+			}
+		}
+	}
+
+	const { nextOffset } = readSubBlocks(data, pos);
+	return { nextOffset };
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Reads a 16-bit little-endian unsigned integer from the data.
+ */
+function readUint16LE(data: Uint8Array, offset: number): number {
+	return (data[offset] ?? 0) | ((data[offset + 1] ?? 0) << 8);
+}


### PR DESCRIPTION
## Summary

- Implement GIF file parser supporting both GIF87a and GIF89a formats
- Add LZW decompression with variable code widths (2-12 bits), clear codes, and EOI handling
- Support animated GIFs with frame timing, disposal methods, and Netscape loop extensions
- Support transparency and local/global color tables
- Add frame-to-RGBA conversion and interlace de-interlacing

## Files Added
- `src/media/gif/lzw.ts` - LZW decompression with bit reader utilities
- `src/media/gif/parser.ts` - Full GIF format parser with frame extraction
- `src/media/gif/index.ts` - Barrel exports
- `src/media/gif/lzw.test.ts` - 19 tests for LZW decompression
- `src/media/gif/parser.test.ts` - 34 tests for GIF parsing

## Test plan
- [x] LZW decompression with various code sizes (2, 3, 8)
- [x] Code size increases handled correctly
- [x] GIF87a and GIF89a signature validation
- [x] Header parsing with Zod schema validation
- [x] Global/local color table parsing
- [x] Graphics control extension (delay, disposal, transparency)
- [x] Netscape loop extension (infinite and finite)
- [x] Interlace de-interlacing
- [x] Frame-to-RGBA conversion with transparency
- [x] All 8688 tests pass
- [x] Lint, typecheck, and build pass