### PR TITLE
feat(terminal): add sixel graphics backend (#788)

### DIFF
--- a/src/terminal/graphics/index.ts
+++ b/src/terminal/graphics/index.ts
@@ -49,3 +49,31 @@ export {
 	ST,
 	ST_ALT,
 } from './iterm2';
+
+// Sixel backend
+export type { SixelBackendConfig, SixelEnvChecker } from './sixel';
+export {
+	buildPalette,
+	buildPaletteHeader,
+	buildSixelColumn,
+	bytesPerPixel,
+	clearSixelImage,
+	countImageColors,
+	createSixelGraphicsBackend,
+	cursorPosition as sixelCursorPosition,
+	DCS_START,
+	DEFAULT_MAX_COLORS,
+	encodeSixelData,
+	encodeSixelImage,
+	findNearestColor,
+	getPixelRGBA,
+	isSixelSupported,
+	mapPixelsToPalette,
+	packRGB,
+	rawEncodeBand,
+	renderSixelImage,
+	rleEncodeBand,
+	SIXEL_BACKEND_NAME,
+	SIXEL_ST,
+	SixelBackendConfigSchema,
+} from './sixel';

--- a/src/terminal/graphics/sixel.test.ts
+++ b/src/terminal/graphics/sixel.test.ts
@@ -1,0 +1,646 @@
+import { describe, expect, it } from 'vitest';
+import type { SixelEnvChecker } from './sixel';
+import {
+	buildPalette,
+	buildPaletteHeader,
+	buildSixelColumn,
+	bytesPerPixel,
+	clearSixelImage,
+	countImageColors,
+	createSixelGraphicsBackend,
+	cursorPosition,
+	DCS_START,
+	DEFAULT_MAX_COLORS,
+	encodeSixelData,
+	encodeSixelImage,
+	findNearestColor,
+	getPixelRGBA,
+	isSixelSupported,
+	mapPixelsToPalette,
+	packRGB,
+	rawEncodeBand,
+	renderSixelImage,
+	rleEncodeBand,
+	SIXEL_BACKEND_NAME,
+	SIXEL_ST,
+	SixelBackendConfigSchema,
+} from './sixel';
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+describe('constants', () => {
+	it('should have correct DCS start', () => {
+		expect(DCS_START).toBe('\x1bPq');
+	});
+
+	it('should have correct string terminator', () => {
+		expect(SIXEL_ST).toBe('\x1b\\');
+	});
+
+	it('should have correct backend name', () => {
+		expect(SIXEL_BACKEND_NAME).toBe('sixel');
+	});
+
+	it('should have correct default max colors', () => {
+		expect(DEFAULT_MAX_COLORS).toBe(256);
+	});
+});
+
+// =============================================================================
+// SCHEMA
+// =============================================================================
+
+describe('SixelBackendConfigSchema', () => {
+	it('should apply defaults', () => {
+		const result = SixelBackendConfigSchema.parse({});
+		expect(result.maxColors).toBe(256);
+		expect(result.rleEnabled).toBe(true);
+	});
+
+	it('should accept valid config', () => {
+		const result = SixelBackendConfigSchema.parse({ maxColors: 64, rleEnabled: false });
+		expect(result.maxColors).toBe(64);
+		expect(result.rleEnabled).toBe(false);
+	});
+
+	it('should reject maxColors > 256', () => {
+		expect(() => SixelBackendConfigSchema.parse({ maxColors: 257 })).toThrow();
+	});
+
+	it('should reject maxColors < 2', () => {
+		expect(() => SixelBackendConfigSchema.parse({ maxColors: 1 })).toThrow();
+	});
+
+	it('should accept boundary values', () => {
+		expect(SixelBackendConfigSchema.parse({ maxColors: 2 }).maxColors).toBe(2);
+		expect(SixelBackendConfigSchema.parse({ maxColors: 256 }).maxColors).toBe(256);
+	});
+});
+
+// =============================================================================
+// PIXEL HELPERS
+// =============================================================================
+
+describe('bytesPerPixel', () => {
+	it('should return 4 for rgba', () => {
+		expect(bytesPerPixel('rgba')).toBe(4);
+	});
+
+	it('should return 3 for rgb', () => {
+		expect(bytesPerPixel('rgb')).toBe(3);
+	});
+
+	it('should return 4 for png', () => {
+		expect(bytesPerPixel('png')).toBe(4);
+	});
+});
+
+describe('getPixelRGBA', () => {
+	it('should extract RGBA from 4-byte data', () => {
+		const data = new Uint8Array([255, 128, 64, 200]);
+		expect(getPixelRGBA(data, 0, 4)).toEqual([255, 128, 64, 200]);
+	});
+
+	it('should extract RGB with alpha=255 from 3-byte data', () => {
+		const data = new Uint8Array([255, 128, 64]);
+		expect(getPixelRGBA(data, 0, 3)).toEqual([255, 128, 64, 255]);
+	});
+
+	it('should handle pixel index offset', () => {
+		const data = new Uint8Array([0, 0, 0, 0, 100, 200, 50, 255]);
+		expect(getPixelRGBA(data, 1, 4)).toEqual([100, 200, 50, 255]);
+	});
+});
+
+describe('packRGB', () => {
+	it('should pack RGB into 24-bit integer', () => {
+		expect(packRGB(255, 0, 0)).toBe(0xff0000);
+		expect(packRGB(0, 255, 0)).toBe(0x00ff00);
+		expect(packRGB(0, 0, 255)).toBe(0x0000ff);
+		expect(packRGB(255, 255, 255)).toBe(0xffffff);
+		expect(packRGB(0, 0, 0)).toBe(0);
+	});
+});
+
+// =============================================================================
+// COLOR QUANTIZATION
+// =============================================================================
+
+describe('countImageColors', () => {
+	it('should count unique colors', () => {
+		// 2 red pixels, 1 green pixel (RGBA)
+		const data = new Uint8Array([255, 0, 0, 255, 255, 0, 0, 255, 0, 255, 0, 255]);
+		const counts = countImageColors(data, 3, 4);
+		expect(counts.size).toBe(2);
+		expect(counts.get(packRGB(255, 0, 0))).toBe(2);
+		expect(counts.get(packRGB(0, 255, 0))).toBe(1);
+	});
+
+	it('should skip transparent pixels', () => {
+		const data = new Uint8Array([
+			255,
+			0,
+			0,
+			255,
+			0,
+			255,
+			0,
+			0, // transparent
+		]);
+		const counts = countImageColors(data, 2, 4);
+		expect(counts.size).toBe(1);
+	});
+
+	it('should handle RGB format', () => {
+		const data = new Uint8Array([255, 0, 0, 0, 255, 0]);
+		const counts = countImageColors(data, 2, 3);
+		expect(counts.size).toBe(2);
+	});
+
+	it('should handle empty image', () => {
+		const counts = countImageColors(new Uint8Array([]), 0, 4);
+		expect(counts.size).toBe(0);
+	});
+});
+
+describe('buildPalette', () => {
+	it('should sort by popularity', () => {
+		const counts = new Map<number, number>();
+		counts.set(packRGB(0, 255, 0), 10); // green: most popular
+		counts.set(packRGB(255, 0, 0), 5); // red: second
+		counts.set(packRGB(0, 0, 255), 1); // blue: least
+
+		const { paletteFlat, paletteCount } = buildPalette(counts, 256);
+		expect(paletteCount).toBe(3);
+		// First entry should be green (most popular)
+		expect(paletteFlat[0]).toBe(0);
+		expect(paletteFlat[1]).toBe(255);
+		expect(paletteFlat[2]).toBe(0);
+	});
+
+	it('should limit to maxColors', () => {
+		const counts = new Map<number, number>();
+		counts.set(packRGB(255, 0, 0), 10);
+		counts.set(packRGB(0, 255, 0), 5);
+		counts.set(packRGB(0, 0, 255), 1);
+
+		const { paletteCount } = buildPalette(counts, 2);
+		expect(paletteCount).toBe(2);
+	});
+
+	it('should return at least 1 entry for empty counts', () => {
+		const { paletteCount } = buildPalette(new Map(), 256);
+		expect(paletteCount).toBe(1);
+	});
+});
+
+describe('findNearestColor', () => {
+	it('should find exact color match', () => {
+		const palette = new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255]);
+		expect(findNearestColor(0, 255, 0, palette, 3)).toBe(1);
+	});
+
+	it('should find nearest approximate color', () => {
+		const palette = new Uint8Array([255, 0, 0, 0, 0, 255]);
+		// (200, 50, 50) is closer to red than blue
+		expect(findNearestColor(200, 50, 50, palette, 2)).toBe(0);
+	});
+
+	it('should return 0 for single-entry palette', () => {
+		const palette = new Uint8Array([128, 128, 128]);
+		expect(findNearestColor(0, 0, 0, palette, 1)).toBe(0);
+	});
+});
+
+describe('mapPixelsToPalette', () => {
+	it('should map pixels to nearest palette indices', () => {
+		const data = new Uint8Array([
+			255,
+			0,
+			0,
+			255, // red
+			0,
+			255,
+			0,
+			255, // green
+		]);
+		const palette = new Uint8Array([255, 0, 0, 0, 255, 0]);
+		const indexMap = mapPixelsToPalette(data, 2, 4, palette, 2);
+		expect(indexMap[0]).toBe(0); // red -> palette[0]
+		expect(indexMap[1]).toBe(1); // green -> palette[1]
+	});
+
+	it('should map transparent pixels to index 0', () => {
+		const data = new Uint8Array([0, 0, 0, 0]);
+		const palette = new Uint8Array([255, 0, 0]);
+		const indexMap = mapPixelsToPalette(data, 1, 4, palette, 1);
+		expect(indexMap[0]).toBe(0);
+	});
+});
+
+// =============================================================================
+// SIXEL ENCODING
+// =============================================================================
+
+describe('buildPaletteHeader', () => {
+	it('should format palette as sixel color registers', () => {
+		const palette = new Uint8Array([255, 0, 0, 0, 255, 0]);
+		const header = buildPaletteHeader(palette, 2);
+		expect(header).toContain('#0;2;100;0;0'); // red = 100%
+		expect(header).toContain('#1;2;0;100;0'); // green = 100%
+	});
+
+	it('should round percentages correctly', () => {
+		const palette = new Uint8Array([128, 128, 128]);
+		const header = buildPaletteHeader(palette, 1);
+		// 128/255 * 100 = 50.2 -> rounds to 50
+		expect(header).toContain('#0;2;50;50;50');
+	});
+});
+
+describe('buildSixelColumn', () => {
+	it('should set bits for matching color rows', () => {
+		// 3x6 image, color 0 in rows 0 and 2
+		const indexMap = new Uint8Array([
+			0,
+			1,
+			2, // row 0
+			1,
+			1,
+			1, // row 1
+			0,
+			0,
+			0, // row 2
+			1,
+			1,
+			1, // row 3
+			1,
+			1,
+			1, // row 4
+			1,
+			1,
+			1, // row 5
+		]);
+		// Column 0, color 0: rows 0 and 2 match -> bits 0 and 2 -> 0b000101 = 5
+		expect(buildSixelColumn(indexMap, 0, 0, 6, 3, 0)).toBe(5);
+	});
+
+	it('should handle partial bands', () => {
+		const indexMap = new Uint8Array([0, 0, 0]); // 1 row of 3 pixels
+		expect(buildSixelColumn(indexMap, 0, 0, 1, 3, 0)).toBe(1); // only bit 0
+	});
+
+	it('should return 0 when no rows match', () => {
+		const indexMap = new Uint8Array([1, 1, 1, 1, 1, 1]);
+		expect(buildSixelColumn(indexMap, 0, 0, 6, 1, 0)).toBe(0);
+	});
+
+	it('should return 63 when all 6 rows match', () => {
+		const indexMap = new Uint8Array([0, 0, 0, 0, 0, 0]);
+		expect(buildSixelColumn(indexMap, 0, 0, 6, 1, 0)).toBe(63);
+	});
+});
+
+describe('rleEncodeBand', () => {
+	it('should RLE compress runs of 3+', () => {
+		const values = new Uint8Array([5, 5, 5, 5, 5]);
+		const { encoded, hasPixels } = rleEncodeBand(values, 5);
+		expect(encoded).toBe('!5D'); // 63+5=68='D', 5 repetitions
+		expect(hasPixels).toBe(true);
+	});
+
+	it('should not RLE runs of 1-2', () => {
+		const values = new Uint8Array([5, 5, 3]);
+		const { encoded } = rleEncodeBand(values, 3);
+		expect(encoded).toBe('DDB'); // D=68(63+5), B=66(63+3)
+	});
+
+	it('should detect no pixels when all zero', () => {
+		const values = new Uint8Array([0, 0, 0]);
+		const { hasPixels } = rleEncodeBand(values, 3);
+		expect(hasPixels).toBe(false);
+	});
+
+	it('should handle empty band', () => {
+		const { encoded, hasPixels } = rleEncodeBand(new Uint8Array(0), 0);
+		expect(encoded).toBe('');
+		expect(hasPixels).toBe(false);
+	});
+
+	it('should handle mixed runs', () => {
+		const values = new Uint8Array([1, 1, 1, 2, 2, 2, 2]);
+		const { encoded } = rleEncodeBand(values, 7);
+		expect(encoded).toBe('!3@!4A'); // @=64(63+1), A=65(63+2)
+	});
+});
+
+describe('rawEncodeBand', () => {
+	it('should encode without RLE', () => {
+		const values = new Uint8Array([5, 5, 5]);
+		const { encoded, hasPixels } = rawEncodeBand(values, 3);
+		expect(encoded).toBe('DDD');
+		expect(hasPixels).toBe(true);
+	});
+
+	it('should detect no pixels when all zero', () => {
+		const values = new Uint8Array([0, 0]);
+		const { hasPixels } = rawEncodeBand(values, 2);
+		expect(hasPixels).toBe(false);
+	});
+});
+
+describe('encodeSixelData', () => {
+	it('should encode single-color single-band', () => {
+		// 1x6 image, all color 0
+		const indexMap = new Uint8Array([0, 0, 0, 0, 0, 0]);
+		const data = encodeSixelData(indexMap, 1, 1, 6, true);
+		// color 0, all bits set: char 63+63='~', followed by $
+		expect(data).toContain('#0~$');
+	});
+
+	it('should use band separators for multi-band images', () => {
+		// 1x12 image -> 2 bands
+		const indexMap = new Uint8Array(12).fill(0);
+		const data = encodeSixelData(indexMap, 1, 1, 12, true);
+		expect(data).toContain('-');
+	});
+
+	it('should handle multiple colors', () => {
+		// 2x6 image: column 0 = color 0, column 1 = color 1
+		const indexMap = new Uint8Array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]);
+		const data = encodeSixelData(indexMap, 2, 2, 6, true);
+		expect(data).toContain('#0');
+		expect(data).toContain('#1');
+	});
+});
+
+// =============================================================================
+// FULL ENCODING
+// =============================================================================
+
+describe('encodeSixelImage', () => {
+	it('should produce valid DCS sequence', () => {
+		const image = {
+			width: 2,
+			height: 6,
+			data: new Uint8Array([
+				255, 0, 0, 255, 0, 255, 0, 255, 255, 0, 0, 255, 0, 255, 0, 255, 255, 0, 0, 255, 0, 255, 0,
+				255, 255, 0, 0, 255, 0, 255, 0, 255, 255, 0, 0, 255, 0, 255, 0, 255, 255, 0, 0, 255, 0, 255,
+				0, 255,
+			]),
+			format: 'rgba' as const,
+		};
+		const seq = encodeSixelImage(image, 256, true);
+		expect(seq.startsWith(DCS_START)).toBe(true);
+		expect(seq.endsWith(SIXEL_ST)).toBe(true);
+	});
+
+	it('should contain palette header', () => {
+		const image = {
+			width: 1,
+			height: 6,
+			data: new Uint8Array([
+				255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0,
+				255,
+			]),
+			format: 'rgba' as const,
+		};
+		const seq = encodeSixelImage(image, 256, true);
+		expect(seq).toContain('#0;2;100;0;0');
+	});
+
+	it('should handle empty image', () => {
+		const image = { width: 0, height: 0, data: new Uint8Array([]), format: 'rgba' as const };
+		const seq = encodeSixelImage(image, 256, true);
+		expect(seq).toBe(`${DCS_START}${SIXEL_ST}`);
+	});
+
+	it('should handle RGB format', () => {
+		const image = {
+			width: 1,
+			height: 6,
+			data: new Uint8Array([255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0, 255, 0, 0]),
+			format: 'rgb' as const,
+		};
+		const seq = encodeSixelImage(image, 256, true);
+		expect(seq.startsWith(DCS_START)).toBe(true);
+		expect(seq.endsWith(SIXEL_ST)).toBe(true);
+		expect(seq).toContain('#0;2;100;0;0');
+	});
+});
+
+// =============================================================================
+// CURSOR POSITIONING
+// =============================================================================
+
+describe('cursorPosition', () => {
+	it('should format CUP sequence (1-based)', () => {
+		expect(cursorPosition(0, 0)).toBe('\x1b[1;1H');
+		expect(cursorPosition(9, 4)).toBe('\x1b[5;10H');
+	});
+
+	it('should handle large positions', () => {
+		expect(cursorPosition(199, 49)).toBe('\x1b[50;200H');
+	});
+});
+
+// =============================================================================
+// DETECTION
+// =============================================================================
+
+describe('isSixelSupported', () => {
+	it('should detect xterm with XTERM_VERSION', () => {
+		const env: SixelEnvChecker = {
+			getEnv: (name: string) => {
+				if (name === 'TERM_PROGRAM') return 'xterm';
+				if (name === 'XTERM_VERSION') return 'XTerm(379)';
+				return undefined;
+			},
+		};
+		expect(isSixelSupported(env)).toBe(true);
+	});
+
+	it('should not detect xterm without XTERM_VERSION', () => {
+		const env: SixelEnvChecker = {
+			getEnv: (name: string) => (name === 'TERM_PROGRAM' ? 'xterm' : undefined),
+		};
+		expect(isSixelSupported(env)).toBe(false);
+	});
+
+	it('should detect mlterm via TERM_PROGRAM', () => {
+		const env: SixelEnvChecker = {
+			getEnv: (name: string) => (name === 'TERM_PROGRAM' ? 'mlterm' : undefined),
+		};
+		expect(isSixelSupported(env)).toBe(true);
+	});
+
+	it('should detect foot terminal', () => {
+		const env: SixelEnvChecker = {
+			getEnv: (name: string) => (name === 'TERM_PROGRAM' ? 'foot' : undefined),
+		};
+		expect(isSixelSupported(env)).toBe(true);
+	});
+
+	it('should detect contour terminal', () => {
+		const env: SixelEnvChecker = {
+			getEnv: (name: string) => (name === 'TERM_PROGRAM' ? 'contour' : undefined),
+		};
+		expect(isSixelSupported(env)).toBe(true);
+	});
+
+	it('should detect WezTerm', () => {
+		const env: SixelEnvChecker = {
+			getEnv: (name: string) => (name === 'TERM_PROGRAM' ? 'WezTerm' : undefined),
+		};
+		expect(isSixelSupported(env)).toBe(true);
+	});
+
+	it('should detect via TERM containing sixel', () => {
+		const env: SixelEnvChecker = {
+			getEnv: (name: string) => (name === 'TERM' ? 'xterm-sixel' : undefined),
+		};
+		expect(isSixelSupported(env)).toBe(true);
+	});
+
+	it('should detect mlterm via TERM', () => {
+		const env: SixelEnvChecker = {
+			getEnv: (name: string) => (name === 'TERM' ? 'mlterm' : undefined),
+		};
+		expect(isSixelSupported(env)).toBe(true);
+	});
+
+	it('should return false for unknown terminal', () => {
+		const env: SixelEnvChecker = { getEnv: () => undefined };
+		expect(isSixelSupported(env)).toBe(false);
+	});
+
+	it('should return false for iTerm2', () => {
+		const env: SixelEnvChecker = {
+			getEnv: (name: string) => (name === 'TERM_PROGRAM' ? 'iTerm.app' : undefined),
+		};
+		expect(isSixelSupported(env)).toBe(false);
+	});
+});
+
+// =============================================================================
+// RENDER
+// =============================================================================
+
+describe('renderSixelImage', () => {
+	it('should include cursor positioning', () => {
+		const image = {
+			width: 1,
+			height: 6,
+			data: new Uint8Array([
+				255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0,
+				255,
+			]),
+			format: 'rgba' as const,
+		};
+		const output = renderSixelImage(image, { x: 5, y: 3 }, 256, true);
+		expect(output.startsWith('\x1b[4;6H')).toBe(true);
+	});
+
+	it('should include sixel sequence', () => {
+		const image = {
+			width: 1,
+			height: 6,
+			data: new Uint8Array([
+				255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0,
+				255,
+			]),
+			format: 'rgba' as const,
+		};
+		const output = renderSixelImage(image, { x: 0, y: 0 }, 256, true);
+		expect(output).toContain(DCS_START);
+		expect(output).toContain(SIXEL_ST);
+	});
+});
+
+// =============================================================================
+// CLEAR
+// =============================================================================
+
+describe('clearSixelImage', () => {
+	it('should return empty string without options', () => {
+		expect(clearSixelImage()).toBe('');
+	});
+
+	it('should generate space-fill for area', () => {
+		const output = clearSixelImage({ x: 0, y: 0, width: 3, height: 2 });
+		expect(output).toContain('\x1b[1;1H   ');
+		expect(output).toContain('\x1b[2;1H   ');
+	});
+});
+
+// =============================================================================
+// BACKEND FACTORY
+// =============================================================================
+
+describe('createSixelGraphicsBackend', () => {
+	it('should create backend with correct name', () => {
+		const backend = createSixelGraphicsBackend();
+		expect(backend.name).toBe('sixel');
+	});
+
+	it('should have correct capabilities', () => {
+		const backend = createSixelGraphicsBackend();
+		expect(backend.capabilities.staticImages).toBe(true);
+		expect(backend.capabilities.animation).toBe(false);
+		expect(backend.capabilities.alphaChannel).toBe(false);
+		expect(backend.capabilities.maxWidth).toBeNull();
+		expect(backend.capabilities.maxHeight).toBeNull();
+	});
+
+	it('should detect support using env checker', () => {
+		const footEnv: SixelEnvChecker = {
+			getEnv: (name: string) => (name === 'TERM_PROGRAM' ? 'foot' : undefined),
+		};
+		const backend = createSixelGraphicsBackend(undefined, footEnv);
+		expect(backend.isSupported()).toBe(true);
+
+		const unknownEnv: SixelEnvChecker = { getEnv: () => undefined };
+		const unsupported = createSixelGraphicsBackend(undefined, unknownEnv);
+		expect(unsupported.isSupported()).toBe(false);
+	});
+
+	it('should render images', () => {
+		const backend = createSixelGraphicsBackend();
+		const image = {
+			width: 1,
+			height: 6,
+			data: new Uint8Array([
+				255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0,
+				255,
+			]),
+			format: 'rgba' as const,
+		};
+		const output = backend.render(image, { x: 0, y: 0 });
+		expect(output).toContain(DCS_START);
+		expect(output).toContain(SIXEL_ST);
+	});
+
+	it('should return empty string for clear (sixel limitation)', () => {
+		const backend = createSixelGraphicsBackend();
+		expect(backend.clear()).toBe('');
+	});
+
+	it('should accept custom config', () => {
+		const backend = createSixelGraphicsBackend({ maxColors: 16, rleEnabled: false });
+		expect(backend.name).toBe('sixel');
+		// Config is internal, but we can verify it still renders
+		const image = {
+			width: 1,
+			height: 6,
+			data: new Uint8Array([
+				255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0,
+				255,
+			]),
+			format: 'rgba' as const,
+		};
+		const output = backend.render(image, { x: 0, y: 0 });
+		expect(output).toContain(DCS_START);
+	});
+});

