### PR TITLE
feat(doom): add title screen and menu system

### DIFF
--- a/examples/doom/game/menu.test.ts
+++ b/examples/doom/game/menu.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for the menu state machine.
+ *
+ * @module game/menu.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	createMenuState,
+	isMenuActive,
+	MAIN_MENU_ITEMS,
+	MenuMode,
+	SKILL_NAMES,
+	SkillLevel,
+	updateMenu,
+} from './menu.js';
+
+// ─── createMenuState ──────────────────────────────────────────────
+
+describe('createMenuState', () => {
+	it('starts in TITLE mode', () => {
+		const menu = createMenuState();
+		expect(menu.mode).toBe(MenuMode.TITLE);
+	});
+
+	it('starts with item 0 selected', () => {
+		const menu = createMenuState();
+		expect(menu.selectedItem).toBe(0);
+	});
+
+	it('defaults to MEDIUM skill', () => {
+		const menu = createMenuState();
+		expect(menu.skill).toBe(SkillLevel.MEDIUM);
+	});
+
+	it('starts with ticCount 0', () => {
+		const menu = createMenuState();
+		expect(menu.ticCount).toBe(0);
+	});
+});
+
+// ─── isMenuActive ─────────────────────────────────────────────────
+
+describe('isMenuActive', () => {
+	it('returns true in TITLE mode', () => {
+		const menu = createMenuState();
+		expect(isMenuActive(menu)).toBe(true);
+	});
+
+	it('returns true in SKILL_SELECT mode', () => {
+		const menu = createMenuState();
+		menu.mode = MenuMode.SKILL_SELECT;
+		expect(isMenuActive(menu)).toBe(true);
+	});
+
+	it('returns false in PLAYING mode', () => {
+		const menu = createMenuState();
+		menu.mode = MenuMode.PLAYING;
+		expect(isMenuActive(menu)).toBe(false);
+	});
+});
+
+// ─── Title Menu Navigation ────────────────────────────────────────
+
+describe('title menu navigation', () => {
+	it('increments ticCount each update', () => {
+		const menu = createMenuState();
+		updateMenu(menu, new Set());
+		expect(menu.ticCount).toBe(1);
+		updateMenu(menu, new Set());
+		expect(menu.ticCount).toBe(2);
+	});
+
+	it('moves down with down key', () => {
+		const menu = createMenuState();
+		updateMenu(menu, new Set(['down']));
+		expect(menu.selectedItem).toBe(1);
+	});
+
+	it('moves down with s key', () => {
+		const menu = createMenuState();
+		updateMenu(menu, new Set(['s']));
+		expect(menu.selectedItem).toBe(1);
+	});
+
+	it('moves up with up key', () => {
+		const menu = createMenuState();
+		menu.selectedItem = 1;
+		updateMenu(menu, new Set(['up']));
+		expect(menu.selectedItem).toBe(0);
+	});
+
+	it('moves up with w key', () => {
+		const menu = createMenuState();
+		menu.selectedItem = 1;
+		updateMenu(menu, new Set(['w']));
+		expect(menu.selectedItem).toBe(0);
+	});
+
+	it('wraps from bottom to top', () => {
+		const menu = createMenuState();
+		menu.selectedItem = MAIN_MENU_ITEMS.length - 1;
+		updateMenu(menu, new Set(['down']));
+		expect(menu.selectedItem).toBe(0);
+	});
+
+	it('wraps from top to bottom', () => {
+		const menu = createMenuState();
+		menu.selectedItem = 0;
+		updateMenu(menu, new Set(['up']));
+		expect(menu.selectedItem).toBe(MAIN_MENU_ITEMS.length - 1);
+	});
+
+	it('does not change mode without confirm', () => {
+		const menu = createMenuState();
+		const result = updateMenu(menu, new Set(['down']));
+		expect(menu.mode).toBe(MenuMode.TITLE);
+		expect(result.startGame).toBe(false);
+		expect(result.quit).toBe(false);
+	});
+});
+
+// ─── Title Menu Selection ─────────────────────────────────────────
+
+describe('title menu selection', () => {
+	it('selects NEW GAME with return key', () => {
+		const menu = createMenuState();
+		menu.selectedItem = 0; // NEW GAME
+		const result = updateMenu(menu, new Set(['return']));
+		expect(menu.mode).toBe(MenuMode.SKILL_SELECT);
+		expect(result.startGame).toBe(false);
+	});
+
+	it('selects NEW GAME with space key', () => {
+		const menu = createMenuState();
+		menu.selectedItem = 0;
+		const result = updateMenu(menu, new Set(['space']));
+		expect(menu.mode).toBe(MenuMode.SKILL_SELECT);
+		expect(result.startGame).toBe(false);
+	});
+
+	it('defaults to MEDIUM skill when entering skill select', () => {
+		const menu = createMenuState();
+		menu.selectedItem = 0;
+		updateMenu(menu, new Set(['return']));
+		expect(menu.selectedItem).toBe(SkillLevel.MEDIUM);
+	});
+
+	it('selects QUIT with return key', () => {
+		const menu = createMenuState();
+		menu.selectedItem = 1; // QUIT
+		const result = updateMenu(menu, new Set(['return']));
+		expect(result.quit).toBe(true);
+		expect(result.startGame).toBe(false);
+	});
+});
+
+// ─── Skill Menu Navigation ───────────────────────────────────────
+
+describe('skill menu navigation', () => {
+	function skillMenu() {
+		const menu = createMenuState();
+		menu.mode = MenuMode.SKILL_SELECT;
+		menu.selectedItem = SkillLevel.MEDIUM;
+		return menu;
+	}
+
+	it('moves down with down key', () => {
+		const menu = skillMenu();
+		updateMenu(menu, new Set(['down']));
+		expect(menu.selectedItem).toBe(SkillLevel.HARD);
+	});
+
+	it('moves up with up key', () => {
+		const menu = skillMenu();
+		updateMenu(menu, new Set(['up']));
+		expect(menu.selectedItem).toBe(SkillLevel.EASY);
+	});
+
+	it('wraps from bottom to top', () => {
+		const menu = skillMenu();
+		menu.selectedItem = SKILL_NAMES.length - 1;
+		updateMenu(menu, new Set(['down']));
+		expect(menu.selectedItem).toBe(0);
+	});
+
+	it('wraps from top to bottom', () => {
+		const menu = skillMenu();
+		menu.selectedItem = 0;
+		updateMenu(menu, new Set(['up']));
+		expect(menu.selectedItem).toBe(SKILL_NAMES.length - 1);
+	});
+});
+
+// ─── Skill Menu Selection ─────────────────────────────────────────
+
+describe('skill menu selection', () => {
+	it('starts the game with return key', () => {
+		const menu = createMenuState();
+		menu.mode = MenuMode.SKILL_SELECT;
+		menu.selectedItem = SkillLevel.HARD;
+		const result = updateMenu(menu, new Set(['return']));
+		expect(result.startGame).toBe(true);
+		expect(result.skill).toBe(SkillLevel.HARD);
+		expect(menu.mode).toBe(MenuMode.PLAYING);
+	});
+
+	it('starts the game with space key', () => {
+		const menu = createMenuState();
+		menu.mode = MenuMode.SKILL_SELECT;
+		menu.selectedItem = SkillLevel.BABY;
+		const result = updateMenu(menu, new Set(['space']));
+		expect(result.startGame).toBe(true);
+		expect(result.skill).toBe(SkillLevel.BABY);
+	});
+
+	it('goes back to title with escape', () => {
+		const menu = createMenuState();
+		menu.mode = MenuMode.SKILL_SELECT;
+		menu.selectedItem = SkillLevel.HARD;
+		const result = updateMenu(menu, new Set(['escape']));
+		expect(menu.mode).toBe(MenuMode.TITLE);
+		expect(menu.selectedItem).toBe(0);
+		expect(result.startGame).toBe(false);
+	});
+
+	it('sets skill on menu state when selected', () => {
+		const menu = createMenuState();
+		menu.mode = MenuMode.SKILL_SELECT;
+		menu.selectedItem = SkillLevel.NIGHTMARE;
+		updateMenu(menu, new Set(['return']));
+		expect(menu.skill).toBe(SkillLevel.NIGHTMARE);
+	});
+});
+
+// ─── PLAYING Mode ─────────────────────────────────────────────────
+
+describe('PLAYING mode', () => {
+	it('returns neutral result in PLAYING mode', () => {
+		const menu = createMenuState();
+		menu.mode = MenuMode.PLAYING;
+		const result = updateMenu(menu, new Set(['return']));
+		expect(result.startGame).toBe(false);
+		expect(result.quit).toBe(false);
+	});
+
+	it('still increments ticCount in PLAYING mode', () => {
+		const menu = createMenuState();
+		menu.mode = MenuMode.PLAYING;
+		updateMenu(menu, new Set());
+		expect(menu.ticCount).toBe(1);
+	});
+});
+
+// ─── Full Flow ────────────────────────────────────────────────────
+
+describe('full menu flow', () => {
+	it('title -> skill select -> playing', () => {
+		const menu = createMenuState();
+
+		// Start in TITLE
+		expect(isMenuActive(menu)).toBe(true);
+		expect(menu.mode).toBe(MenuMode.TITLE);
+
+		// Select NEW GAME
+		updateMenu(menu, new Set(['return']));
+		expect(menu.mode).toBe(MenuMode.SKILL_SELECT);
+		expect(isMenuActive(menu)).toBe(true);
+
+		// Pick ULTRA-VIOLENCE
+		menu.selectedItem = SkillLevel.HARD;
+		const result = updateMenu(menu, new Set(['return']));
+		expect(menu.mode).toBe(MenuMode.PLAYING);
+		expect(result.startGame).toBe(true);
+		expect(result.skill).toBe(SkillLevel.HARD);
+		expect(isMenuActive(menu)).toBe(false);
+	});
+
+	it('title -> skill select -> back to title -> quit', () => {
+		const menu = createMenuState();
+
+		// NEW GAME
+		updateMenu(menu, new Set(['return']));
+		expect(menu.mode).toBe(MenuMode.SKILL_SELECT);
+
+		// ESC back
+		updateMenu(menu, new Set(['escape']));
+		expect(menu.mode).toBe(MenuMode.TITLE);
+		expect(menu.selectedItem).toBe(0);
+
+		// Move to QUIT and select
+		updateMenu(menu, new Set(['down']));
+		expect(menu.selectedItem).toBe(1);
+		const result = updateMenu(menu, new Set(['return']));
+		expect(result.quit).toBe(true);
+	});
+});

