### PR TITLE
feat(widgets): add Image factory widget

### DIFF
--- a/src/widgets/image.test.ts
+++ b/src/widgets/image.test.ts
@@ -1,0 +1,432 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { addEntity, createWorld } from '../core/ecs';
+import type { World } from '../core/types';
+import type { Bitmap } from '../media/render/ansi';
+import {
+	createImage,
+	getImageBitmap,
+	getImageCellMap,
+	Image,
+	ImageConfigSchema,
+	isImage,
+	resetImageStore,
+} from './image';
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Creates a solid-color RGBA bitmap for testing.
+ */
+function createTestBitmap(
+	width: number,
+	height: number,
+	r: number,
+	g: number,
+	b: number,
+	a = 255,
+): Bitmap {
+	const data = new Uint8Array(width * height * 4);
+	for (let i = 0; i < width * height; i++) {
+		data[i * 4] = r;
+		data[i * 4 + 1] = g;
+		data[i * 4 + 2] = b;
+		data[i * 4 + 3] = a;
+	}
+	return { width, height, data };
+}
+
+let world: World;
+
+beforeEach(() => {
+	resetImageStore();
+	world = createWorld();
+});
+
+// =============================================================================
+// SCHEMA VALIDATION
+// =============================================================================
+
+describe('ImageConfigSchema', () => {
+	it('should accept empty config with defaults', () => {
+		const result = ImageConfigSchema.parse({});
+		expect(result.x).toBe(0);
+		expect(result.y).toBe(0);
+		expect(result.type).toBe('ansi');
+		expect(result.renderMode).toBe('color');
+		expect(result.dither).toBe(false);
+		expect(result.visible).toBe(true);
+	});
+
+	it('should accept valid config', () => {
+		const result = ImageConfigSchema.parse({
+			x: 10,
+			y: 5,
+			width: 40,
+			height: 20,
+			type: 'overlay',
+			renderMode: 'ascii',
+			dither: true,
+			visible: false,
+		});
+		expect(result.x).toBe(10);
+		expect(result.y).toBe(5);
+		expect(result.type).toBe('overlay');
+		expect(result.renderMode).toBe('ascii');
+		expect(result.dither).toBe(true);
+		expect(result.visible).toBe(false);
+	});
+
+	it('should reject invalid type', () => {
+		expect(() => ImageConfigSchema.parse({ type: 'invalid' })).toThrow();
+	});
+
+	it('should reject invalid render mode', () => {
+		expect(() => ImageConfigSchema.parse({ renderMode: 'nope' })).toThrow();
+	});
+
+	it('should reject negative width', () => {
+		expect(() => ImageConfigSchema.parse({ width: -1 })).toThrow();
+	});
+
+	it('should reject zero width', () => {
+		expect(() => ImageConfigSchema.parse({ width: 0 })).toThrow();
+	});
+
+	it('should accept bitmap in config', () => {
+		const bitmap = createTestBitmap(2, 2, 255, 0, 0);
+		const result = ImageConfigSchema.parse({ bitmap });
+		expect(result.bitmap).toBeDefined();
+		expect(result.bitmap?.width).toBe(2);
+		expect(result.bitmap?.height).toBe(2);
+	});
+});
+
+// =============================================================================
+// FACTORY
+// =============================================================================
+
+describe('createImage', () => {
+	it('should create an image widget with default config', () => {
+		const image = createImage(world);
+		expect(image.eid).toBeDefined();
+		expect(image.getType()).toBe('ansi');
+		expect(image.getRenderMode()).toBe('color');
+		expect(image.isVisible()).toBe(true);
+		expect(image.getImage()).toBeUndefined();
+	});
+
+	it('should create with position', () => {
+		const image = createImage(world, { x: 10, y: 5 });
+		const pos = image.getPosition();
+		expect(pos.x).toBe(10);
+		expect(pos.y).toBe(5);
+	});
+
+	it('should create with bitmap', () => {
+		const bitmap = createTestBitmap(4, 4, 255, 0, 0);
+		const image = createImage(world, { bitmap });
+		expect(image.getImage()).toEqual(bitmap);
+	});
+
+	it('should create in overlay mode', () => {
+		const image = createImage(world, { type: 'overlay' });
+		expect(image.getType()).toBe('overlay');
+	});
+
+	it('should create hidden', () => {
+		const image = createImage(world, { visible: false });
+		expect(image.isVisible()).toBe(false);
+	});
+
+	it('should mark entity with Image component tag', () => {
+		const image = createImage(world);
+		expect(Image.isImage[image.eid]).toBe(1);
+	});
+
+	it('should render bitmap on creation in ansi mode', () => {
+		const bitmap = createTestBitmap(2, 2, 255, 0, 0);
+		const image = createImage(world, { bitmap, type: 'ansi' });
+		expect(image.getCellMap()).toBeDefined();
+		const cellMap = image.getCellMap();
+		expect(cellMap?.width).toBe(2);
+		// Color mode: 2 pixels high = 1 row (2 vertical pixels per cell)
+		expect(cellMap?.height).toBe(1);
+	});
+
+	it('should not generate cellMap for overlay mode', () => {
+		const bitmap = createTestBitmap(2, 2, 255, 0, 0);
+		const image = createImage(world, { bitmap, type: 'overlay' });
+		expect(image.getCellMap()).toBeUndefined();
+	});
+});
+
+// =============================================================================
+// VISIBILITY
+// =============================================================================
+
+describe('visibility', () => {
+	it('should show and hide', () => {
+		const image = createImage(world, { visible: false });
+		expect(image.isVisible()).toBe(false);
+
+		image.show();
+		expect(image.isVisible()).toBe(true);
+
+		image.hide();
+		expect(image.isVisible()).toBe(false);
+	});
+
+	it('should return this for chaining', () => {
+		const image = createImage(world);
+		const result = image.show();
+		expect(result).toBe(image);
+		expect(image.hide()).toBe(image);
+	});
+});
+
+// =============================================================================
+// POSITION
+// =============================================================================
+
+describe('position', () => {
+	it('should move by delta', () => {
+		const image = createImage(world, { x: 10, y: 5 });
+		image.move(3, -2);
+		const pos = image.getPosition();
+		expect(pos.x).toBe(13);
+		expect(pos.y).toBe(3);
+	});
+
+	it('should set absolute position', () => {
+		const image = createImage(world, { x: 0, y: 0 });
+		image.setPosition(20, 15);
+		const pos = image.getPosition();
+		expect(pos.x).toBe(20);
+		expect(pos.y).toBe(15);
+	});
+
+	it('should return this for chaining', () => {
+		const image = createImage(world);
+		expect(image.move(1, 1)).toBe(image);
+		expect(image.setPosition(0, 0)).toBe(image);
+	});
+});
+
+// =============================================================================
+// IMAGE DATA
+// =============================================================================
+
+describe('image data', () => {
+	it('should set and get bitmap', () => {
+		const image = createImage(world);
+		const bitmap = createTestBitmap(4, 4, 0, 255, 0);
+
+		image.setImage(bitmap);
+		expect(image.getImage()).toEqual(bitmap);
+	});
+
+	it('should re-render on setImage', () => {
+		const image = createImage(world);
+
+		const bitmap1 = createTestBitmap(2, 2, 255, 0, 0);
+		image.setImage(bitmap1);
+		const cellMap1 = image.getCellMap();
+		expect(cellMap1).toBeDefined();
+
+		const bitmap2 = createTestBitmap(4, 4, 0, 0, 255);
+		image.setImage(bitmap2);
+		const cellMap2 = image.getCellMap();
+		expect(cellMap2).toBeDefined();
+		expect(cellMap2?.width).toBe(4);
+	});
+
+	it('should return this for chaining on setImage', () => {
+		const image = createImage(world);
+		const bitmap = createTestBitmap(2, 2, 0, 0, 0);
+		expect(image.setImage(bitmap)).toBe(image);
+	});
+});
+
+// =============================================================================
+// RENDER OPTIONS
+// =============================================================================
+
+describe('render options', () => {
+	it('should change render mode', () => {
+		const bitmap = createTestBitmap(4, 4, 128, 128, 128);
+		const image = createImage(world, { bitmap, renderMode: 'color' });
+
+		image.setRenderMode('ascii');
+		expect(image.getRenderMode()).toBe('ascii');
+		// ASCII mode: one cell per pixel (not half-block)
+		const cellMap = image.getCellMap();
+		expect(cellMap?.height).toBe(4);
+	});
+
+	it('should change to braille mode', () => {
+		const bitmap = createTestBitmap(4, 8, 255, 255, 255);
+		const image = createImage(world, { bitmap, renderMode: 'color' });
+
+		image.setRenderMode('braille');
+		expect(image.getRenderMode()).toBe('braille');
+		// Braille: 2 pixels wide per cell, 4 pixels tall per cell
+		const cellMap = image.getCellMap();
+		expect(cellMap?.width).toBe(2); // 4 / 2
+		expect(cellMap?.height).toBe(2); // 8 / 4
+	});
+
+	it('should return this for chaining on setRenderMode', () => {
+		const image = createImage(world);
+		expect(image.setRenderMode('ascii')).toBe(image);
+	});
+});
+
+// =============================================================================
+// RENDER OUTPUT
+// =============================================================================
+
+describe('render', () => {
+	it('should return empty string without bitmap', () => {
+		const image = createImage(world);
+		expect(image.render()).toBe('');
+	});
+
+	it('should return ANSI string for color mode', () => {
+		const bitmap = createTestBitmap(2, 2, 255, 0, 0);
+		const image = createImage(world, { bitmap, renderMode: 'color' });
+
+		const output = image.render();
+		expect(output).toContain('\x1b['); // Contains escape sequences
+		expect(output).toContain('\x1b[0m'); // Ends with reset
+	});
+
+	it('should return ASCII characters for ascii mode', () => {
+		const bitmap = createTestBitmap(2, 2, 255, 255, 255);
+		const image = createImage(world, { bitmap, renderMode: 'ascii' });
+
+		const output = image.render();
+		expect(output).toContain('\x1b['); // Still has color sequences
+		// White pixels should map to bright ASCII char '@'
+		expect(output).toContain('@');
+	});
+
+	it('should return braille characters for braille mode', () => {
+		const bitmap = createTestBitmap(2, 4, 255, 255, 255);
+		const image = createImage(world, { bitmap, renderMode: 'braille' });
+
+		const output = image.render();
+		// Braille characters are in U+2800-U+28FF range
+		const hasBraille = /[\u2800-\u28FF]/.test(output);
+		expect(hasBraille).toBe(true);
+	});
+});
+
+// =============================================================================
+// LIFECYCLE
+// =============================================================================
+
+describe('destroy', () => {
+	it('should clean up all stores', () => {
+		const bitmap = createTestBitmap(2, 2, 255, 0, 0);
+		const image = createImage(world, { bitmap });
+		const eid = image.eid;
+
+		expect(Image.isImage[eid]).toBe(1);
+		expect(getImageBitmap(eid)).toBeDefined();
+		expect(getImageCellMap(eid)).toBeDefined();
+
+		image.destroy();
+
+		expect(Image.isImage[eid]).toBe(0);
+		expect(getImageBitmap(eid)).toBeUndefined();
+		expect(getImageCellMap(eid)).toBeUndefined();
+	});
+});
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+describe('isImage', () => {
+	it('should return true for image widgets', () => {
+		const image = createImage(world);
+		expect(isImage(world, image.eid)).toBe(true);
+	});
+
+	it('should return false for non-image entities', () => {
+		const eid = addEntity(world);
+		expect(isImage(world, eid)).toBe(false);
+	});
+});
+
+describe('getImageBitmap', () => {
+	it('should return bitmap for image entity', () => {
+		const bitmap = createTestBitmap(3, 3, 0, 255, 0);
+		const image = createImage(world, { bitmap });
+		expect(getImageBitmap(image.eid)).toEqual(bitmap);
+	});
+
+	it('should return undefined for entity without bitmap', () => {
+		const image = createImage(world);
+		expect(getImageBitmap(image.eid)).toBeUndefined();
+	});
+});
+
+describe('getImageCellMap', () => {
+	it('should return cellMap after render', () => {
+		const bitmap = createTestBitmap(4, 2, 128, 128, 128);
+		const image = createImage(world, { bitmap });
+		const cellMap = getImageCellMap(image.eid);
+		expect(cellMap).toBeDefined();
+		expect(cellMap?.width).toBe(4);
+	});
+
+	it('should return undefined without bitmap', () => {
+		const image = createImage(world);
+		expect(getImageCellMap(image.eid)).toBeUndefined();
+	});
+});
+
+// =============================================================================
+// CHAINING
+// =============================================================================
+
+describe('chaining', () => {
+	it('should support full method chaining', () => {
+		const bitmap = createTestBitmap(2, 2, 255, 0, 0);
+		const image = createImage(world, { bitmap });
+
+		const result = image.setPosition(10, 5).setRenderMode('ascii').move(1, 1).show().hide().show();
+
+		expect(result).toBe(image);
+		expect(image.getPosition()).toEqual({ x: 11, y: 6 });
+		expect(image.getRenderMode()).toBe('ascii');
+		expect(image.isVisible()).toBe(true);
+	});
+});
+
+// =============================================================================
+// MULTIPLE IMAGES
+// =============================================================================
+
+describe('multiple images', () => {
+	it('should support independent image widgets', () => {
+		const red = createTestBitmap(2, 2, 255, 0, 0);
+		const green = createTestBitmap(2, 2, 0, 255, 0);
+
+		const image1 = createImage(world, { bitmap: red, x: 0, y: 0 });
+		const image2 = createImage(world, { bitmap: green, x: 10, y: 5 });
+
+		expect(image1.eid).not.toBe(image2.eid);
+		expect(image1.getPosition()).toEqual({ x: 0, y: 0 });
+		expect(image2.getPosition()).toEqual({ x: 10, y: 5 });
+
+		// Destroying one should not affect the other
+		image1.destroy();
+		expect(isImage(world, image1.eid)).toBe(false);
+		expect(isImage(world, image2.eid)).toBe(true);
+		expect(getImageBitmap(image2.eid)).toEqual(green);
+	});
+});