--- a/src/terminal/graphics/sixel.ts
+++ b/src/terminal/graphics/sixel.ts
@@ -1,0 +1,642 @@
+/**
+ * Sixel Graphics Backend
+ *
+ * Implements the DEC sixel protocol (DCS q ... ST) for displaying images
+ * in terminals that support sixel graphics. Encodes raw pixel data as
+ * sixel escape sequences with palette quantization and RLE compression.
+ *
+ * Sixel images are encoded in 6-pixel-tall horizontal bands using a
+ * color-indexed palette (up to 256 colors). Each band column is a
+ * single character whose 6 low bits indicate which of the 6 rows
+ * contain a given color.
+ *
+ * @module terminal/graphics/sixel
+ */
+
+import { z } from 'zod';
+import type {
+	BackendName,
+	GraphicsBackend,
+	GraphicsCapabilities,
+	ImageData,
+	RenderOptions,
+} from './backend';
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/**
+ * DCS introducer for sixel sequences.
+ */
+export const DCS_START = '\x1bPq';
+
+/**
+ * String terminator (ST) for DCS sequences.
+ */
+export const SIXEL_ST = '\x1b\\';
+
+/**
+ * Sixel backend name.
+ */
+export const SIXEL_BACKEND_NAME: BackendName = 'sixel';
+
+/**
+ * Default maximum palette size for sixel encoding.
+ */
+export const DEFAULT_MAX_COLORS = 256;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Configuration for the sixel graphics backend.
+ *
+ * @example
+ * ```typescript
+ * import type { SixelBackendConfig } from 'blecsd';
+ *
+ * const config: SixelBackendConfig = { maxColors: 64, rleEnabled: true };
+ * ```
+ */
+export interface SixelBackendConfig {
+	/** Maximum number of palette colors (2-256). Default: 256 */
+	readonly maxColors?: number;
+	/** Enable run-length encoding for compression. Default: true */
+	readonly rleEnabled?: boolean;
+}
+
+/**
+ * Environment checker for sixel detection (injectable for testing).
+ */
+export interface SixelEnvChecker {
+	readonly getEnv: (name: string) => string | undefined;
+}
+
+// =============================================================================
+// ZOD SCHEMAS
+// =============================================================================
+
+/**
+ * Zod schema for SixelBackendConfig.
+ *
+ * @example
+ * ```typescript
+ * import { SixelBackendConfigSchema } from 'blecsd';
+ *
+ * const result = SixelBackendConfigSchema.safeParse({ maxColors: 64 });
+ * ```
+ */
+export const SixelBackendConfigSchema = z.object({
+	maxColors: z.number().int().min(2).max(256).default(DEFAULT_MAX_COLORS),
+	rleEnabled: z.boolean().default(true),
+});
+
+// =============================================================================
+// PIXEL DATA HELPERS
+// =============================================================================
+
+/**
+ * Gets the bytes-per-pixel for a given format.
+ *
+ * @param format - Image format
+ * @returns Bytes per pixel (4 for rgba, 3 for rgb)
+ */
+export function bytesPerPixel(format: 'rgba' | 'rgb' | 'png'): number {
+	if (format === 'rgb') return 3;
+	return 4; // rgba and png (assumed rgba)
+}
+
+/**
+ * Extracts RGBA values from image data at a pixel index.
+ *
+ * @param data - Raw pixel data
+ * @param index - Pixel index
+ * @param bpp - Bytes per pixel
+ * @returns RGBA tuple [r, g, b, a]
+ */
+export function getPixelRGBA(
+	data: Uint8Array,
+	index: number,
+	bpp: number,
+): [number, number, number, number] {
+	const offset = index * bpp;
+	const r = data[offset] ?? 0;
+	const g = data[offset + 1] ?? 0;
+	const b = data[offset + 2] ?? 0;
+	const a = bpp === 4 ? (data[offset + 3] ?? 255) : 255;
+	return [r, g, b, a];
+}
+
+// =============================================================================
+// COLOR QUANTIZATION
+// =============================================================================
+
+/**
+ * Packs RGB into a single 24-bit integer.
+ *
+ * @param r - Red (0-255)
+ * @param g - Green (0-255)
+ * @param b - Blue (0-255)
+ * @returns Packed RGB value
+ */
+export function packRGB(r: number, g: number, b: number): number {
+	return (r << 16) | (g << 8) | b;
+}
+
+/**
+ * Counts color occurrences in image data, skipping transparent pixels.
+ *
+ * @param data - Raw pixel data
+ * @param pixelCount - Number of pixels
+ * @param bpp - Bytes per pixel
+ * @returns Map of packed RGB to count
+ */
+export function countImageColors(
+	data: Uint8Array,
+	pixelCount: number,
+	bpp: number,
+): Map<number, number> {
+	const counts = new Map<number, number>();
+	for (let i = 0; i < pixelCount; i++) {
+		const [r, g, b, a] = getPixelRGBA(data, i, bpp);
+		if (a === 0) continue;
+		const key = packRGB(r, g, b);
+		counts.set(key, (counts.get(key) ?? 0) + 1);
+	}
+	return counts;
+}
+
+/**
+ * Builds a palette from color counts sorted by popularity.
+ *
+ * @param colorCounts - Map of packed RGB to occurrence count
+ * @param maxColors - Maximum palette entries
+ * @returns Palette as flat Uint8Array (r,g,b triples) and palette size
+ */
+export function buildPalette(
+	colorCounts: Map<number, number>,
+	maxColors: number,
+): { paletteFlat: Uint8Array; paletteCount: number } {
+	const entries: Array<[number, number]> = [];
+	for (const entry of colorCounts) {
+		entries.push(entry);
+	}
+	entries.sort((a, b) => b[1] - a[1]);
+
+	const paletteCount = Math.min(entries.length, maxColors) || 1;
+	const paletteFlat = new Uint8Array(paletteCount * 3);
+
+	for (let i = 0; i < paletteCount; i++) {
+		const entry = entries[i];
+		if (entry) {
+			const key = entry[0];
+			paletteFlat[i * 3] = (key >> 16) & 0xff;
+			paletteFlat[i * 3 + 1] = (key >> 8) & 0xff;
+			paletteFlat[i * 3 + 2] = key & 0xff;
+		}
+	}
+
+	return { paletteFlat, paletteCount };
+}
+
+/**
+ * Finds the nearest palette index for an RGB color using squared distance.
+ *
+ * @param r - Red (0-255)
+ * @param g - Green (0-255)
+ * @param b - Blue (0-255)
+ * @param paletteFlat - Flat palette array (r,g,b triples)
+ * @param paletteCount - Number of palette entries
+ * @returns Nearest palette index
+ */
+export function findNearestColor(
+	r: number,
+	g: number,
+	b: number,
+	paletteFlat: Uint8Array,
+	paletteCount: number,
+): number {
+	let bestDist = 0x7fffffff;
+	let bestIdx = 0;
+	for (let p = 0; p < paletteCount; p++) {
+		const p3 = p * 3;
+		const dr = r - (paletteFlat[p3] as number);
+		const dg = g - (paletteFlat[p3 + 1] as number);
+		const db = b - (paletteFlat[p3 + 2] as number);
+		const dist = dr * dr + dg * dg + db * db;
+		if (dist < bestDist) {
+			bestDist = dist;
+			bestIdx = p;
+			if (dist === 0) break;
+		}
+	}
+	return bestIdx;
+}
+
+/**
+ * Maps all pixels to their nearest palette index.
+ *
+ * @param data - Raw pixel data
+ * @param pixelCount - Number of pixels
+ * @param bpp - Bytes per pixel
+ * @param paletteFlat - Flat palette array
+ * @param paletteCount - Number of palette entries
+ * @returns Array of palette indices per pixel
+ */
+export function mapPixelsToPalette(
+	data: Uint8Array,
+	pixelCount: number,
+	bpp: number,
+	paletteFlat: Uint8Array,
+	paletteCount: number,
+): Uint8Array {
+	const indexMap = new Uint8Array(pixelCount);
+	for (let i = 0; i < pixelCount; i++) {
+		const [r, g, b, a] = getPixelRGBA(data, i, bpp);
+		if (a === 0) {
+			indexMap[i] = 0;
+			continue;
+		}
+		indexMap[i] = findNearestColor(r, g, b, paletteFlat, paletteCount);
+	}
+	return indexMap;
+}
+
+// =============================================================================
+// SIXEL ENCODING
+// =============================================================================
+
+/**
+ * Builds the sixel palette header string.
+ *
+ * Format: `#<n>;2;<r%>;<g%>;<b%>` for each color.
+ *
+ * @param paletteFlat - Flat palette array (r,g,b triples)
+ * @param paletteCount - Number of palette entries
+ * @returns Palette header string
+ */
+export function buildPaletteHeader(paletteFlat: Uint8Array, paletteCount: number): string {
+	const parts: string[] = [];
+	for (let i = 0; i < paletteCount; i++) {
+		const i3 = i * 3;
+		const rp = Math.round(((paletteFlat[i3] as number) / 255) * 100);
+		const gp = Math.round(((paletteFlat[i3 + 1] as number) / 255) * 100);
+		const bp = Math.round(((paletteFlat[i3 + 2] as number) / 255) * 100);
+		parts.push(`#${i};2;${rp};${gp};${bp}`);
+	}
+	return parts.join('');
+}
+
+/**
+ * Builds a sixel bit pattern for one column across all rows in a band.
+ *
+ * @param indexMap - Per-pixel palette index map
+ * @param colorIdx - Palette color index to match
+ * @param bandY - Starting y position of the band
+ * @param maxRow - Number of rows in this band (max 6)
+ * @param width - Image width
+ * @param x - Column position
+ * @returns 6-bit pattern where bit n is set if row n matches the color
+ */
+export function buildSixelColumn(
+	indexMap: Uint8Array,
+	colorIdx: number,
+	bandY: number,
+	maxRow: number,
+	width: number,
+	x: number,
+): number {
+	let bits = 0;
+	for (let row = 0; row < maxRow; row++) {
+		const pixelIdx = (bandY + row) * width + x;
+		if (indexMap[pixelIdx] === colorIdx) {
+			bits |= 1 << row;
+		}
+	}
+	return bits;
+}
+
+/**
+ * Run-length encodes a band of sixel values.
+ * Uses `!<count><char>` for runs of 3 or more identical values.
+ *
+ * @param sixelValues - Array of 6-bit values for each column
+ * @param width - Number of columns
+ * @returns Object with the encoded string and whether any pixels were set
+ */
+export function rleEncodeBand(
+	sixelValues: Uint8Array,
+	width: number,
+): { encoded: string; hasPixels: boolean } {
+	const parts: string[] = [];
+	let hasPixels = false;
+	let i = 0;
+
+	while (i < width) {
+		const val = sixelValues[i] as number;
+		let count = 1;
+		while (i + count < width && sixelValues[i + count] === val) {
+			count++;
+		}
+		const ch = String.fromCharCode(63 + val);
+		if (val > 0) hasPixels = true;
+		if (count >= 3) {
+			parts.push(`!${count}${ch}`);
+		} else {
+			for (let j = 0; j < count; j++) {
+				parts.push(ch);
+			}
+		}
+		i += count;
+	}
+
+	return { encoded: parts.join(''), hasPixels };
+}
+
+/**
+ * Raw-encodes a band of sixel values (no RLE compression).
+ *
+ * @param sixelValues - Array of 6-bit values for each column
+ * @param width - Number of columns
+ * @returns Object with the encoded string and whether any pixels were set
+ */
+export function rawEncodeBand(
+	sixelValues: Uint8Array,
+	width: number,
+): { encoded: string; hasPixels: boolean } {
+	const parts: string[] = [];
+	let hasPixels = false;
+	for (let x = 0; x < width; x++) {
+		const val = sixelValues[x] as number;
+		if (val > 0) hasPixels = true;
+		parts.push(String.fromCharCode(63 + val));
+	}
+	return { encoded: parts.join(''), hasPixels };
+}
+
+/**
+ * Encodes a complete sixel image from pixel index map data.
+ *
+ * Processes the image in 6-pixel-tall bands. Within each band,
+ * iterates over all palette colors, encoding column data for each
+ * color with `$` (carriage return) between colors and `-` (newline)
+ * between bands.
+ *
+ * @param indexMap - Per-pixel palette index map
+ * @param paletteCount - Number of palette entries
+ * @param width - Image width
+ * @param height - Image height
+ * @param rleEnabled - Whether to use RLE compression
+ * @returns Encoded sixel data string
+ */
+export function encodeSixelData(
+	indexMap: Uint8Array,
+	paletteCount: number,
+	width: number,
+	height: number,
+	rleEnabled: boolean,
+): string {
+	const parts: string[] = [];
+	const sixelRow = new Uint8Array(width);
+	const bandCount = Math.ceil(height / 6);
+
+	for (let band = 0; band < bandCount; band++) {
+		const bandY = band * 6;
+		const maxRow = Math.min(6, height - bandY);
+
+		for (let colorIdx = 0; colorIdx < paletteCount; colorIdx++) {
+			for (let x = 0; x < width; x++) {
+				sixelRow[x] = buildSixelColumn(indexMap, colorIdx, bandY, maxRow, width, x);
+			}
+
+			const { encoded, hasPixels } = rleEnabled
+				? rleEncodeBand(sixelRow, width)
+				: rawEncodeBand(sixelRow, width);
+
+			if (hasPixels) {
+				parts.push(`#${colorIdx}${encoded}$`);
+			}
+		}
+
+		if (band < bandCount - 1) {
+			parts.push('-');
+		}
+	}
+
+	return parts.join('');
+}
+
+/**
+ * Encodes image data as a complete sixel escape sequence.
+ *
+ * @param image - Image data (RGBA or RGB pixels)
+ * @param maxColors - Maximum palette colors (2-256)
+ * @param rleEnabled - Whether to use RLE compression
+ * @returns Complete DCS sixel escape sequence
+ *
+ * @example
+ * ```typescript
+ * import { encodeSixelImage } from 'blecsd';
+ *
+ * const seq = encodeSixelImage(imageData, 256, true);
+ * process.stdout.write(seq);
+ * ```
+ */
+export function encodeSixelImage(image: ImageData, maxColors: number, rleEnabled: boolean): string {
+	const bpp = bytesPerPixel(image.format);
+	const pixelCount = image.width * image.height;
+
+	if (pixelCount === 0) {
+		return `${DCS_START}${SIXEL_ST}`;
+	}
+
+	const colorCounts = countImageColors(image.data, pixelCount, bpp);
+	const { paletteFlat, paletteCount } = buildPalette(colorCounts, maxColors);
+	const indexMap = mapPixelsToPalette(image.data, pixelCount, bpp, paletteFlat, paletteCount);
+
+	const paletteHeader = buildPaletteHeader(paletteFlat, paletteCount);
+	const sixelData = encodeSixelData(indexMap, paletteCount, image.width, image.height, rleEnabled);
+
+	return `${DCS_START}${paletteHeader}${sixelData}${SIXEL_ST}`;
+}
+
+// =============================================================================
+// CURSOR POSITIONING
+// =============================================================================
+
+/**
+ * Builds a cursor positioning escape sequence.
+ *
+ * @param x - Column position (0-based)
+ * @param y - Row position (0-based)
+ * @returns ANSI CUP escape sequence (1-based)
+ */
+export function cursorPosition(x: number, y: number): string {
+	return `\x1b[${y + 1};${x + 1}H`;
+}
+
+// =============================================================================
+// SIXEL DETECTION
+// =============================================================================
+
+/**
+ * Default environment checker using process.env.
+ */
+const defaultEnvChecker: SixelEnvChecker = {
+	getEnv: (name: string) => process.env[name],
+};
+
+/**
+ * Checks if the current terminal likely supports sixel graphics.
+ *
+ * Detection heuristics:
+ * - xterm with XTERM_VERSION set (xterm -ti vt340)
+ * - mlterm
+ * - foot terminal
+ * - TERM containing "sixel"
+ * - WezTerm (supports sixel)
+ * - contour terminal
+ *
+ * @param env - Environment checker (defaults to process.env)
+ * @returns true if sixel graphics are likely supported
+ *
+ * @example
+ * ```typescript
+ * import { isSixelSupported } from 'blecsd';
+ *
+ * if (isSixelSupported()) {
+ *   // Use sixel image protocol
+ * }
+ * ```
+ */
+export function isSixelSupported(env: SixelEnvChecker = defaultEnvChecker): boolean {
+	const termProgram = env.getEnv('TERM_PROGRAM') ?? '';
+	const term = env.getEnv('TERM') ?? '';
+	const xtermVersion = env.getEnv('XTERM_VERSION') ?? '';
+
+	// xterm with sixel support (usually started with -ti vt340)
+	if (termProgram === 'xterm' && xtermVersion !== '') return true;
+
+	// Terminals known to support sixel
+	const sixelPrograms = ['mlterm', 'foot', 'contour', 'WezTerm'];
+	if (sixelPrograms.some((p) => termProgram === p)) return true;
+
+	// TERM hints
+	if (term.includes('sixel') || term === 'mlterm') return true;
+
+	return false;
+}
+
+// =============================================================================
+// RENDER HELPER
+// =============================================================================
+
+/**
+ * Renders image data as a positioned sixel escape sequence.
+ *
+ * Positions the cursor, then outputs the sixel-encoded image.
+ * For PNG format data, the raw bytes are treated as RGBA (callers should
+ * decode PNG to raw pixels before passing to this function).
+ *
+ * @param image - Image data (RGBA or RGB pixels)
+ * @param options - Render options with position
+ * @param maxColors - Maximum palette colors
+ * @param rleEnabled - Whether to use RLE compression
+ * @returns Complete escape sequence with cursor positioning and sixel image
+ *
+ * @example
+ * ```typescript
+ * import { renderSixelImage } from 'blecsd';
+ *
+ * const output = renderSixelImage(
+ *   { width: 100, height: 50, data: rgbaBuffer, format: 'rgba' },
+ *   { x: 0, y: 0 },
+ *   256,
+ *   true,
+ * );
+ * process.stdout.write(output);
+ * ```
+ */
+export function renderSixelImage(
+	image: ImageData,
+	options: RenderOptions,
+	maxColors: number,
+	rleEnabled: boolean,
+): string {
+	const pos = cursorPosition(options.x, options.y);
+	const seq = encodeSixelImage(image, maxColors, rleEnabled);
+	return pos + seq;
+}
+
+/**
+ * Generates a clear sequence for sixel images.
+ *
+ * Sixel protocol does not have a dedicated clear command.
+ * Overwrites the area with spaces to clear the image.
+ *
+ * @param options - Area to clear (x, y, width, height in cells)
+ * @returns Escape sequence to blank the area
+ */
+export function clearSixelImage(options?: {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}): string {
+	if (!options) return '';
+	const lines: string[] = [];
+	for (let row = 0; row < options.height; row++) {
+		lines.push(cursorPosition(options.x, options.y + row) + ' '.repeat(options.width));
+	}
+	return lines.join('');
+}
+
+// =============================================================================
+// BACKEND FACTORY
+// =============================================================================
+
+/**
+ * Creates a sixel graphics backend.
+ *
+ * @param config - Optional backend configuration
+ * @param envChecker - Optional environment checker for testing
+ * @returns A GraphicsBackend for sixel image rendering
+ *
+ * @example
+ * ```typescript
+ * import { createSixelGraphicsBackend, createGraphicsManager, registerBackend } from 'blecsd';
+ *
+ * const manager = createGraphicsManager();
+ * registerBackend(manager, createSixelGraphicsBackend());
+ *
+ * // With custom config:
+ * registerBackend(manager, createSixelGraphicsBackend({ maxColors: 64 }));
+ * ```
+ */
+export function createSixelGraphicsBackend(
+	config?: SixelBackendConfig,
+	envChecker?: SixelEnvChecker,
+): GraphicsBackend {
+	const validated = SixelBackendConfigSchema.parse(config ?? {});
+	const maxColors = validated.maxColors;
+	const rleEnabled = validated.rleEnabled;
+
+	const capabilities: GraphicsCapabilities = {
+		staticImages: true,
+		animation: false,
+		alphaChannel: false,
+		maxWidth: null,
+		maxHeight: null,
+	};
+
+	return {
+		name: SIXEL_BACKEND_NAME,
+		capabilities,
+		render: (image: ImageData, options: RenderOptions) =>
+			renderSixelImage(image, options, maxColors, rleEnabled),
+		clear: () => '',
+		isSupported: () => isSixelSupported(envChecker),
+	};
+}