--- a/examples/doom/game/menu.ts
+++ b/examples/doom/game/menu.ts
@@ -1,0 +1,177 @@
+/**
+ * Title screen and menu state management.
+ *
+ * Handles the main menu (New Game, Quit) and skill selection screen.
+ * The game starts in TITLE mode and transitions to PLAYING after
+ * the player selects a skill level.
+ *
+ * @module game/menu
+ */
+
+// ─── Menu Mode ──────────────────────────────────────────────────
+
+/** Game modes for the menu system. */
+export const MenuMode = {
+	/** Title screen with main menu. */
+	TITLE: 0,
+	/** Skill level selection. */
+	SKILL_SELECT: 1,
+	/** In-game (menu dismissed). */
+	PLAYING: 2,
+} as const;
+
+// ─── Skill Levels ───────────────────────────────────────────────
+
+/** Doom skill levels matching the original game. */
+export const SkillLevel = {
+	BABY: 0,
+	EASY: 1,
+	MEDIUM: 2,
+	HARD: 3,
+	NIGHTMARE: 4,
+} as const;
+
+/** Display names for each skill level. */
+export const SKILL_NAMES: readonly string[] = [
+	"I'M TOO YOUNG TO DIE",
+	'HEY, NOT TOO ROUGH',
+	'HURT ME PLENTY',
+	'ULTRA-VIOLENCE',
+	'NIGHTMARE!',
+];
+
+// ─── Main Menu Items ────────────────────────────────────────────
+
+/** Display names for main menu items. */
+export const MAIN_MENU_ITEMS: readonly string[] = [
+	'NEW GAME',
+	'QUIT',
+];
+
+// ─── Menu State ─────────────────────────────────────────────────
+
+/** Mutable menu state. */
+export interface MenuState {
+	/** Current menu mode. */
+	mode: number;
+	/** Currently highlighted menu item index. */
+	selectedItem: number;
+	/** Selected skill level (set when entering game). */
+	skill: number;
+	/** Tic counter for title screen animation. */
+	ticCount: number;
+}
+
+/**
+ * Create initial menu state at the title screen.
+ *
+ * @returns Menu state in TITLE mode
+ */
+export function createMenuState(): MenuState {
+	return {
+		mode: MenuMode.TITLE,
+		selectedItem: 0,
+		skill: SkillLevel.MEDIUM,
+		ticCount: 0,
+	};
+}
+
+// ─── Menu Input ─────────────────────────────────────────────────
+
+/** Result of menu input processing. */
+export interface MenuResult {
+	/** Whether the game should start (transition to PLAYING). */
+	startGame: boolean;
+	/** Whether the game should quit. */
+	quit: boolean;
+	/** Selected skill level (valid when startGame is true). */
+	skill: number;
+}
+
+/**
+ * Process input for the current menu mode.
+ *
+ * @param menu - Mutable menu state
+ * @param keys - Set of pressed key names
+ * @returns Menu result indicating game start or quit
+ */
+export function updateMenu(menu: MenuState, keys: Set<string>): MenuResult {
+	menu.ticCount++;
+
+	if (menu.mode === MenuMode.TITLE) {
+		return updateTitleMenu(menu, keys);
+	}
+	if (menu.mode === MenuMode.SKILL_SELECT) {
+		return updateSkillMenu(menu, keys);
+	}
+
+	return { startGame: false, quit: false, skill: menu.skill };
+}
+
+/**
+ * Process input for the main title menu.
+ */
+function updateTitleMenu(menu: MenuState, keys: Set<string>): MenuResult {
+	const itemCount = MAIN_MENU_ITEMS.length;
+
+	if (keys.has('up') || keys.has('w')) {
+		menu.selectedItem = (menu.selectedItem - 1 + itemCount) % itemCount;
+	}
+	if (keys.has('down') || keys.has('s')) {
+		menu.selectedItem = (menu.selectedItem + 1) % itemCount;
+	}
+
+	if (keys.has('return') || keys.has('space')) {
+		if (menu.selectedItem === 0) {
+			// New Game -> go to skill select
+			menu.mode = MenuMode.SKILL_SELECT;
+			menu.selectedItem = SkillLevel.MEDIUM; // default to Hurt Me Plenty
+			return { startGame: false, quit: false, skill: menu.skill };
+		}
+		if (menu.selectedItem === 1) {
+			// Quit
+			return { startGame: false, quit: true, skill: menu.skill };
+		}
+	}
+
+	return { startGame: false, quit: false, skill: menu.skill };
+}
+
+/**
+ * Process input for the skill selection menu.
+ */
+function updateSkillMenu(menu: MenuState, keys: Set<string>): MenuResult {
+	const itemCount = SKILL_NAMES.length;
+
+	if (keys.has('up') || keys.has('w')) {
+		menu.selectedItem = (menu.selectedItem - 1 + itemCount) % itemCount;
+	}
+	if (keys.has('down') || keys.has('s')) {
+		menu.selectedItem = (menu.selectedItem + 1) % itemCount;
+	}
+
+	if (keys.has('return') || keys.has('space')) {
+		menu.skill = menu.selectedItem;
+		menu.mode = MenuMode.PLAYING;
+		return { startGame: true, quit: false, skill: menu.skill };
+	}
+
+	if (keys.has('escape')) {
+		// Go back to main menu
+		menu.mode = MenuMode.TITLE;
+		menu.selectedItem = 0;
+		return { startGame: false, quit: false, skill: menu.skill };
+	}
+
+	return { startGame: false, quit: false, skill: menu.skill };
+}
+
+/**
+ * Check if the menu is active (not in PLAYING mode).
+ *
+ * @param menu - Menu state
+ * @returns true if the menu is showing
+ */
+export function isMenuActive(menu: MenuState): boolean {
+	return menu.mode !== MenuMode.PLAYING;
+}