--- a/src/widgets/image.ts
+++ b/src/widgets/image.ts
@@ -1,0 +1,488 @@
+/**
+ * Image Widget
+ *
+ * Factory widget that renders bitmap images in the terminal.
+ * Supports ANSI rendering (256-color, ASCII, braille) and an overlay mode
+ * for external image protocols (w3m, iTerm2, Kitty, Sixel).
+ *
+ * @module widgets/image
+ */
+
+import { z } from 'zod';
+import { setContent } from '../components/content';
+import { setDimensions } from '../components/dimensions';
+import { Position, setPosition } from '../components/position';
+import { markDirty, setVisible } from '../components/renderable';
+import { addEntity, removeEntity } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+import type { Bitmap, CellMap, RenderMode } from '../media/render/ansi';
+import { cellMapToString, renderToAnsi } from '../media/render/ansi';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Image rendering type.
+ * - 'ansi': Renders bitmap as ANSI escape sequences using 256-color palette
+ * - 'overlay': Stores bitmap for external overlay protocols (w3m, iTerm2, Kitty, Sixel)
+ */
+export type ImageType = 'ansi' | 'overlay';
+
+/**
+ * Configuration for creating an Image widget.
+ *
+ * @example
+ * ```typescript
+ * import type { ImageConfig } from 'blecsd';
+ *
+ * const config: ImageConfig = {
+ *   x: 10,
+ *   y: 5,
+ *   width: 40,
+ *   height: 20,
+ *   type: 'ansi',
+ *   renderMode: 'color',
+ * };
+ * ```
+ */
+export interface ImageConfig {
+	/** X position */
+	readonly x?: number;
+	/** Y position */
+	readonly y?: number;
+	/** Width in terminal columns */
+	readonly width?: number;
+	/** Height in terminal rows */
+	readonly height?: number;
+	/** Image rendering type (default: 'ansi') */
+	readonly type?: ImageType;
+	/** Initial bitmap data to render */
+	readonly bitmap?: Bitmap;
+	/** ANSI render mode (default: 'color'). Only used when type is 'ansi'. */
+	readonly renderMode?: RenderMode;
+	/** Enable dithering for ANSI color mode (default: false) */
+	readonly dither?: boolean;
+	/** Whether to show initially (default: true) */
+	readonly visible?: boolean;
+}
+
+/**
+ * Image widget interface providing chainable methods.
+ *
+ * @example
+ * ```typescript
+ * import { createImage } from 'blecsd';
+ *
+ * const image = createImage(world, {
+ *   x: 0, y: 0, width: 40, height: 20,
+ * });
+ * image.setImage(bitmap).show();
+ * ```
+ */
+export interface ImageWidget {
+	/** The underlying entity ID */
+	readonly eid: Entity;
+
+	// Visibility
+	/** Shows the image */
+	show(): ImageWidget;
+	/** Hides the image */
+	hide(): ImageWidget;
+	/** Checks if visible */
+	isVisible(): boolean;
+
+	// Position
+	/** Moves the image by dx, dy */
+	move(dx: number, dy: number): ImageWidget;
+	/** Sets the absolute position */
+	setPosition(x: number, y: number): ImageWidget;
+	/** Gets current position */
+	getPosition(): { x: number; y: number };
+
+	// Image data
+	/** Sets the bitmap to render */
+	setImage(bitmap: Bitmap): ImageWidget;
+	/** Gets the current bitmap data */
+	getImage(): Bitmap | undefined;
+	/** Gets the image rendering type */
+	getType(): ImageType;
+	/** Gets the last rendered CellMap (ANSI mode only) */
+	getCellMap(): CellMap | undefined;
+
+	// Render options
+	/** Sets the ANSI render mode */
+	setRenderMode(mode: RenderMode): ImageWidget;
+	/** Gets the current render mode */
+	getRenderMode(): RenderMode;
+	/** Renders the current bitmap to an ANSI string */
+	render(): string;
+
+	// Lifecycle
+	/** Destroys the image widget */
+	destroy(): void;
+}
+
+// =============================================================================
+// ZOD SCHEMAS
+// =============================================================================
+
+/**
+ * Zod schema for image widget configuration.
+ *
+ * @example
+ * ```typescript
+ * import { ImageConfigSchema } from 'blecsd';
+ *
+ * const result = ImageConfigSchema.safeParse({ type: 'ansi', width: 40 });
+ * ```
+ */
+export const ImageConfigSchema = z.object({
+	x: z.number().int().default(0),
+	y: z.number().int().default(0),
+	width: z.number().int().positive().optional(),
+	height: z.number().int().positive().optional(),
+	type: z.enum(['ansi', 'overlay']).default('ansi'),
+	bitmap: z
+		.object({
+			width: z.number().int().nonnegative(),
+			height: z.number().int().nonnegative(),
+			data: z.instanceof(Uint8Array),
+		})
+		.optional(),
+	renderMode: z.enum(['color', 'ascii', 'braille']).default('color'),
+	dither: z.boolean().default(false),
+	visible: z.boolean().default(true),
+});
+
+// =============================================================================
+// COMPONENT TAG
+// =============================================================================
+
+/** Default entity capacity for typed arrays */
+const DEFAULT_CAPACITY = 10000;
+
+/**
+ * Image component marker for identifying image entities.
+ */
+export const Image = {
+	/** Tag indicating this is an image widget (1 = yes) */
+	isImage: new Uint8Array(DEFAULT_CAPACITY),
+};
+
+// =============================================================================
+// INTERNAL STATE
+// =============================================================================
+
+/** Maps entity IDs to their bitmap data */
+const imageBitmapStore = new Map<Entity, Bitmap>();
+
+/** Maps entity IDs to their image type */
+const imageTypeStore = new Map<Entity, ImageType>();
+
+/** Maps entity IDs to their render mode */
+const imageRenderModeStore = new Map<Entity, RenderMode>();
+
+/** Maps entity IDs to their dither setting */
+const imageDitherStore = new Map<Entity, boolean>();
+
+/** Maps entity IDs to their last rendered CellMap */
+const imageCellMapStore = new Map<Entity, CellMap>();
+
+/** Maps entity IDs to their visibility state */
+const imageVisibleStore = new Map<Entity, boolean>();
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+/**
+ * Renders the stored bitmap for an entity and updates its content.
+ */
+function renderImageContent(world: World, eid: Entity): void {
+	const bitmap = imageBitmapStore.get(eid);
+	if (!bitmap) {
+		setContent(world, eid, '');
+		imageCellMapStore.delete(eid);
+		return;
+	}
+
+	const imageType = imageTypeStore.get(eid) ?? 'ansi';
+	if (imageType !== 'ansi') {
+		// Overlay mode: content is empty, bitmap is stored for external rendering
+		setContent(world, eid, '');
+		return;
+	}
+
+	const mode = imageRenderModeStore.get(eid) ?? 'color';
+	const dither = imageDitherStore.get(eid) ?? false;
+
+	const cellMap = renderToAnsi(bitmap, {
+		width: undefined,
+		height: undefined,
+		mode,
+		dither,
+	});
+	imageCellMapStore.set(eid, cellMap);
+
+	const content = cellMapToString(cellMap);
+	setContent(world, eid, content);
+}
+
+// =============================================================================
+// FACTORY FUNCTION
+// =============================================================================
+
+/**
+ * Creates an Image widget.
+ *
+ * The Image widget renders bitmap data in the terminal using either ANSI escape
+ * sequences (for 256-color, ASCII art, or braille output) or stores the bitmap
+ * for external overlay protocols.
+ *
+ * @param world - The ECS world
+ * @param config - Image configuration
+ * @returns ImageWidget interface
+ *
+ * @example
+ * ```typescript
+ * import { createImage } from 'blecsd';
+ *
+ * // Create a 2x2 red image in ANSI mode
+ * const bitmap = {
+ *   width: 2,
+ *   height: 2,
+ *   data: new Uint8Array([
+ *     255, 0, 0, 255,  255, 0, 0, 255,
+ *     255, 0, 0, 255,  255, 0, 0, 255,
+ *   ]),
+ * };
+ *
+ * const image = createImage(world, {
+ *   x: 5,
+ *   y: 2,
+ *   type: 'ansi',
+ *   renderMode: 'color',
+ *   bitmap,
+ * });
+ *
+ * // Get the rendered ANSI string
+ * const output = image.render();
+ * ```
+ */
+export function createImage(world: World, config: ImageConfig = {}): ImageWidget {
+	const parsed = ImageConfigSchema.parse(config);
+
+	const eid = addEntity(world);
+
+	// Set position
+	setPosition(world, eid, parsed.x, parsed.y);
+
+	// Set dimensions
+	const width = parsed.width ?? parsed.bitmap?.width ?? 0;
+	const height = parsed.height ?? parsed.bitmap?.height ?? 0;
+	setDimensions(world, eid, width, height);
+
+	// Mark as image
+	Image.isImage[eid] = 1;
+
+	// Store state
+	imageTypeStore.set(eid, parsed.type);
+	imageRenderModeStore.set(eid, parsed.renderMode);
+	imageDitherStore.set(eid, parsed.dither);
+	imageVisibleStore.set(eid, parsed.visible);
+
+	// Store and render bitmap if provided
+	if (parsed.bitmap) {
+		imageBitmapStore.set(eid, parsed.bitmap);
+		renderImageContent(world, eid);
+	}
+
+	// Set visibility
+	if (!parsed.visible) {
+		setVisible(world, eid, false);
+	}
+
+	return createImageWidgetInterface(world, eid);
+}
+
+/**
+ * Creates the ImageWidget interface for an entity.
+ */
+function createImageWidgetInterface(world: World, eid: Entity): ImageWidget {
+	return {
+		get eid() {
+			return eid;
+		},
+
+		show() {
+			imageVisibleStore.set(eid, true);
+			setVisible(world, eid, true);
+			markDirty(world, eid);
+			return this;
+		},
+
+		hide() {
+			imageVisibleStore.set(eid, false);
+			setVisible(world, eid, false);
+			markDirty(world, eid);
+			return this;
+		},
+
+		isVisible() {
+			return imageVisibleStore.get(eid) ?? false;
+		},
+
+		move(dx: number, dy: number) {
+			const x = Position.x[eid] ?? 0;
+			const y = Position.y[eid] ?? 0;
+			setPosition(world, eid, x + dx, y + dy);
+			markDirty(world, eid);
+			return this;
+		},
+
+		setPosition(x: number, y: number) {
+			setPosition(world, eid, x, y);
+			markDirty(world, eid);
+			return this;
+		},
+
+		getPosition() {
+			return {
+				x: Position.x[eid] ?? 0,
+				y: Position.y[eid] ?? 0,
+			};
+		},
+
+		setImage(bitmap: Bitmap) {
+			imageBitmapStore.set(eid, bitmap);
+			renderImageContent(world, eid);
+			markDirty(world, eid);
+			return this;
+		},
+
+		getImage() {
+			return imageBitmapStore.get(eid);
+		},
+
+		getType() {
+			return imageTypeStore.get(eid) ?? 'ansi';
+		},
+
+		getCellMap() {
+			return imageCellMapStore.get(eid);
+		},
+
+		setRenderMode(mode: RenderMode) {
+			imageRenderModeStore.set(eid, mode);
+			renderImageContent(world, eid);
+			markDirty(world, eid);
+			return this;
+		},
+
+		getRenderMode() {
+			return imageRenderModeStore.get(eid) ?? 'color';
+		},
+
+		render() {
+			const bitmap = imageBitmapStore.get(eid);
+			if (!bitmap) return '';
+
+			const mode = imageRenderModeStore.get(eid) ?? 'color';
+			const dither = imageDitherStore.get(eid) ?? false;
+
+			const cellMap = renderToAnsi(bitmap, { mode, dither });
+			return cellMapToString(cellMap);
+		},
+
+		destroy() {
+			Image.isImage[eid] = 0;
+			imageBitmapStore.delete(eid);
+			imageTypeStore.delete(eid);
+			imageRenderModeStore.delete(eid);
+			imageDitherStore.delete(eid);
+			imageCellMapStore.delete(eid);
+			imageVisibleStore.delete(eid);
+			removeEntity(world, eid);
+		},
+	};
+}
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+/**
+ * Checks if an entity is an image widget.
+ *
+ * @param _world - The ECS world (unused, for API consistency)
+ * @param eid - Entity ID
+ * @returns true if entity is an image widget
+ *
+ * @example
+ * ```typescript
+ * import { isImage } from 'blecsd';
+ *
+ * if (isImage(world, entity)) {
+ *   // Handle image-specific logic
+ * }
+ * ```
+ */
+export function isImage(_world: World, eid: Entity): boolean {
+	return Image.isImage[eid] === 1;
+}
+
+/**
+ * Gets the bitmap stored for an image entity.
+ *
+ * @param eid - Entity ID
+ * @returns The stored bitmap, or undefined
+ *
+ * @example
+ * ```typescript
+ * import { getImageBitmap } from 'blecsd';
+ *
+ * const bitmap = getImageBitmap(imageEntity);
+ * if (bitmap) {
+ *   console.log(`Image: ${bitmap.width}x${bitmap.height}`);
+ * }
+ * ```
+ */
+export function getImageBitmap(eid: Entity): Bitmap | undefined {
+	return imageBitmapStore.get(eid);
+}
+
+/**
+ * Gets the last rendered CellMap for an image entity.
+ *
+ * @param eid - Entity ID
+ * @returns The cached CellMap, or undefined
+ *
+ * @example
+ * ```typescript
+ * import { getImageCellMap } from 'blecsd';
+ *
+ * const cellMap = getImageCellMap(imageEntity);
+ * if (cellMap) {
+ *   console.log(`Cells: ${cellMap.width}x${cellMap.height}`);
+ * }
+ * ```
+ */
+export function getImageCellMap(eid: Entity): CellMap | undefined {
+	return imageCellMapStore.get(eid);
+}
+
+/**
+ * Resets all image widget stores. Useful for testing.
+ *
+ * @internal
+ */
+export function resetImageStore(): void {
+	Image.isImage.fill(0);
+	imageBitmapStore.clear();
+	imageTypeStore.clear();
+	imageRenderModeStore.clear();
+	imageDitherStore.clear();
+	imageCellMapStore.clear();
+	imageVisibleStore.clear();
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -120,6 +120,17 @@ export {
 	resetHoverTextStore,
 	setHoverText,
 } from './hoverText';
+// Image widget
+export type { ImageConfig, ImageType, ImageWidget } from './image';
+export {
+	createImage,
+	getImageBitmap,
+	getImageCellMap,
+	Image,
+	ImageConfigSchema,
+	isImage,
+	resetImageStore,
+} from './image';
 // Layout widget
 export type {
 	AlignItems,


### PR DESCRIPTION
## Summary
- Adds `createImage()` factory widget for rendering bitmap data in the terminal
- Supports two rendering types: `'ansi'` (256-color, ASCII art, braille via `renderToAnsi`) and `'overlay'` (stores bitmap for external protocols like w3m, iTerm2, Kitty, Sixel)
- Provides chainable API with `setImage()`, `setRenderMode()`, `render()`, `show()`/`hide()`, position methods, and `destroy()`
- Follows established widget factory pattern with Zod schema validation, Map-based stores, and ECS entity tagging

## Test plan
- [x] 39 unit tests covering schema validation, factory creation, visibility, position, image data, render modes, ANSI/ASCII/braille output, lifecycle/destroy, chaining, and multi-instance independence
- [x] All 8797 tests pass
- [x] Lint clean (no new warnings)
- [x] TypeScript strict mode passes
- [x] Build succeeds

Closes #713