### PR DESCRIPTION
## Summary

- Implements a DEC sixel protocol backend for the terminal graphics system (`src/terminal/graphics/sixel.ts`)
- Popularity-based color quantization to 256-color palette with configurable max colors (2-256)
- Run-length encoding (RLE) compression for efficient sixel output
- Terminal detection heuristics for xterm, mlterm, foot, contour, WezTerm
- Full Zod schema validation for backend configuration
- 70 unit tests covering encoding, quantization, detection, and the backend factory

## Details

This adds the sixel backend to the **terminal graphics system** (for inline image rendering), complementing the existing iTerm2 backend. It follows the same `GraphicsBackend` interface pattern:

```typescript
import { createSixelGraphicsBackend, createGraphicsManager, registerBackend } from 'blecsd';

const manager = createGraphicsManager();
registerBackend(manager, createSixelGraphicsBackend({ maxColors: 64 }));
```

Note: This is separate from the existing 3D renderer sixel backend (`src/3d/backends/sixel.ts`) which encodes `PixelFramebuffer` data. This backend accepts `ImageData` (raw RGBA/RGB pixels) for positioned inline image rendering.

## Files Changed

- `src/terminal/graphics/sixel.ts` (new) - Sixel graphics backend implementation
- `src/terminal/graphics/sixel.test.ts` (new) - 70 tests
- `src/terminal/graphics/index.ts` - Export sixel backend

## Test plan

- [x] All 70 sixel-specific tests pass
- [x] Full test suite passes (9234/9235, 1 pre-existing flaky timing test)
- [x] TypeScript typecheck passes
- [x] Biome lint passes (no new warnings)
- [x] Production build succeeds

Closes #788