--- a/examples/doom/render/titleScreen.ts
+++ b/examples/doom/render/titleScreen.ts
@@ -1,0 +1,365 @@
+/**
+ * Title screen and menu rendering.
+ *
+ * Loads TITLEPIC from the WAD and draws it as the background.
+ * Renders menu overlays (main menu, skill selection) with
+ * a simple 5x7 bitmap font.
+ *
+ * @module render/titleScreen
+ */
+
+import { three } from 'blecsd';
+import type { WadFile, Palette } from '../wad/types.js';
+import { findLump, getLumpData } from '../wad/wad.js';
+import { parsePicture, renderPictureToFlat } from '../wad/pictureFormat.js';
+import type { MenuState } from '../game/menu.js';
+import { MenuMode, MAIN_MENU_ITEMS, SKILL_NAMES } from '../game/menu.js';
+
+// ─── Title Picture Cache ──────────────────────────────────────────
+
+/** Cached TITLEPIC pixel data (palette indices, 320x200). */
+let titlePicPixels: Uint8Array | null = null;
+let titlePicWidth = 0;
+let titlePicHeight = 0;
+
+/**
+ * Load the TITLEPIC lump from the WAD and cache it.
+ *
+ * @param wad - Loaded WAD file
+ * @returns true if TITLEPIC was loaded successfully
+ */
+export function loadTitlePic(wad: WadFile): boolean {
+	const entry = findLump(wad, 'TITLEPIC');
+	if (!entry) return false;
+
+	try {
+		const data = getLumpData(wad, entry);
+		const picture = parsePicture(data);
+		titlePicPixels = renderPictureToFlat(picture);
+		titlePicWidth = picture.width;
+		titlePicHeight = picture.height;
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// ─── 5x7 Bitmap Font ──────────────────────────────────────────────
+
+/**
+ * 5x7 pixel patterns for characters used in menus.
+ * '#' marks a lit pixel, ' ' marks an unlit pixel.
+ */
+const FONT: Readonly<Record<string, readonly string[]>> = {
+	A: [' ### ', '#   #', '#   #', '#####', '#   #', '#   #', '#   #'],
+	B: ['#### ', '#   #', '#### ', '#   #', '#   #', '#   #', '#### '],
+	C: [' ### ', '#   #', '#    ', '#    ', '#    ', '#   #', ' ### '],
+	D: ['#### ', '#   #', '#   #', '#   #', '#   #', '#   #', '#### '],
+	E: ['#####', '#    ', '#####', '#    ', '#    ', '#    ', '#####'],
+	F: ['#####', '#    ', '#### ', '#    ', '#    ', '#    ', '#    '],
+	G: [' ### ', '#   #', '#    ', '# ###', '#   #', '#   #', ' ### '],
+	H: ['#   #', '#   #', '#####', '#   #', '#   #', '#   #', '#   #'],
+	I: [' ### ', '  #  ', '  #  ', '  #  ', '  #  ', '  #  ', ' ### '],
+	J: ['  ###', '   # ', '   # ', '   # ', '#  # ', '#  # ', ' ## '],
+	K: ['#   #', '#  # ', '# #  ', '##   ', '# #  ', '#  # ', '#   #'],
+	L: ['#    ', '#    ', '#    ', '#    ', '#    ', '#    ', '#####'],
+	M: ['#   #', '## ##', '# # #', '#   #', '#   #', '#   #', '#   #'],
+	N: ['#   #', '##  #', '# # #', '#  ##', '#   #', '#   #', '#   #'],
+	O: [' ### ', '#   #', '#   #', '#   #', '#   #', '#   #', ' ### '],
+	P: ['#### ', '#   #', '#   #', '#### ', '#    ', '#    ', '#    '],
+	Q: [' ### ', '#   #', '#   #', '#   #', '# # #', '#  # ', ' ## #'],
+	R: ['#### ', '#   #', '#   #', '#### ', '#  # ', '#   #', '#   #'],
+	S: [' ####', '#    ', ' ### ', '    #', '    #', '#   #', ' ### '],
+	T: ['#####', '  #  ', '  #  ', '  #  ', '  #  ', '  #  ', '  #  '],
+	U: ['#   #', '#   #', '#   #', '#   #', '#   #', '#   #', ' ### '],
+	V: ['#   #', '#   #', '#   #', '#   #', ' # # ', ' # # ', '  #  '],
+	W: ['#   #', '#   #', '#   #', '# # #', '# # #', '## ##', '#   #'],
+	X: ['#   #', ' # # ', '  #  ', '  #  ', '  #  ', ' # # ', '#   #'],
+	Y: ['#   #', ' # # ', '  #  ', '  #  ', '  #  ', '  #  ', '  #  '],
+	Z: ['#####', '    #', '   # ', '  #  ', ' #   ', '#    ', '#####'],
+	'0': [' ### ', '#   #', '#  ##', '# # #', '##  #', '#   #', ' ### '],
+	'1': ['  #  ', ' ##  ', '  #  ', '  #  ', '  #  ', '  #  ', ' ### '],
+	'2': [' ### ', '#   #', '    #', '  ## ', ' #   ', '#    ', '#####'],
+	'3': [' ### ', '#   #', '    #', '  ## ', '    #', '#   #', ' ### '],
+	'4': ['#   #', '#   #', '#   #', '#####', '    #', '    #', '    #'],
+	'5': ['#####', '#    ', '#### ', '    #', '    #', '#   #', ' ### '],
+	'6': [' ### ', '#    ', '#### ', '#   #', '#   #', '#   #', ' ### '],
+	'7': ['#####', '    #', '   # ', '  #  ', '  #  ', '  #  ', '  #  '],
+	'8': [' ### ', '#   #', '#   #', ' ### ', '#   #', '#   #', ' ### '],
+	'9': [' ### ', '#   #', '#   #', ' ####', '    #', '    #', ' ### '],
+	"'": ['  #  ', '  #  ', ' #   ', '     ', '     ', '     ', '     '],
+	',': ['     ', '     ', '     ', '     ', '  #  ', '  #  ', ' #   '],
+	'-': ['     ', '     ', '     ', '#####', '     ', '     ', '     '],
+	'!': ['  #  ', '  #  ', '  #  ', '  #  ', '  #  ', '     ', '  #  '],
+	'.': ['     ', '     ', '     ', '     ', '     ', '     ', '  #  '],
+};
+
+/** Character width including 1px gap. */
+const CHAR_WIDTH = 6;
+
+/** Character height. */
+const CHAR_HEIGHT = 7;
+
+// ─── Drawing Helpers ──────────────────────────────────────────────
+
+/**
+ * Draw a character at the given position using the bitmap font.
+ */
+function drawFontChar(
+	fb: three.PixelFramebuffer,
+	x: number,
+	y: number,
+	ch: string,
+	r: number,
+	g: number,
+	b: number,
+): void {
+	const pattern = FONT[ch];
+	if (!pattern) return;
+
+	for (let row = 0; row < CHAR_HEIGHT; row++) {
+		const line = pattern[row];
+		if (!line) continue;
+		for (let col = 0; col < 5; col++) {
+			if (line[col] === '#') {
+				const px = x + col;
+				const py = y + row;
+				if (px >= 0 && px < fb.width && py >= 0 && py < fb.height) {
+					three.setPixelUnsafe(fb, px, py, r, g, b, 255);
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Draw a string at the given position.
+ */
+function drawText(
+	fb: three.PixelFramebuffer,
+	x: number,
+	y: number,
+	text: string,
+	r: number,
+	g: number,
+	b: number,
+): void {
+	for (let i = 0; i < text.length; i++) {
+		const ch = text[i];
+		if (ch && ch !== ' ') {
+			drawFontChar(fb, x + i * CHAR_WIDTH, y, ch, r, g, b);
+		}
+	}
+}
+
+/**
+ * Draw a string centered horizontally on screen.
+ */
+function drawTextCentered(
+	fb: three.PixelFramebuffer,
+	y: number,
+	text: string,
+	r: number,
+	g: number,
+	b: number,
+): void {
+	const textWidth = text.length * CHAR_WIDTH;
+	const x = Math.floor((fb.width - textWidth) / 2);
+	drawText(fb, x, y, text, r, g, b);
+}
+
+/**
+ * Fill a rectangle with a color (with alpha blending for dimming).
+ */
+function fillRect(
+	fb: three.PixelFramebuffer,
+	x: number,
+	y: number,
+	w: number,
+	h: number,
+	r: number,
+	g: number,
+	b: number,
+	a: number,
+): void {
+	for (let py = y; py < y + h && py < fb.height; py++) {
+		if (py < 0) continue;
+		for (let px = x; px < x + w && px < fb.width; px++) {
+			if (px < 0) continue;
+			if (a >= 255) {
+				three.setPixelUnsafe(fb, px, py, r, g, b, 255);
+			} else {
+				// Alpha blend
+				const idx = (py * fb.width + px) * 4;
+				const sr = fb.data[idx] ?? 0;
+				const sg = fb.data[idx + 1] ?? 0;
+				const sb = fb.data[idx + 2] ?? 0;
+				const alpha = a / 255;
+				const outR = Math.round(sr * (1 - alpha) + r * alpha);
+				const outG = Math.round(sg * (1 - alpha) + g * alpha);
+				const outB = Math.round(sb * (1 - alpha) + b * alpha);
+				three.setPixelUnsafe(fb, px, py, outR, outG, outB, 255);
+			}
+		}
+	}
+}
+
+// ─── Title Screen Rendering ───────────────────────────────────────
+
+/**
+ * Draw the TITLEPIC background to the framebuffer.
+ *
+ * @param fb - Pixel framebuffer (320x200)
+ * @param palette - Color palette for index-to-RGB conversion
+ */
+export function drawTitlePic(
+	fb: three.PixelFramebuffer,
+	palette: Palette,
+): void {
+	if (!titlePicPixels) {
+		// No TITLEPIC, fill with dark red
+		for (let y = 0; y < fb.height; y++) {
+			for (let x = 0; x < fb.width; x++) {
+				three.setPixelUnsafe(fb, x, y, 80, 0, 0, 255);
+			}
+		}
+		return;
+	}
+
+	for (let y = 0; y < fb.height && y < titlePicHeight; y++) {
+		for (let x = 0; x < fb.width && x < titlePicWidth; x++) {
+			const palIdx = titlePicPixels[y * titlePicWidth + x] ?? 0;
+			const color = palette[palIdx];
+			if (color) {
+				three.setPixelUnsafe(fb, x, y, color.r, color.g, color.b, 255);
+			}
+		}
+	}
+}
+
+// ─── Menu Colors ──────────────────────────────────────────────────
+
+const MENU_BG_ALPHA = 160;
+const ITEM_R = 220;
+const ITEM_G = 180;
+const ITEM_B = 50;
+const SELECTED_R = 255;
+const SELECTED_G = 50;
+const SELECTED_B = 50;
+const TITLE_R = 255;
+const TITLE_G = 255;
+const TITLE_B = 255;
+const CURSOR_R = 255;
+const CURSOR_G = 50;
+const CURSOR_B = 50;
+
+// ─── Menu Drawing ─────────────────────────────────────────────────
+
+/**
+ * Draw the title screen with menu overlays.
+ *
+ * Renders the TITLEPIC background, then overlays the appropriate
+ * menu (main menu or skill selection) based on the menu state.
+ *
+ * @param fb - Pixel framebuffer
+ * @param palette - Color palette
+ * @param menu - Current menu state
+ */
+export function drawTitleScreen(
+	fb: three.PixelFramebuffer,
+	palette: Palette,
+	menu: MenuState,
+): void {
+	// Draw TITLEPIC as background
+	drawTitlePic(fb, palette);
+
+	if (menu.mode === MenuMode.TITLE) {
+		drawMainMenu(fb, menu);
+	} else if (menu.mode === MenuMode.SKILL_SELECT) {
+		drawSkillMenu(fb, menu);
+	}
+}
+
+/**
+ * Draw the main menu overlay (NEW GAME, QUIT).
+ */
+function drawMainMenu(
+	fb: three.PixelFramebuffer,
+	menu: MenuState,
+): void {
+	const items = MAIN_MENU_ITEMS;
+	const menuHeight = items.length * 16 + 30;
+	const menuTop = Math.floor((fb.height - menuHeight) / 2) + 20;
+
+	// Semi-transparent background panel
+	fillRect(fb, 60, menuTop - 10, 200, menuHeight + 10, 0, 0, 0, MENU_BG_ALPHA);
+
+	// Title text
+	drawTextCentered(fb, menuTop, 'TERMINAL DOOM', TITLE_R, TITLE_G, TITLE_B);
+
+	// Menu items
+	const itemStartY = menuTop + 20;
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i];
+		if (!item) continue;
+
+		const y = itemStartY + i * 16;
+		const isSelected = menu.selectedItem === i;
+
+		if (isSelected) {
+			// Blinking cursor (every 16 tics)
+			const showCursor = (menu.ticCount % 32) < 20;
+			if (showCursor) {
+				const textWidth = item.length * CHAR_WIDTH;
+				const textX = Math.floor((fb.width - textWidth) / 2);
+				drawText(fb, textX - 12, y, '>', CURSOR_R, CURSOR_G, CURSOR_B);
+			}
+			drawTextCentered(fb, y, item, SELECTED_R, SELECTED_G, SELECTED_B);
+		} else {
+			drawTextCentered(fb, y, item, ITEM_R, ITEM_G, ITEM_B);
+		}
+	}
+}
+
+/**
+ * Draw the skill selection menu overlay.
+ */
+function drawSkillMenu(
+	fb: three.PixelFramebuffer,
+	menu: MenuState,
+): void {
+	const items = SKILL_NAMES;
+	const menuHeight = items.length * 14 + 30;
+	const menuTop = Math.floor((fb.height - menuHeight) / 2);
+
+	// Semi-transparent background panel
+	fillRect(fb, 20, menuTop - 10, 280, menuHeight + 10, 0, 0, 0, MENU_BG_ALPHA);
+
+	// Title
+	drawTextCentered(fb, menuTop, 'CHOOSE YOUR SKILL', TITLE_R, TITLE_G, TITLE_B);
+
+	// Skill items
+	const itemStartY = menuTop + 18;
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i];
+		if (!item) continue;
+
+		const y = itemStartY + i * 14;
+		const isSelected = menu.selectedItem === i;
+
+		if (isSelected) {
+			const showCursor = (menu.ticCount % 32) < 20;
+			if (showCursor) {
+				const textWidth = item.length * CHAR_WIDTH;
+				const textX = Math.floor((fb.width - textWidth) / 2);
+				drawText(fb, textX - 12, y, '>', CURSOR_R, CURSOR_G, CURSOR_B);
+			}
+			drawTextCentered(fb, y, item, SELECTED_R, SELECTED_G, SELECTED_B);
+		} else {
+			drawTextCentered(fb, y, item, ITEM_R, ITEM_G, ITEM_B);
+		}
+	}
+
+	// Footer hint
+	drawTextCentered(fb, menuTop + menuHeight - 4, 'ESC TO GO BACK', 120, 120, 120);
+}


### PR DESCRIPTION
## Summary
- Add menu state machine with main menu (New Game, Quit) and skill level selection supporting Doom's five difficulty levels
- Add title screen renderer that loads TITLEPIC from WAD and draws menu overlays with a 5x7 bitmap font
- Integrate menu system into the game loop: game starts on title screen and transitions to gameplay after skill selection

## Files Changed
- `examples/doom/game/menu.ts` - Menu state machine (MenuMode, SkillLevel, navigation, mode transitions)
- `examples/doom/render/titleScreen.ts` - TITLEPIC loader, bitmap font, menu/skill overlay rendering
- `examples/doom/game/menu.test.ts` - 27 tests covering full menu flow
- `examples/doom/index.ts` - Integrate menu into frame loop with title/gameplay modes

## Test plan
- [x] All 246 doom tests pass (including 27 new menu tests)
- [x] All 8758 root tests pass
- [x] TypeScript type checking passes
- [x] Build succeeds

Closes #718