### PR TITLE
feat: add sub-path exports for major modules (#661)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,14 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./components": {
+      "import": "./dist/components/index.js",
+      "types": "./dist/components/index.d.ts"
+    },
+    "./systems": {
+      "import": "./dist/systems/index.js",
+      "types": "./dist/systems/index.d.ts"
+    },
     "./widgets": {
       "import": "./dist/widgets/index.js",
       "types": "./dist/widgets/index.d.ts"
@@ -21,6 +29,30 @@
     "./widgets/fonts": {
       "import": "./dist/widgets/fonts/index.js",
       "types": "./dist/widgets/fonts/index.d.ts"
+    },
+    "./terminal": {
+      "import": "./dist/terminal/index.js",
+      "types": "./dist/terminal/index.d.ts"
+    },
+    "./3d": {
+      "import": "./dist/3d/index.js",
+      "types": "./dist/3d/index.d.ts"
+    },
+    "./schemas": {
+      "import": "./dist/schemas/index.js",
+      "types": "./dist/schemas/index.d.ts"
+    },
+    "./utils": {
+      "import": "./dist/utils/index.js",
+      "types": "./dist/utils/index.d.ts"
+    },
+    "./game": {
+      "import": "./dist/game/index.js",
+      "types": "./dist/game/index.d.ts"
+    },
+    "./audio": {
+      "import": "./dist/audio/index.js",
+      "types": "./dist/audio/index.d.ts"
     }
   },
   "files": [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,9 +3,17 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
 	entry: [
 		'src/index.ts',
+		'src/components/index.ts',
+		'src/systems/index.ts',
 		'src/widgets/index.ts',
 		'src/widgets/bigText.ts',
 		'src/widgets/fonts/index.ts',
+		'src/terminal/index.ts',
+		'src/3d/index.ts',
+		'src/schemas/index.ts',
+		'src/utils/index.ts',
+		'src/game/index.ts',
+		'src/audio/index.ts',
 	],
 	format: ['esm'],
 	dts: true,


### PR DESCRIPTION
## Summary

- Add package.json exports map for all major modules: `blecsd/components`, `blecsd/systems`, `blecsd/widgets`, `blecsd/terminal`, `blecsd/3d`, `blecsd/schemas`, `blecsd/utils`, `blecsd/game`, `blecsd/audio`
- Add corresponding tsup entry points so each sub-path gets its own chunk for tree-shaking
- Existing root export (`blecsd`) continues to re-export everything

Users can now do targeted imports:
```typescript
import { Position, Velocity } from 'blecsd/components';
import { animationSystem } from 'blecsd/systems';
import { createBox } from 'blecsd/widgets';
```

Closes #661

## Test plan

- [ ] Verify `pnpm build` produces all entry point files (dist/components/index.js, etc.)
- [ ] Verify `pnpm typecheck` passes
- [ ] Verify `pnpm lint` passes with no new warnings
- [ ] Verify TypeScript resolution works with `moduleResolution: bundler` and `node16`