### PR TITLE
docs: add API reference for 80 undocumented modules

### DIFF
--- a/docs/api/components/animation.md
+++ b/docs/api/components/animation.md
@@ -1,0 +1,299 @@
+# Animation Components API
+
+ECS components for sprite animation playback, timing, and frame sequencing.
+
+## Overview
+
+The animation module provides two layers:
+- **Animation store** - Registers named animation definitions (frame sequences with per-frame durations)
+- **Animation component** - Per-entity playback state (current frame, speed, direction, looping)
+
+Animation definitions are stored in a global registry. Each entity references a definition by ID and tracks its own playback position.
+
+## Import
+
+```typescript
+import {
+  Animation,
+  registerAnimation,
+  getAnimation,
+  getAnimationByName,
+  playAnimation,
+  playAnimationByName,
+  stopAnimation,
+  pauseAnimation,
+  resumeAnimation,
+  getAnimationData,
+  isAnimationPlaying,
+  hasAnimation,
+  setAnimationSpeed,
+  setAnimationLoop,
+  setAnimationDirection,
+  removeAnimation,
+  updateAnimationEntity,
+  AnimationDirection,
+} from 'blecsd';
+```
+
+## Animation Store
+
+### registerAnimation
+
+Registers a new animation definition and returns its numeric ID.
+
+```typescript
+import { registerAnimation } from 'blecsd';
+
+const walkId = registerAnimation({
+  name: 'walk',
+  frames: [
+    { frameIndex: 0, duration: 0.1 },
+    { frameIndex: 1, duration: 0.1 },
+    { frameIndex: 2, duration: 0.1 },
+    { frameIndex: 3, duration: 0.1 },
+  ],
+});
+```
+
+**Options:**
+- `name` - Human-readable name for lookup
+- `frames` - Array of `{ frameIndex: number, duration: number }` (duration in seconds)
+
+### getAnimation / getAnimationByName
+
+Retrieve a registered animation by ID or name.
+
+```typescript
+import { getAnimation, getAnimationByName } from 'blecsd';
+
+const anim = getAnimation(walkId);
+const same = getAnimationByName('walk');
+console.log(anim?.totalDuration); // 0.4
+```
+
+**Returns:** `AnimationDefinition | undefined`
+
+### unregisterAnimation
+
+Removes a registered animation.
+
+```typescript
+import { unregisterAnimation } from 'blecsd';
+
+unregisterAnimation(walkId); // returns true if found
+```
+
+## Animation Component
+
+### Component Data Layout
+
+```typescript
+const Animation = {
+  animationId:      Uint32Array,   // Reference to animation definition
+  playing:          Uint8Array,    // 0=stopped, 1=playing
+  loop:             Uint8Array,    // 0=play once, 1=loop
+  speed:            Float32Array,  // Playback speed multiplier (1.0 = normal)
+  elapsed:          Float32Array,  // Time elapsed in current frame (seconds)
+  currentFrameIndex: Uint16Array,  // Current position in frames array
+  direction:        Int8Array,     // 1=forward, -1=reverse
+};
+```
+
+### AnimationDirection
+
+```typescript
+import { AnimationDirection } from 'blecsd';
+
+AnimationDirection.FORWARD  // 1
+AnimationDirection.REVERSE  // -1
+```
+
+### playAnimation
+
+Starts an animation on an entity. Adds the Animation component if not present.
+
+```typescript
+import { playAnimation } from 'blecsd';
+
+playAnimation(world, entity, walkId, {
+  loop: true,       // default: true
+  speed: 1.5,       // default: 1.0
+  direction: AnimationDirection.FORWARD, // default
+  startFrame: 0,    // default: 0 (or last frame if reverse)
+});
+```
+
+**Returns:** Entity ID for chaining, or `undefined` if animation not found.
+
+### playAnimationByName
+
+Same as `playAnimation` but looks up the animation by name.
+
+```typescript
+import { playAnimationByName } from 'blecsd';
+
+playAnimationByName(world, entity, 'walk', { loop: true });
+```
+
+### stopAnimation / pauseAnimation / resumeAnimation
+
+```typescript
+import { stopAnimation, pauseAnimation, resumeAnimation } from 'blecsd';
+
+pauseAnimation(world, entity);  // Pauses without resetting position
+resumeAnimation(world, entity); // Continues from where paused
+stopAnimation(world, entity);   // Stops and resets to frame 0
+```
+
+### getAnimationData
+
+Returns a snapshot of the entity's animation state.
+
+```typescript
+import { getAnimationData } from 'blecsd';
+
+const anim = getAnimationData(world, entity);
+if (anim?.playing) {
+  console.log(`Frame ${anim.currentFrameIndex}, elapsed: ${anim.elapsed}s`);
+}
+```
+
+**Returns:** `AnimationData | undefined`
+
+### isAnimationPlaying / hasAnimation
+
+```typescript
+import { isAnimationPlaying, hasAnimation } from 'blecsd';
+
+if (hasAnimation(world, entity) && isAnimationPlaying(world, entity)) {
+  // Animation is active
+}
+```
+
+### setAnimationSpeed / setAnimationLoop / setAnimationDirection
+
+Modify playback properties on a running animation.
+
+```typescript
+import { setAnimationSpeed, setAnimationLoop, setAnimationDirection, AnimationDirection } from 'blecsd';
+
+setAnimationSpeed(world, entity, 2.0);
+setAnimationLoop(world, entity, false);
+setAnimationDirection(world, entity, AnimationDirection.REVERSE);
+```
+
+### removeAnimation
+
+Removes the Animation component and resets all fields to defaults.
+
+```typescript
+import { removeAnimation } from 'blecsd';
+
+removeAnimation(world, entity);
+```
+
+### updateAnimationEntity
+
+Advances animation state for a single entity by delta time. Typically called by the animation system, but can be used manually.
+
+```typescript
+import { updateAnimationEntity } from 'blecsd';
+
+const completed = updateAnimationEntity(world, entity, 0.016);
+if (completed) {
+  console.log('Non-looping animation finished');
+}
+```
+
+**Returns:** `true` if a non-looping animation completed this frame.
+
+## Usage Example
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import {
+  registerSprite,
+  setSprite,
+  registerAnimation,
+  playAnimation,
+  updateAnimationEntity,
+} from 'blecsd';
+
+const world = createWorld();
+const entity = addEntity(world);
+
+// Register sprite sheet
+const spriteId = registerSprite({
+  name: 'hero',
+  frames: [
+    [[{ char: '@' }]],
+    [[{ char: 'O' }]],
+    [[{ char: '@' }]],
+    [[{ char: 'o' }]],
+  ],
+});
+setSprite(world, entity, spriteId);
+
+// Register and play animation
+const idleId = registerAnimation({
+  name: 'idle',
+  frames: [
+    { frameIndex: 0, duration: 0.5 },
+    { frameIndex: 1, duration: 0.5 },
+    { frameIndex: 2, duration: 0.5 },
+    { frameIndex: 3, duration: 0.5 },
+  ],
+});
+
+playAnimation(world, entity, idleId, { loop: true });
+
+// In your update loop
+updateAnimationEntity(world, entity, deltaTime);
+```
+
+## Types
+
+### AnimationFrame
+
+```typescript
+interface AnimationFrame {
+  frameIndex: number;
+  duration: number;
+}
+```
+
+### AnimationDefinition
+
+```typescript
+interface AnimationDefinition {
+  readonly id: number;
+  readonly name: string;
+  readonly frames: readonly AnimationFrame[];
+  readonly totalDuration: number;
+}
+```
+
+### AnimationData
+
+```typescript
+interface AnimationData {
+  readonly animationId: number;
+  readonly playing: boolean;
+  readonly loop: boolean;
+  readonly speed: number;
+  readonly elapsed: number;
+  readonly currentFrameIndex: number;
+  readonly direction: AnimationDirection;
+}
+```
+
+### PlayAnimationOptions
+
+```typescript
+interface PlayAnimationOptions {
+  loop?: boolean;
+  speed?: number;
+  direction?: AnimationDirection;
+  startFrame?: number;
+}
+```

--- a/docs/api/components/behavior.md
+++ b/docs/api/components/behavior.md
@@ -1,0 +1,288 @@
+# Behavior Components API
+
+ECS component for AI behavior control with idle, patrol, chase, flee, and custom behavior modes.
+
+## Overview
+
+The Behavior module provides a lightweight behavior system for game entities. Each entity gets a behavior type (idle, patrol, chase, flee, custom) and the module provides direction-computation helpers that return movement vectors without directly modifying position. Side stores hold patrol routes and custom callbacks.
+
+## Import
+
+```typescript
+import {
+  Behavior,
+  BehaviorType,
+  BehaviorState,
+  setBehavior,
+  getBehavior,
+  hasBehavior,
+  removeBehavior,
+  setIdle,
+  setPatrol,
+  setChase,
+  setFlee,
+  setCustomBehavior,
+  getBehaviorType,
+  getBehaviorState,
+  getBehaviorTarget,
+  setBehaviorTarget,
+  setBehaviorSpeed,
+  setDetectionRange,
+  isBehaviorActive,
+  isBehaviorWaiting,
+  isBehaviorCompleted,
+  getPatrolRoute,
+  getCurrentPatrolPoint,
+  computePatrolDirection,
+  computeChaseDirection,
+  computeFleeDirection,
+  executeCustomBehavior,
+  updateBehaviorTimer,
+} from 'blecsd';
+```
+
+## Component Data Layout
+
+```typescript
+const Behavior = {
+  behaviorType:   Uint8Array,    // Current behavior type
+  state:          Uint8Array,    // Current behavior state
+  targetEntity:   Uint32Array,   // Chase/flee target (0 = none)
+  waitTimer:      Float32Array,  // Remaining wait time in seconds
+  patrolIndex:    Uint16Array,   // Current patrol waypoint index
+  patrolCount:    Uint16Array,   // Total patrol waypoints
+  speed:          Float32Array,  // Movement speed
+  detectionRange: Float32Array,  // Detection range for chase/flee
+  fleeRange:      Float32Array,  // Distance to flee before stopping
+};
+```
+
+## Constants
+
+### BehaviorType
+
+```typescript
+import { BehaviorType } from 'blecsd';
+
+BehaviorType.Idle    // 0
+BehaviorType.Patrol  // 1
+BehaviorType.Chase   // 2
+BehaviorType.Flee    // 3
+BehaviorType.Custom  // 4
+```
+
+### BehaviorState
+
+```typescript
+import { BehaviorState } from 'blecsd';
+
+BehaviorState.Inactive  // 0
+BehaviorState.Active    // 1
+BehaviorState.Waiting   // 2
+BehaviorState.Completed // 3
+```
+
+## Core Functions
+
+### setBehavior
+
+Sets behavior on an entity. Adds the component if not present.
+
+```typescript
+import { setBehavior, BehaviorType } from 'blecsd';
+
+setBehavior(world, entity, {
+  type: BehaviorType.Chase,
+  speed: 3,
+  targetEntity: player,
+  detectionRange: 15,
+  fleeRange: 20,
+});
+```
+
+**Options:**
+- `type` - Behavior type (default: `Idle`)
+- `speed` - Movement speed (default: `1`)
+- `targetEntity` - Target for chase/flee (default: `0`)
+- `detectionRange` - Detection range (default: `10`)
+- `fleeRange` - Flee distance (default: `15`)
+
+### getBehavior
+
+Returns a snapshot of the entity's behavior data.
+
+```typescript
+import { getBehavior } from 'blecsd';
+
+const ai = getBehavior(world, entity);
+if (ai) {
+  console.log(`Type: ${ai.type}, State: ${ai.state}, Speed: ${ai.speed}`);
+}
+```
+
+**Returns:** `BehaviorData | undefined`
+
+### hasBehavior / removeBehavior
+
+```typescript
+import { hasBehavior, removeBehavior } from 'blecsd';
+
+if (hasBehavior(world, entity)) {
+  removeBehavior(world, entity); // Also cleans up patrol routes and custom callbacks
+}
+```
+
+## Behavior Type Setters
+
+### setIdle / setPatrol / setChase / setFlee / setCustomBehavior
+
+```typescript
+import { setPatrol, setChase, setFlee, setCustomBehavior } from 'blecsd';
+
+// Patrol with waypoints
+setPatrol(world, guard, [
+  { x: 10, y: 5 },
+  { x: 20, y: 5 },
+  { x: 20, y: 15 },
+], { loop: true, waitTime: 2 });
+
+// Chase a target
+setChase(world, enemy, player);
+
+// Flee from a target
+setFlee(world, civilian, enemy);
+
+// Custom behavior callback
+setCustomBehavior(world, boss, (world, eid, delta) => {
+  // Custom AI logic
+});
+```
+
+## Query Helpers
+
+```typescript
+import {
+  getBehaviorType,
+  getBehaviorState,
+  getBehaviorTarget,
+  isBehaviorActive,
+  isBehaviorWaiting,
+  isBehaviorCompleted,
+  getPatrolRoute,
+  getCurrentPatrolPoint,
+} from 'blecsd';
+
+const type = getBehaviorType(world, entity);    // BehaviorTypeValue | undefined
+const state = getBehaviorState(world, entity);  // BehaviorStateValue | undefined
+const target = getBehaviorTarget(world, entity); // number (0 if none)
+const active = isBehaviorActive(world, entity);  // boolean
+const route = getPatrolRoute(world, entity);     // PatrolRoute | undefined
+const point = getCurrentPatrolPoint(world, entity); // Point2D | undefined
+```
+
+## Direction Computation
+
+These functions return movement direction vectors without modifying entity position.
+
+### computePatrolDirection
+
+```typescript
+import { computePatrolDirection } from 'blecsd';
+
+const dir = computePatrolDirection(world, entity, currentX, currentY, deltaTime);
+if (dir) {
+  // Apply dir.dx, dir.dy to entity position
+}
+```
+
+### computeChaseDirection / computeFleeDirection
+
+```typescript
+import { computeChaseDirection, computeFleeDirection } from 'blecsd';
+
+const chase = computeChaseDirection(world, entity, myX, myY, targetX, targetY);
+const flee = computeFleeDirection(world, entity, myX, myY, targetX, targetY);
+```
+
+**Returns:** `BehaviorDirection | undefined` (with `dx` and `dy` fields)
+
+### executeCustomBehavior / updateBehaviorTimer
+
+```typescript
+import { executeCustomBehavior, updateBehaviorTimer } from 'blecsd';
+
+// In your update loop
+updateBehaviorTimer(world, entity, deltaTime);
+executeCustomBehavior(world, entity, deltaTime);
+```
+
+## Usage Example
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import { setBehavior, BehaviorType, setPatrol, computePatrolDirection } from 'blecsd';
+
+const world = createWorld();
+const guard = addEntity(world);
+
+// Set up patrol behavior
+setBehavior(world, guard, { type: BehaviorType.Patrol, speed: 2 });
+setPatrol(world, guard, [
+  { x: 5, y: 5 },
+  { x: 15, y: 5 },
+  { x: 15, y: 10 },
+], { loop: true, waitTime: 1.0 });
+
+// In update loop
+const dir = computePatrolDirection(world, guard, currentX, currentY, deltaTime);
+if (dir) {
+  currentX += dir.dx * deltaTime;
+  currentY += dir.dy * deltaTime;
+}
+```
+
+## Types
+
+### BehaviorData
+
+```typescript
+interface BehaviorData {
+  readonly type: BehaviorTypeValue;
+  readonly state: BehaviorStateValue;
+  readonly targetEntity: number;
+  readonly waitTimer: number;
+  readonly patrolIndex: number;
+  readonly patrolCount: number;
+  readonly speed: number;
+  readonly detectionRange: number;
+  readonly fleeRange: number;
+}
+```
+
+### Point2D
+
+```typescript
+interface Point2D {
+  readonly x: number;
+  readonly y: number;
+}
+```
+
+### PatrolRoute
+
+```typescript
+interface PatrolRoute {
+  readonly points: readonly Point2D[];
+  readonly loop: boolean;
+  readonly waitTime: number;
+}
+```
+
+### BehaviorDirection
+
+```typescript
+interface BehaviorDirection {
+  readonly dx: number;
+  readonly dy: number;
+}
+```

--- a/docs/api/components/camera.md
+++ b/docs/api/components/camera.md
@@ -1,0 +1,268 @@
+# Camera Components API
+
+ECS component for viewport control, target following, and coordinate conversion.
+
+## Overview
+
+The Camera component manages a 2D viewport into a larger world space. It supports smooth target following with dead zones, world-space bounds clamping, and coordinate conversion between world and screen space.
+
+## Import
+
+```typescript
+import {
+  Camera,
+  setCamera,
+  getCamera,
+  hasCamera,
+  removeCamera,
+  setCameraTarget,
+  getCameraTarget,
+  isFollowingTarget,
+  setCameraDeadZone,
+  setCameraBounds,
+  clearCameraBounds,
+  isCameraBounded,
+  setCameraPosition,
+  getCameraPosition,
+  moveCameraBy,
+  centerCameraOn,
+  worldToScreen,
+  screenToWorld,
+  isInView,
+  isAreaInView,
+  updateCameraFollow,
+} from 'blecsd';
+```
+
+## Component Data Layout
+
+```typescript
+const Camera = {
+  x:            Float32Array,  // Camera X position (world coordinates)
+  y:            Float32Array,  // Camera Y position (world coordinates)
+  width:        Uint16Array,   // Viewport width in cells
+  height:       Uint16Array,   // Viewport height in cells
+  followTarget: Uint32Array,   // Entity to follow (0 = none)
+  smoothing:    Float32Array,  // Follow smoothing (0 = instant, 1 = max)
+  deadZoneX:    Float32Array,  // Dead zone X size
+  deadZoneY:    Float32Array,  // Dead zone Y size
+  bounded:      Uint8Array,    // 0 = unbounded, 1 = bounded
+  minX:         Float32Array,  // Min X bound
+  maxX:         Float32Array,  // Max X bound
+  minY:         Float32Array,  // Min Y bound
+  maxY:         Float32Array,  // Max Y bound
+};
+```
+
+## Core Functions
+
+### setCamera
+
+Creates or updates a camera on an entity.
+
+```typescript
+import { setCamera } from 'blecsd';
+
+setCamera(world, cameraEntity, {
+  width: 80,
+  height: 24,
+  x: 0,
+  y: 0,
+  smoothing: 0.1,
+});
+```
+
+**Options:**
+- `x`, `y` - Camera position (default: `0`)
+- `width` - Viewport width (default: `80`)
+- `height` - Viewport height (default: `24`)
+- `followTarget` - Entity to follow (default: none)
+- `smoothing` - Follow smoothing 0-1 (default: `0`)
+- `deadZoneX`, `deadZoneY` - Dead zone size (default: `0`)
+
+### getCamera
+
+Returns a snapshot of camera state.
+
+```typescript
+import { getCamera } from 'blecsd';
+
+const cam = getCamera(world, cameraEntity);
+if (cam) {
+  console.log(`Camera at (${cam.x}, ${cam.y}), viewport ${cam.width}x${cam.height}`);
+}
+```
+
+**Returns:** `CameraData | undefined`
+
+### hasCamera / removeCamera
+
+```typescript
+import { hasCamera, removeCamera } from 'blecsd';
+
+if (hasCamera(world, entity)) {
+  removeCamera(world, entity);
+}
+```
+
+## Target Following
+
+### setCameraTarget
+
+Sets the entity for the camera to follow with optional smoothing.
+
+```typescript
+import { setCameraTarget } from 'blecsd';
+
+setCameraTarget(world, camera, player, 0.1); // Follow with smooth interpolation
+setCameraTarget(world, camera, 0);            // Stop following
+```
+
+### getCameraTarget / isFollowingTarget
+
+```typescript
+import { getCameraTarget, isFollowingTarget } from 'blecsd';
+
+const target = getCameraTarget(world, camera); // Entity ID or 0
+const following = isFollowingTarget(world, camera); // boolean
+```
+
+### setCameraDeadZone
+
+Sets the dead zone. The camera only moves when the target exits this zone around the viewport center.
+
+```typescript
+import { setCameraDeadZone } from 'blecsd';
+
+setCameraDeadZone(world, camera, 10, 5);
+```
+
+### updateCameraFollow
+
+Updates camera position to follow its target. Call each frame.
+
+```typescript
+import { updateCameraFollow } from 'blecsd';
+
+updateCameraFollow(world, camera, deltaTime);
+```
+
+## Bounds
+
+### setCameraBounds / clearCameraBounds / isCameraBounded
+
+Restrict the camera to a rectangular area.
+
+```typescript
+import { setCameraBounds, clearCameraBounds, isCameraBounded } from 'blecsd';
+
+setCameraBounds(world, camera, {
+  minX: 0, maxX: 200,
+  minY: 0, maxY: 100,
+});
+
+if (isCameraBounded(world, camera)) {
+  clearCameraBounds(world, camera);
+}
+```
+
+## Position
+
+### setCameraPosition / getCameraPosition / moveCameraBy / centerCameraOn
+
+```typescript
+import { setCameraPosition, getCameraPosition, moveCameraBy, centerCameraOn } from 'blecsd';
+
+setCameraPosition(world, camera, 50, 25);
+moveCameraBy(world, camera, 10, 0);     // Relative move
+centerCameraOn(world, camera, 100, 50); // Center on a world position
+
+const pos = getCameraPosition(world, camera);
+// pos: { x: number, y: number } | undefined
+```
+
+## Coordinate Conversion
+
+### worldToScreen / screenToWorld
+
+```typescript
+import { worldToScreen, screenToWorld } from 'blecsd';
+
+const screen = worldToScreen(world, camera, worldX, worldY);
+if (screen) {
+  // Draw at screen.x, screen.y
+}
+
+const worldPos = screenToWorld(world, camera, mouseX, mouseY);
+if (worldPos) {
+  // Handle click at worldPos.x, worldPos.y
+}
+```
+
+### isInView / isAreaInView
+
+```typescript
+import { isInView, isAreaInView } from 'blecsd';
+
+if (isInView(world, camera, enemy.x, enemy.y)) {
+  // Point is visible
+}
+
+if (isAreaInView(world, camera, rect.x, rect.y, rect.w, rect.h)) {
+  // Rectangle overlaps viewport
+}
+```
+
+## Usage Example
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import { setCamera, setCameraTarget, setCameraBounds, updateCameraFollow } from 'blecsd';
+
+const world = createWorld();
+const camera = addEntity(world);
+const player = addEntity(world);
+
+// Create viewport
+setCamera(world, camera, { width: 80, height: 24 });
+
+// Follow player with smoothing and bounds
+setCameraTarget(world, camera, player, 0.15);
+setCameraBounds(world, camera, { minX: 0, maxX: 200, minY: 0, maxY: 100 });
+
+// Each frame
+updateCameraFollow(world, camera, deltaTime);
+```
+
+## Types
+
+### CameraData
+
+```typescript
+interface CameraData {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly followTarget: number;
+  readonly smoothing: number;
+  readonly deadZoneX: number;
+  readonly deadZoneY: number;
+  readonly bounded: boolean;
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minY: number;
+  readonly maxY: number;
+}
+```
+
+### CameraBounds
+
+```typescript
+interface CameraBounds {
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minY: number;
+  readonly maxY: number;
+}
+```

--- a/docs/api/components/collision.md
+++ b/docs/api/components/collision.md
@@ -1,0 +1,281 @@
+# Collision Components API
+
+ECS component for entity collision detection with box and circle colliders, layer/mask filtering, and overlap testing.
+
+## Overview
+
+The Collision module provides a `Collider` component that supports axis-aligned bounding box (AABB) and circle shapes. Colliders use bitmask-based layer/mask filtering to control which entities can collide. Trigger colliders generate events without physics response.
+
+## Import
+
+```typescript
+import {
+  Collider,
+  ColliderType,
+  setCollider,
+  getCollider,
+  hasCollider,
+  removeCollider,
+  setCollisionLayer,
+  setCollisionMask,
+  setTrigger,
+  isTrigger,
+  canLayersCollide,
+  getColliderAABB,
+  testAABBOverlap,
+  testCircleOverlap,
+  testCircleAABBOverlap,
+  testCollision,
+  createCollisionPair,
+  collisionPairKey,
+  DEFAULT_LAYER,
+  DEFAULT_MASK,
+} from 'blecsd';
+```
+
+## Component Data Layout
+
+```typescript
+const Collider = {
+  type:      Uint8Array,    // 0=BOX, 1=CIRCLE
+  width:     Float32Array,  // Width (or diameter for circles)
+  height:    Float32Array,  // Height (ignored for circles)
+  offsetX:   Float32Array,  // X offset from entity position
+  offsetY:   Float32Array,  // Y offset from entity position
+  layer:     Uint16Array,   // Collision layer bitmask
+  mask:      Uint16Array,   // Layers to collide with
+  isTrigger: Uint8Array,    // 1=trigger, 0=solid
+};
+```
+
+## Constants
+
+### ColliderType
+
+```typescript
+import { ColliderType } from 'blecsd';
+
+ColliderType.BOX    // 0
+ColliderType.CIRCLE // 1
+```
+
+### DEFAULT_LAYER / DEFAULT_MASK
+
+```typescript
+import { DEFAULT_LAYER, DEFAULT_MASK } from 'blecsd';
+
+DEFAULT_LAYER // 1
+DEFAULT_MASK  // 0xFFFF (collide with all layers)
+```
+
+## Core Functions
+
+### setCollider
+
+Creates or updates a collider on an entity.
+
+```typescript
+import { setCollider, ColliderType } from 'blecsd';
+
+// Box collider with layer filtering
+setCollider(world, player, {
+  type: ColliderType.BOX,
+  width: 1,
+  height: 2,
+  layer: 0b0001,
+  mask: 0b0110,
+});
+
+// Circle trigger zone
+setCollider(world, checkpoint, {
+  type: ColliderType.CIRCLE,
+  width: 5, // diameter
+  isTrigger: true,
+});
+```
+
+**Options:**
+- `type` - `ColliderType.BOX` or `ColliderType.CIRCLE` (default: `BOX`)
+- `width` - Width or diameter (default: `1`)
+- `height` - Height, ignored for circles (default: `1`)
+- `offsetX`, `offsetY` - Offset from position (default: `0`)
+- `layer` - Collision layer bitmask (default: `1`)
+- `mask` - Collision mask (default: `0xFFFF`)
+- `isTrigger` - Trigger only (default: `false`)
+
+### getCollider
+
+Returns collider data for an entity.
+
+```typescript
+import { getCollider } from 'blecsd';
+
+const col = getCollider(world, entity);
+if (col) {
+  console.log(`${col.width}x${col.height}, trigger: ${col.isTrigger}`);
+}
+```
+
+**Returns:** `ColliderData | undefined`
+
+### hasCollider / removeCollider
+
+```typescript
+import { hasCollider, removeCollider } from 'blecsd';
+
+if (hasCollider(world, entity)) {
+  removeCollider(world, entity);
+}
+```
+
+## Layer and Mask
+
+### setCollisionLayer / setCollisionMask
+
+```typescript
+import { setCollisionLayer, setCollisionMask } from 'blecsd';
+
+setCollisionLayer(world, entity, 0b0010); // Entity is on layer 2
+setCollisionMask(world, entity, 0b0101);  // Collide with layers 1 and 3
+```
+
+### canLayersCollide
+
+Checks if two entities can collide based on their layer/mask configuration. Both entities must include the other's layer in their mask.
+
+```typescript
+import { canLayersCollide } from 'blecsd';
+
+const canCollide = canLayersCollide(
+  1, 6,  // entity A: layer 1, mask 6
+  2, 1,  // entity B: layer 2, mask 1
+); // true
+```
+
+### setTrigger / isTrigger
+
+```typescript
+import { setTrigger, isTrigger } from 'blecsd';
+
+setTrigger(world, entity, true);
+if (isTrigger(world, entity)) {
+  // Event only, no physics response
+}
+```
+
+## Collision Testing
+
+### getColliderAABB
+
+Gets the axis-aligned bounding box for an entity's collider at a given position.
+
+```typescript
+import { getColliderAABB } from 'blecsd';
+
+const bounds = getColliderAABB(entity, posX, posY);
+// bounds: { minX, minY, maxX, maxY }
+```
+
+### testAABBOverlap / testCircleOverlap / testCircleAABBOverlap
+
+Low-level overlap tests.
+
+```typescript
+import { testAABBOverlap, testCircleOverlap, testCircleAABBOverlap } from 'blecsd';
+
+testAABBOverlap(boundsA, boundsB);              // AABB vs AABB
+testCircleOverlap(x1, y1, r1, x2, y2, r2);     // Circle vs Circle
+testCircleAABBOverlap(cx, cy, radius, aabb);    // Circle vs AABB
+```
+
+### testCollision
+
+Tests if two entities' colliders overlap. Handles all shape combinations.
+
+```typescript
+import { testCollision } from 'blecsd';
+
+const colliding = testCollision(
+  entityA, posAX, posAY,
+  entityB, posBX, posBY,
+);
+```
+
+## Collision Pairs
+
+### createCollisionPair / collisionPairKey
+
+Utility for tracking collision pairs with consistent ordering.
+
+```typescript
+import { createCollisionPair, collisionPairKey } from 'blecsd';
+
+const pair = createCollisionPair(entityA, entityB, false);
+const key = collisionPairKey(pair); // "1:5" (lower ID first)
+```
+
+## Usage Example
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import { setCollider, ColliderType, testCollision, canLayersCollide } from 'blecsd';
+
+const world = createWorld();
+const player = addEntity(world);
+const enemy = addEntity(world);
+
+setCollider(world, player, {
+  type: ColliderType.BOX,
+  width: 1, height: 1,
+  layer: 0b0001, mask: 0b0010,
+});
+
+setCollider(world, enemy, {
+  type: ColliderType.CIRCLE,
+  width: 2,
+  layer: 0b0010, mask: 0b0001,
+});
+
+// Check collision
+if (testCollision(player, 10, 5, enemy, 11, 5)) {
+  console.log('Hit!');
+}
+```
+
+## Types
+
+### ColliderData
+
+```typescript
+interface ColliderData {
+  readonly type: ColliderType;
+  readonly width: number;
+  readonly height: number;
+  readonly offsetX: number;
+  readonly offsetY: number;
+  readonly layer: number;
+  readonly mask: number;
+  readonly isTrigger: boolean;
+}
+```
+
+### AABB
+
+```typescript
+interface AABB {
+  readonly minX: number;
+  readonly minY: number;
+  readonly maxX: number;
+  readonly maxY: number;
+}
+```
+
+### CollisionPair
+
+```typescript
+interface CollisionPair {
+  readonly entityA: Entity;
+  readonly entityB: Entity;
+  readonly isTrigger: boolean;
+}
+```

--- a/docs/api/components/health.md
+++ b/docs/api/components/health.md
@@ -1,0 +1,228 @@
+# Health Components API
+
+ECS component for health/resource pools with current/max values, regeneration, invulnerability, and damage/heal helpers.
+
+## Overview
+
+The Health component is a generic resource pool suitable for HP, mana, stamina, or any numeric resource. It tracks current and max values, supports per-second regeneration, and provides timed invulnerability. Damage respects invulnerability and clamps to zero; healing clamps to max.
+
+## Import
+
+```typescript
+import {
+  Health,
+  setHealth,
+  getHealth,
+  hasHealth,
+  removeHealth,
+  damage,
+  heal,
+  isDead,
+  isInvulnerable,
+  setInvulnerable,
+  clearInvulnerable,
+  getHealthPercent,
+  setCurrentHealth,
+  setMaxHealth,
+  setRegen,
+  updateHealth,
+} from 'blecsd';
+```
+
+## Component Data Layout
+
+```typescript
+const Health = {
+  current:          Float32Array,  // Current resource value
+  max:              Float32Array,  // Maximum resource value
+  regen:            Float32Array,  // Regeneration per second
+  invulnerable:     Uint8Array,    // 1=invulnerable, 0=vulnerable
+  invulnerableTime: Float32Array,  // Remaining invulnerability seconds
+};
+```
+
+## Core Functions
+
+### setHealth
+
+Sets health on an entity. Adds the component if not present.
+
+```typescript
+import { setHealth } from 'blecsd';
+
+setHealth(world, entity, { max: 100 });                   // Full HP
+setHealth(world, entity, { max: 100, current: 75, regen: 2 }); // Damaged, regenerating
+```
+
+**Options:**
+- `max` - Maximum resource value (required)
+- `current` - Current value (default: same as `max`)
+- `regen` - Regeneration per second (default: `0`)
+
+### getHealth
+
+Returns a snapshot of health state.
+
+```typescript
+import { getHealth } from 'blecsd';
+
+const hp = getHealth(world, entity);
+if (hp) {
+  console.log(`HP: ${hp.current}/${hp.max}`);
+}
+```
+
+**Returns:** `HealthData | undefined`
+
+### hasHealth / removeHealth
+
+```typescript
+import { hasHealth, removeHealth } from 'blecsd';
+
+if (hasHealth(world, entity)) {
+  removeHealth(world, entity);
+}
+```
+
+## Damage and Healing
+
+### damage
+
+Applies damage. Respects invulnerability. Clamps to zero.
+
+```typescript
+import { damage } from 'blecsd';
+
+const killed = damage(world, entity, 50);
+if (killed) {
+  console.log('Entity was killed!');
+}
+```
+
+**Returns:** `true` if the entity's health reached zero.
+
+### heal
+
+Restores health, clamped to max.
+
+```typescript
+import { heal } from 'blecsd';
+
+heal(world, entity, 25);
+```
+
+## Invulnerability
+
+### setInvulnerable / clearInvulnerable / isInvulnerable
+
+```typescript
+import { setInvulnerable, clearInvulnerable, isInvulnerable } from 'blecsd';
+
+setInvulnerable(world, entity, 2.0); // 2 seconds of invulnerability
+setInvulnerable(world, entity, 0);   // Permanent until cleared
+clearInvulnerable(world, entity);
+
+if (isInvulnerable(world, entity)) {
+  // Takes no damage
+}
+```
+
+## Query Helpers
+
+### isDead
+
+```typescript
+import { isDead } from 'blecsd';
+
+if (isDead(world, entity)) {
+  // current health <= 0
+}
+```
+
+### getHealthPercent
+
+Returns health as a 0-1 ratio.
+
+```typescript
+import { getHealthPercent } from 'blecsd';
+
+const percent = getHealthPercent(world, entity);
+console.log(`HP: ${Math.round(percent * 100)}%`);
+```
+
+### setCurrentHealth / setMaxHealth / setRegen
+
+Direct setters for individual fields.
+
+```typescript
+import { setCurrentHealth, setMaxHealth, setRegen } from 'blecsd';
+
+setCurrentHealth(world, entity, 50); // Clamped to [0, max]
+setMaxHealth(world, entity, 200);    // Clamps current if over new max
+setRegen(world, entity, 5);          // 5 HP per second
+```
+
+## Update
+
+### updateHealth
+
+Call each frame. Decrements invulnerability timer and applies regeneration.
+
+```typescript
+import { updateHealth } from 'blecsd';
+
+// In your update loop
+updateHealth(world, entity, deltaTime);
+```
+
+## Usage Example
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import { setHealth, damage, heal, isDead, setInvulnerable, updateHealth } from 'blecsd';
+
+const world = createWorld();
+const player = addEntity(world);
+
+setHealth(world, player, { max: 100, regen: 1 });
+
+// Take damage
+damage(world, player, 30); // 70 HP
+
+// Heal
+heal(world, player, 10); // 80 HP
+
+// Invulnerability after hit
+setInvulnerable(world, player, 1.5);
+
+// Each frame
+updateHealth(world, player, deltaTime);
+
+if (isDead(world, player)) {
+  // Game over
+}
+```
+
+## Types
+
+### HealthData
+
+```typescript
+interface HealthData {
+  readonly current: number;
+  readonly max: number;
+  readonly regen: number;
+  readonly invulnerable: boolean;
+  readonly invulnerableTime: number;
+}
+```
+
+### HealthOptions
+
+```typescript
+interface HealthOptions {
+  current?: number;
+  max: number;
+  regen?: number;
+}
+```

--- a/docs/api/components/particle.md
+++ b/docs/api/components/particle.md
@@ -1,0 +1,316 @@
+# Particle Components API
+
+ECS components for particle effects, providing both individual particle state and emitter configuration.
+
+## Overview
+
+The particle module provides two components:
+- **Particle** - Per-particle state (lifetime, age, character, color interpolation, fade)
+- **ParticleEmitter** - Emitter configuration (rate, burst, speed, spread, gravity, appearance)
+
+Emitters track which particles they have spawned via a side store. Particle colors interpolate from `startFg` to `endFg` over the particle's lifetime.
+
+## Import
+
+```typescript
+import {
+  Particle,
+  ParticleEmitter,
+  setParticle,
+  getParticle,
+  hasParticle,
+  removeParticle,
+  isParticleDead,
+  getParticleProgress,
+  getParticleColor,
+  interpolateColor,
+  setEmitter,
+  getEmitter,
+  hasEmitter,
+  removeEmitter,
+  setEmitterAppearance,
+  getEmitterAppearance,
+  getEmitterParticles,
+  trackParticle,
+  untrackParticle,
+  activateEmitter,
+  pauseEmitter,
+  isEmitterActive,
+  setEmitterRate,
+  setEmitterSpeed,
+  setEmitterGravity,
+} from 'blecsd';
+```
+
+## Particle Component
+
+### Component Data Layout
+
+```typescript
+const Particle = {
+  lifetime: Float32Array,  // Total lifetime in seconds
+  age:      Float32Array,  // Current age in seconds
+  fadeOut:   Uint8Array,    // 1=fades out, 0=no fade
+  char:     Uint32Array,   // Character code point to render
+  startFg:  Uint32Array,   // Foreground color at birth (packed RGBA)
+  endFg:    Uint32Array,   // Foreground color at death (packed RGBA)
+  emitter:  Uint32Array,   // Emitter entity ID (0 = none)
+};
+```
+
+### setParticle
+
+Creates or updates a particle on an entity.
+
+```typescript
+import { setParticle } from 'blecsd';
+
+setParticle(world, entity, {
+  lifetime: 1.5,
+  char: '*'.codePointAt(0)!,
+  startFg: 0xffff0000,  // Red
+  endFg: 0xff880000,    // Dark red
+  fadeOut: true,
+  emitter: emitterEntity,
+});
+```
+
+**Options:**
+- `lifetime` - Total lifetime in seconds (required)
+- `char` - Character code point (required)
+- `startFg` - Start color packed RGBA (required)
+- `endFg` - End color packed RGBA (default: same as `startFg`)
+- `fadeOut` - Whether particle fades (default: `false`)
+- `emitter` - Emitter entity ID (default: `0`)
+
+### getParticle
+
+```typescript
+import { getParticle } from 'blecsd';
+
+const p = getParticle(world, entity);
+if (p) {
+  console.log(`Age: ${p.age}/${p.lifetime}`);
+}
+```
+
+### isParticleDead / getParticleProgress / getParticleColor
+
+```typescript
+import { isParticleDead, getParticleProgress, getParticleColor } from 'blecsd';
+
+if (isParticleDead(world, entity)) {
+  // age >= lifetime, ready for removal
+}
+
+const progress = getParticleProgress(world, entity); // 0-1
+const color = getParticleColor(world, entity);        // Interpolated packed RGBA
+```
+
+### interpolateColor
+
+Utility for interpolating between two packed RGBA colors.
+
+```typescript
+import { interpolateColor } from 'blecsd';
+
+const mid = interpolateColor(0xffff0000, 0xff0000ff, 0.5); // Red to blue at 50%
+```
+
+### hasParticle / removeParticle
+
+```typescript
+import { hasParticle, removeParticle } from 'blecsd';
+
+if (hasParticle(world, entity)) {
+  removeParticle(world, entity); // Also untracks from emitter
+}
+```
+
+## ParticleEmitter Component
+
+### Component Data Layout
+
+```typescript
+const ParticleEmitter = {
+  rate:        Float32Array,  // Particles per second
+  burstCount:  Uint16Array,   // Burst particle count
+  lifetime:    Float32Array,  // Default particle lifetime
+  spread:      Float32Array,  // Emission spread angle (radians)
+  speed:       Float32Array,  // Initial particle speed (cells/sec)
+  gravity:     Float32Array,  // Downward acceleration (cells/sec^2)
+  angle:       Float32Array,  // Base emission angle (radians, 0 = right)
+  active:      Uint8Array,    // 1=active, 0=paused
+  accumulator: Float32Array,  // Internal rate accumulator
+};
+```
+
+### setEmitter
+
+Creates or updates an emitter on an entity.
+
+```typescript
+import { setEmitter } from 'blecsd';
+
+setEmitter(world, entity, {
+  rate: 20,
+  lifetime: 1.0,
+  speed: 5,
+  spread: Math.PI / 3,
+  gravity: 9.8,
+  active: true,
+});
+```
+
+**Options:**
+- `lifetime` - Default particle lifetime (required)
+- `rate` - Particles per second (default: `0`)
+- `burstCount` - Burst count (default: `0`)
+- `spread` - Spread angle in radians (default: `2*PI`)
+- `speed` - Initial speed (default: `3`)
+- `gravity` - Gravity (default: `0`)
+- `angle` - Base angle (default: `0`)
+- `active` - Whether emitting (default: `true`)
+
+### getEmitter
+
+```typescript
+import { getEmitter } from 'blecsd';
+
+const em = getEmitter(world, entity);
+if (em) {
+  console.log(`Rate: ${em.rate}, Speed: ${em.speed}`);
+}
+```
+
+### Emitter Controls
+
+```typescript
+import { activateEmitter, pauseEmitter, isEmitterActive } from 'blecsd';
+import { setEmitterRate, setEmitterSpeed, setEmitterGravity } from 'blecsd';
+
+activateEmitter(world, entity);
+pauseEmitter(world, entity);
+isEmitterActive(world, entity); // boolean
+
+setEmitterRate(world, entity, 50);
+setEmitterSpeed(world, entity, 10);
+setEmitterGravity(world, entity, 20);
+```
+
+### Emitter Appearance
+
+Configure the visual appearance of spawned particles.
+
+```typescript
+import { setEmitterAppearance, getEmitterAppearance } from 'blecsd';
+
+setEmitterAppearance(entity, {
+  chars: ['*', '.', 'o'].map(c => c.codePointAt(0)!),
+  startFg: 0xffff0000,
+  endFg: 0xff880000,
+  fadeOut: true,
+});
+
+const appearance = getEmitterAppearance(entity);
+```
+
+### Particle Tracking
+
+```typescript
+import { trackParticle, untrackParticle, getEmitterParticles } from 'blecsd';
+
+trackParticle(emitterEntity, particleEntity);
+untrackParticle(emitterEntity, particleEntity);
+
+const particles = getEmitterParticles(emitterEntity); // ReadonlySet<number>
+```
+
+### hasEmitter / removeEmitter
+
+```typescript
+import { hasEmitter, removeEmitter } from 'blecsd';
+
+if (hasEmitter(world, entity)) {
+  removeEmitter(world, entity); // Cleans up appearance and particle tracking
+}
+```
+
+## Usage Example
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import { setEmitter, setEmitterAppearance, setParticle, isParticleDead } from 'blecsd';
+
+const world = createWorld();
+const emitter = addEntity(world);
+
+// Configure emitter
+setEmitter(world, emitter, {
+  rate: 10,
+  lifetime: 2.0,
+  speed: 4,
+  spread: Math.PI / 4,
+  gravity: 5,
+});
+
+setEmitterAppearance(emitter, {
+  chars: ['*', '.'].map(c => c.codePointAt(0)!),
+  startFg: 0xffffff00, // Yellow
+  endFg: 0xffff0000,   // Red
+  fadeOut: true,
+});
+
+// Spawn a particle (typically done by the particle system)
+const particle = addEntity(world);
+setParticle(world, particle, {
+  lifetime: 2.0,
+  char: '*'.codePointAt(0)!,
+  startFg: 0xffffff00,
+  endFg: 0xffff0000,
+  fadeOut: true,
+  emitter,
+});
+```
+
+## Types
+
+### ParticleData
+
+```typescript
+interface ParticleData {
+  readonly lifetime: number;
+  readonly age: number;
+  readonly fadeOut: boolean;
+  readonly char: number;
+  readonly startFg: number;
+  readonly endFg: number;
+  readonly emitter: number;
+}
+```
+
+### EmitterData
+
+```typescript
+interface EmitterData {
+  readonly rate: number;
+  readonly burstCount: number;
+  readonly lifetime: number;
+  readonly spread: number;
+  readonly speed: number;
+  readonly gravity: number;
+  readonly angle: number;
+  readonly active: boolean;
+}
+```
+
+### EmitterAppearance
+
+```typescript
+interface EmitterAppearance {
+  chars: ReadonlyArray<number>;
+  startFg: number;
+  endFg?: number;
+  fadeOut?: boolean;
+}
+```

--- a/docs/api/components/sprite.md
+++ b/docs/api/components/sprite.md
@@ -1,0 +1,252 @@
+# Sprite Components API
+
+ECS component for frame-based sprite graphics with a global sprite sheet registry.
+
+## Overview
+
+The Sprite module provides two layers:
+- **Sprite store** - Registers named sprite sheets containing one or more frames of 2D cell data
+- **Sprite component** - Per-entity reference to a sprite sheet with current frame index
+
+Each sprite frame is a 2D grid of cells, where each cell has a character and optional foreground/background colors. Frames are stored in the global `spriteStore` and referenced by ID.
+
+## Import
+
+```typescript
+import {
+  Sprite,
+  spriteStore,
+  registerSprite,
+  getSpriteSheet,
+  getSpriteSheetByName,
+  getSpriteIdByName,
+  unregisterSprite,
+  setSprite,
+  setSpriteByName,
+  getSprite,
+  getCurrentFrame,
+  setFrame,
+  nextFrame,
+  prevFrame,
+  hasSprite,
+  getEntitySpriteSheet,
+  removeSprite,
+} from 'blecsd';
+```
+
+## Sprite Store
+
+### registerSprite
+
+Registers a sprite sheet and returns its numeric ID.
+
+```typescript
+import { registerSprite } from 'blecsd';
+
+const playerId = registerSprite({
+  name: 'player',
+  frames: [
+    [[{ char: '@' }]],           // Frame 0
+    [[{ char: 'O' }]],           // Frame 1
+  ],
+});
+
+// Multi-row sprite with colors
+const tankId = registerSprite({
+  name: 'tank',
+  frames: [
+    [
+      [{ char: ' ', bg: 0xff0000ff }, { char: ' ', bg: 0xff0000ff }],
+      [{ char: '/', fg: 0xffffffff }, { char: '\\', fg: 0xffffffff }],
+    ],
+  ],
+});
+```
+
+**Options:**
+- `name` - Human-readable name
+- `frames` - Array of `SpriteFrame` (2D arrays of `SpriteCell`)
+- `width` - Width in cells (inferred from first frame if omitted)
+- `height` - Height in cells (inferred from first frame if omitted)
+
+### getSpriteSheet / getSpriteSheetByName / getSpriteIdByName
+
+```typescript
+import { getSpriteSheet, getSpriteSheetByName, getSpriteIdByName } from 'blecsd';
+
+const sheet = getSpriteSheet(playerId);
+const same = getSpriteSheetByName('player');
+const id = getSpriteIdByName('player');
+
+if (sheet) {
+  console.log(`${sheet.name}: ${sheet.frames.length} frames, ${sheet.width}x${sheet.height}`);
+}
+```
+
+### unregisterSprite
+
+```typescript
+import { unregisterSprite } from 'blecsd';
+
+unregisterSprite(playerId); // returns true if found
+```
+
+## Sprite Component
+
+### Component Data Layout
+
+```typescript
+const Sprite = {
+  frameIndex:    Uint16Array,  // Current animation frame (0-based)
+  frameCount:    Uint16Array,  // Total frames (cached from sheet)
+  frameWidth:    Uint8Array,   // Width in cells (cached from sheet)
+  frameHeight:   Uint8Array,   // Height in cells (cached from sheet)
+  spriteSheetId: Uint32Array,  // Reference to sprite sheet ID
+};
+```
+
+### setSprite / setSpriteByName
+
+Assigns a sprite to an entity. Adds the component if not present.
+
+```typescript
+import { setSprite, setSpriteByName } from 'blecsd';
+
+setSprite(world, entity, playerId);
+setSprite(world, entity, playerId, 1); // Start at frame 1
+
+setSpriteByName(world, entity, 'player');
+```
+
+**Returns:** Entity ID for chaining, or `undefined` if sprite not found.
+
+### getSprite
+
+Returns sprite state for an entity.
+
+```typescript
+import { getSprite } from 'blecsd';
+
+const sprite = getSprite(world, entity);
+if (sprite) {
+  console.log(`Frame ${sprite.frameIndex + 1} of ${sprite.frameCount}`);
+}
+```
+
+**Returns:** `SpriteData | undefined`
+
+### getCurrentFrame
+
+Returns the current frame's 2D cell data.
+
+```typescript
+import { getCurrentFrame } from 'blecsd';
+
+const frame = getCurrentFrame(world, entity);
+if (frame) {
+  for (const row of frame) {
+    for (const cell of row) {
+      // Render cell.char with cell.fg and cell.bg
+    }
+  }
+}
+```
+
+**Returns:** `SpriteFrame | undefined`
+
+### setFrame / nextFrame / prevFrame
+
+Control frame index directly or step through frames.
+
+```typescript
+import { setFrame, nextFrame, prevFrame } from 'blecsd';
+
+setFrame(world, entity, 2);   // Jump to frame 2 (clamped to valid range)
+nextFrame(world, entity);      // Advance, wraps to 0 at end
+prevFrame(world, entity);      // Go back, wraps to last at 0
+```
+
+### hasSprite / getEntitySpriteSheet / removeSprite
+
+```typescript
+import { hasSprite, getEntitySpriteSheet, removeSprite } from 'blecsd';
+
+if (hasSprite(world, entity)) {
+  const sheet = getEntitySpriteSheet(world, entity);
+  console.log(sheet?.name);
+}
+
+removeSprite(world, entity); // Does not affect the sheet in the store
+```
+
+## Usage Example
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import { registerSprite, setSprite, nextFrame, getCurrentFrame } from 'blecsd';
+
+const world = createWorld();
+const entity = addEntity(world);
+
+// Register a simple animated sprite
+const coinId = registerSprite({
+  name: 'coin',
+  frames: [
+    [[{ char: 'O', fg: 0xffffff00 }]],
+    [[{ char: 'o', fg: 0xffffff00 }]],
+    [[{ char: '.', fg: 0xffffff00 }]],
+    [[{ char: 'o', fg: 0xffffff00 }]],
+  ],
+});
+
+// Assign to entity
+setSprite(world, entity, coinId);
+
+// Advance frame each tick
+nextFrame(world, entity);
+
+// Read current frame for rendering
+const frame = getCurrentFrame(world, entity);
+```
+
+## Types
+
+### SpriteCell
+
+```typescript
+interface SpriteCell {
+  char: string;
+  fg?: number;  // Packed RGBA
+  bg?: number;  // Packed RGBA
+}
+```
+
+### SpriteFrame
+
+```typescript
+type SpriteFrame = SpriteCell[][];  // [row][col]
+```
+
+### SpriteSheetData
+
+```typescript
+interface SpriteSheetData {
+  readonly id: number;
+  readonly name: string;
+  readonly frames: readonly SpriteFrame[];
+  readonly width: number;
+  readonly height: number;
+}
+```
+
+### SpriteData
+
+```typescript
+interface SpriteData {
+  readonly frameIndex: number;
+  readonly frameCount: number;
+  readonly frameWidth: number;
+  readonly frameHeight: number;
+  readonly spriteSheetId: number;
+}
+```

--- a/docs/api/components/state-machine.md
+++ b/docs/api/components/state-machine.md
@@ -1,0 +1,208 @@
+# State Machine Components API
+
+ECS component for finite state machines with typed states, events, and transition tracking.
+
+## Overview
+
+The StateMachine module attaches a finite state machine to an entity. State machine definitions are registered in a global store, and each entity tracks its current/previous state index and time spent in the current state. Transitions are triggered by sending named events.
+
+## Import
+
+```typescript
+import {
+  StateMachineStore,
+  attachStateMachine,
+  detachStateMachine,
+  getState,
+  getPreviousState,
+  sendEvent,
+  canSendEvent,
+  getStateAge,
+  isInState,
+  updateStateAge,
+  hasStateMachine,
+} from 'blecsd';
+```
+
+## Component Data Layout
+
+The component uses a custom store with the following typed arrays:
+
+```typescript
+interface StateMachineStore {
+  machineId:     Uint32Array,   // Index into machine definitions
+  currentState:  Uint16Array,   // Current state index
+  previousState: Uint16Array,   // Previous state index
+  stateAge:      Float32Array,  // Time in current state (seconds)
+}
+```
+
+## StateMachineStore (Definition Registry)
+
+The `StateMachineStore` object manages state machine definitions:
+
+```typescript
+import { StateMachineStore } from 'blecsd';
+
+// Register a definition (returns machine ID)
+const id = StateMachineStore.register({
+  initial: 'idle',
+  states: {
+    idle: { on: { activate: 'active' } },
+    active: { on: { deactivate: 'idle' } },
+  },
+});
+
+// Query definitions
+const machine = StateMachineStore.getMachine(id);
+const index = StateMachineStore.getStateIndex(id, 'idle');   // 0
+const name = StateMachineStore.getStateName(id, 0);          // 'idle'
+
+// Cleanup
+StateMachineStore.unregister(id);
+StateMachineStore.clear(); // Remove all
+```
+
+## Core Functions
+
+### attachStateMachine
+
+Attaches a state machine to an entity. Returns the machine ID.
+
+```typescript
+import { attachStateMachine } from 'blecsd';
+
+const machineId = attachStateMachine(world, entity, {
+  initial: 'idle',
+  states: {
+    idle: { on: { activate: 'active', destroy: 'dead' } },
+    active: { on: { deactivate: 'idle', destroy: 'dead' } },
+    dead: {},
+  },
+});
+```
+
+### detachStateMachine
+
+Removes the state machine from an entity and unregisters its definition.
+
+```typescript
+import { detachStateMachine } from 'blecsd';
+
+detachStateMachine(world, entity);
+```
+
+### getState / getPreviousState
+
+Query current and previous state names.
+
+```typescript
+import { getState, getPreviousState } from 'blecsd';
+
+const current = getState(world, entity);    // 'idle'
+const previous = getPreviousState(world, entity); // 'active'
+```
+
+**Returns:** State name string, or `''` if no machine attached.
+
+### sendEvent
+
+Sends an event to the entity's state machine. Returns whether a transition occurred.
+
+```typescript
+import { sendEvent } from 'blecsd';
+
+const transitioned = sendEvent(world, entity, 'activate');
+if (transitioned) {
+  console.log(`Now in state: ${getState(world, entity)}`);
+}
+```
+
+### canSendEvent
+
+Checks if an event would cause a transition from the current state.
+
+```typescript
+import { canSendEvent } from 'blecsd';
+
+if (canSendEvent(world, entity, 'activate')) {
+  sendEvent(world, entity, 'activate');
+}
+```
+
+### getStateAge
+
+Returns the time spent in the current state.
+
+```typescript
+import { getStateAge } from 'blecsd';
+
+const age = getStateAge(world, entity);
+if (age > 5.0) {
+  // Been in this state for over 5 seconds
+}
+```
+
+### isInState
+
+Convenience check for a specific state.
+
+```typescript
+import { isInState } from 'blecsd';
+
+if (isInState(world, entity, 'active')) {
+  // Handle active state
+}
+```
+
+### hasStateMachine
+
+```typescript
+import { hasStateMachine } from 'blecsd';
+
+if (hasStateMachine(world, entity)) {
+  // Entity has a state machine attached
+}
+```
+
+### updateStateAge
+
+Updates state age for a batch of entities. Call each frame.
+
+```typescript
+import { updateStateAge } from 'blecsd';
+
+updateStateAge(world, entities, deltaTime);
+```
+
+## Usage Example
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import { attachStateMachine, sendEvent, getState, isInState, updateStateAge } from 'blecsd';
+
+const world = createWorld();
+const entity = addEntity(world);
+
+// Attach a door state machine
+attachStateMachine(world, entity, {
+  initial: 'closed',
+  states: {
+    closed: { on: { open: 'opening' } },
+    opening: { on: { opened: 'open' } },
+    open: { on: { close: 'closing' } },
+    closing: { on: { closed: 'closed' } },
+  },
+});
+
+console.log(getState(world, entity)); // 'closed'
+
+sendEvent(world, entity, 'open');
+console.log(getState(world, entity)); // 'opening'
+
+sendEvent(world, entity, 'opened');
+console.log(isInState(world, entity, 'open')); // true
+
+// Each frame
+updateStateAge(world, [entity], deltaTime);
+```

--- a/docs/api/components/terminal-buffer.md
+++ b/docs/api/components/terminal-buffer.md
@@ -1,0 +1,287 @@
+# Terminal Buffer Components API
+
+ECS component for terminal emulator buffers with a 2D cell grid, cursor state, scrollback history, and ANSI escape sequence processing.
+
+## Overview
+
+The TerminalBuffer component provides a full terminal emulator buffer. It stores a 2D grid of styled cells, tracks cursor position and visibility, maintains scrollback history, supports alternate screen buffers, and processes ANSI/CSI escape sequences including SGR color codes, cursor movement, and erase commands.
+
+## Import
+
+```typescript
+import {
+  TerminalBuffer,
+  setTerminalBuffer,
+  hasTerminalBuffer,
+  getTerminalState,
+  getTerminalBuffer,
+  writeChar,
+  writeToTerminal,
+  clearTerminal,
+  resetTerminal,
+  setCursorPosition,
+  setCursorVisible,
+  scrollTerminalUp,
+  scrollTerminalDown,
+  scrollTerminalToTop,
+  scrollTerminalToBottom,
+  resizeTerminalBuffer,
+  removeTerminalBuffer,
+  renderTerminalToAnsi,
+  getTerminalCells,
+} from 'blecsd';
+```
+
+## Component Data Layout
+
+Scalar data stored in typed arrays:
+
+```typescript
+const TerminalBuffer = {
+  isTerminal:      Uint8Array,   // Tag (1 = has terminal buffer)
+  width:           Uint16Array,  // Width in columns
+  height:          Uint16Array,  // Height in rows
+  cursorX:         Uint16Array,  // Cursor column
+  cursorY:         Uint16Array,  // Cursor row
+  cursorVisible:   Uint8Array,   // 1=visible, 0=hidden
+  scrollOffset:    Uint32Array,  // Scroll offset from top
+  altScreenActive: Uint8Array,   // 1=alternate screen active
+};
+```
+
+Complex state (cell buffer, scrollback, parser state) is stored in a separate `Map<Entity, TerminalState>`.
+
+## Constants
+
+```typescript
+import {
+  DEFAULT_TERMINAL_WIDTH,   // 80
+  DEFAULT_TERMINAL_HEIGHT,  // 24
+  DEFAULT_SCROLLBACK_LINES, // 1000
+} from 'blecsd';
+```
+
+## Core Functions
+
+### setTerminalBuffer
+
+Initializes a terminal buffer on an entity. Configuration is validated with Zod.
+
+```typescript
+import { setTerminalBuffer } from 'blecsd';
+
+setTerminalBuffer(world, entity, {
+  width: 80,
+  height: 24,
+  scrollbackLines: 1000,
+  cursorVisible: true,
+  cursorShape: 'block',
+  cursorBlink: true,
+});
+```
+
+All options are optional and use defaults.
+
+### hasTerminalBuffer
+
+```typescript
+import { hasTerminalBuffer } from 'blecsd';
+
+if (hasTerminalBuffer(entity)) {
+  // Entity has a terminal buffer
+}
+```
+
+### getTerminalBuffer
+
+Returns scalar terminal state.
+
+```typescript
+import { getTerminalBuffer } from 'blecsd';
+
+const buf = getTerminalBuffer(entity);
+if (buf) {
+  console.log(`${buf.width}x${buf.height}, cursor at (${buf.cursorX}, ${buf.cursorY})`);
+}
+```
+
+### getTerminalState
+
+Returns the full internal state including cell buffer, scrollback, and parser state.
+
+```typescript
+import { getTerminalState } from 'blecsd';
+
+const state = getTerminalState(entity);
+// state.buffer, state.scrollback, state.currentAttr, etc.
+```
+
+## Writing
+
+### writeChar
+
+Writes a single character at the cursor position. Handles `\n`, `\r`, `\b`, `\t`.
+
+```typescript
+import { writeChar } from 'blecsd';
+
+writeChar(world, entity, 'A');
+writeChar(world, entity, '\n');
+```
+
+### writeToTerminal
+
+Writes a string with ANSI escape sequence processing. Supports CSI sequences for cursor movement, SGR color codes (basic, 256-color, RGB), erase commands, and DEC private modes (cursor visibility, alternate screen buffer).
+
+```typescript
+import { writeToTerminal } from 'blecsd';
+
+writeToTerminal(world, entity, '\x1b[31mRed text\x1b[0m Normal text\n');
+writeToTerminal(world, entity, '\x1b[2J');  // Clear screen
+```
+
+## Cursor
+
+### setCursorPosition / setCursorVisible
+
+```typescript
+import { setCursorPosition, setCursorVisible } from 'blecsd';
+
+setCursorPosition(world, entity, 10, 5); // Column 10, row 5
+setCursorVisible(world, entity, false);   // Hide cursor
+```
+
+## Scrolling
+
+### scrollTerminalUp / scrollTerminalDown / scrollTerminalToTop / scrollTerminalToBottom
+
+```typescript
+import {
+  scrollTerminalUp,
+  scrollTerminalDown,
+  scrollTerminalToTop,
+  scrollTerminalToBottom,
+} from 'blecsd';
+
+scrollTerminalUp(world, entity, 5);    // Scroll up 5 lines into history
+scrollTerminalDown(world, entity, 5);  // Scroll down 5 lines
+scrollTerminalToTop(world, entity);    // Top of scrollback
+scrollTerminalToBottom(world, entity); // Back to current view
+```
+
+## Terminal Management
+
+### clearTerminal / resetTerminal
+
+```typescript
+import { clearTerminal, resetTerminal } from 'blecsd';
+
+clearTerminal(world, entity);  // Clear cells, reset cursor
+resetTerminal(world, entity);  // Full reset including scrollback and parser state
+```
+
+### resizeTerminalBuffer
+
+Resizes the buffer, preserving existing content where possible.
+
+```typescript
+import { resizeTerminalBuffer } from 'blecsd';
+
+resizeTerminalBuffer(world, entity, 120, 40);
+```
+
+### removeTerminalBuffer
+
+Removes the terminal buffer and cleans up all state.
+
+```typescript
+import { removeTerminalBuffer } from 'blecsd';
+
+removeTerminalBuffer(entity);
+```
+
+## Rendering
+
+### renderTerminalToAnsi
+
+Renders the terminal buffer to an ANSI string for display. Respects scroll offset.
+
+```typescript
+import { renderTerminalToAnsi } from 'blecsd';
+
+const output = renderTerminalToAnsi(entity);
+process.stdout.write(output);
+```
+
+### getTerminalCells
+
+Returns the raw cell array for custom rendering.
+
+```typescript
+import { getTerminalCells } from 'blecsd';
+
+const cells = getTerminalCells(entity);
+// cells: readonly Cell[] | undefined
+```
+
+## Usage Example
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import { setTerminalBuffer, writeToTerminal, getTerminalBuffer, renderTerminalToAnsi } from 'blecsd';
+
+const world = createWorld();
+const entity = addEntity(world);
+
+// Initialize terminal
+setTerminalBuffer(world, entity, { width: 80, height: 24 });
+
+// Write colored text
+writeToTerminal(world, entity, '\x1b[32mHello, \x1b[1mWorld!\x1b[0m\n');
+
+// Check state
+const buf = getTerminalBuffer(entity);
+console.log(`Cursor: (${buf?.cursorX}, ${buf?.cursorY})`);
+
+// Render to ANSI
+const output = renderTerminalToAnsi(entity);
+```
+
+## Types
+
+### TerminalState
+
+```typescript
+interface TerminalState {
+  readonly buffer: ScreenBufferData;
+  readonly scrollback: ScrollbackBuffer;
+  currentAttr: Attribute;
+  escapeBuffer: string;
+  inEscape: boolean;
+  savedCursorX: number;
+  savedCursorY: number;
+  savedAttr: Attribute;
+  altBuffer: ScreenBufferData | null;
+  cursorShape: CursorShape;
+  cursorBlink: boolean;
+}
+```
+
+### CursorShape
+
+```typescript
+type CursorShape = 'block' | 'underline' | 'bar';
+```
+
+### TerminalBufferConfig
+
+```typescript
+interface TerminalBufferConfig {
+  width?: number;           // default: 80
+  height?: number;          // default: 24
+  scrollbackLines?: number; // default: 1000
+  cursorVisible?: boolean;  // default: true
+  cursorShape?: CursorShape; // default: 'block'
+  cursorBlink?: boolean;    // default: true
+}
+```

--- a/docs/api/components/tilemap.md
+++ b/docs/api/components/tilemap.md
@@ -1,0 +1,306 @@
+# TileMap Components API
+
+ECS components for 2D tile-based maps with multi-layer support, tileset management, and viewport rendering.
+
+## Overview
+
+The TileMap module provides three layers of functionality:
+- **Tileset store** - Registers named tilesets (arrays of tile definitions with char/color)
+- **Tile data store** - Manages variable-sized tile grids with multiple layers
+- **TileMap component** - Per-entity reference linking a tileset and tile data together
+
+Tile data uses `Uint16Array` for compact storage, supporting up to 65,535 tile types per tileset. Index 0 (`EMPTY_TILE`) is conventionally empty/transparent.
+
+## Import
+
+```typescript
+import {
+  TileMap,
+  EMPTY_TILE,
+  // Tileset store
+  registerTileset,
+  getTileset,
+  getTilesetByName,
+  unregisterTileset,
+  // Tile data store
+  createTileData,
+  getTileData,
+  removeTileData,
+  setTile,
+  getTile,
+  fillTiles,
+  fillTileRect,
+  getLayerCount,
+  addLayer,
+  setLayerVisible,
+  isLayerVisible,
+  // TileMap component
+  setTileMap,
+  getTileMap,
+  hasTileMap,
+  removeTileMap,
+  getTileMapDataId,
+  // Rendering
+  renderTileMapArea,
+} from 'blecsd';
+```
+
+## Tileset Store
+
+### registerTileset
+
+Registers a tileset and returns its numeric ID.
+
+```typescript
+import { registerTileset } from 'blecsd';
+
+const tilesetId = registerTileset({
+  name: 'dungeon',
+  tiles: [
+    { char: ' ', fg: 0, bg: 0 },                    // 0: empty
+    { char: '.', fg: 0x888888ff, bg: 0 },            // 1: floor
+    { char: '#', fg: 0xaaaaaaff, bg: 0x444444ff },   // 2: wall
+    { char: '~', fg: 0x0000ffff, bg: 0x000066ff },   // 3: water
+  ],
+});
+```
+
+### getTileset / getTilesetByName / unregisterTileset
+
+```typescript
+import { getTileset, getTilesetByName, unregisterTileset } from 'blecsd';
+
+const tileset = getTileset(tilesetId);
+const same = getTilesetByName('dungeon');
+unregisterTileset(tilesetId);
+```
+
+## Tile Data Store
+
+### createTileData
+
+Creates a tile data grid with specified dimensions and layer count. Returns a data ID.
+
+```typescript
+import { createTileData } from 'blecsd';
+
+const dataId = createTileData(32, 32, 2); // 32x32 map, 2 layers
+```
+
+### setTile / getTile
+
+Set or get individual tiles by position and layer.
+
+```typescript
+import { setTile, getTile, EMPTY_TILE } from 'blecsd';
+
+setTile(dataId, 0, 5, 3, 2);  // Layer 0, position (5,3), tile index 2
+
+const tile = getTile(dataId, 0, 5, 3);
+if (tile !== EMPTY_TILE) {
+  // Tile is not empty
+}
+```
+
+### fillTiles / fillTileRect
+
+Fill operations for bulk tile placement.
+
+```typescript
+import { fillTiles, fillTileRect } from 'blecsd';
+
+fillTiles(dataId, 0, 1);                // Fill entire layer with floor
+fillTileRect(dataId, 0, 2, 4, 5, 3, 2); // 5x3 wall region at (2,4)
+```
+
+### Layer Management
+
+```typescript
+import { getLayerCount, addLayer, setLayerVisible, isLayerVisible } from 'blecsd';
+
+const count = getLayerCount(dataId);     // Number of layers
+const newIdx = addLayer(dataId);          // Add a new empty layer
+setLayerVisible(dataId, 1, false);        // Hide layer 1
+const visible = isLayerVisible(dataId, 0); // Check visibility
+```
+
+### getTileData / removeTileData
+
+```typescript
+import { getTileData, removeTileData } from 'blecsd';
+
+const data = getTileData(dataId);
+if (data) {
+  console.log(`Map: ${data.width}x${data.height}, ${data.layers.length} layers`);
+}
+
+removeTileData(dataId);
+```
+
+## TileMap Component
+
+### Component Data Layout
+
+```typescript
+const TileMap = {
+  width:     Uint16Array,  // Map width in tiles
+  height:    Uint16Array,  // Map height in tiles
+  tileWidth: Uint8Array,   // Tile width in terminal cells
+  tileHeight: Uint8Array,  // Tile height in terminal cells
+  dataId:    Uint32Array,  // Reference to tile data
+  tilesetId: Uint32Array,  // Reference to tileset
+};
+```
+
+### setTileMap
+
+Creates a tile map on an entity. Automatically creates tile data if not provided.
+
+```typescript
+import { setTileMap } from 'blecsd';
+
+setTileMap(world, entity, {
+  width: 20,
+  height: 15,
+  tilesetId: tilesetId,
+  layerCount: 2,
+  tileWidth: 1,   // default: 1
+  tileHeight: 1,  // default: 1
+});
+```
+
+**Options:**
+- `width`, `height` - Map dimensions in tiles (required)
+- `tilesetId` - Tileset ID (required)
+- `tileWidth`, `tileHeight` - Tile size in terminal cells (default: `1`)
+- `layerCount` - Number of layers (default: `1`)
+- `dataId` - Existing data ID to reuse (skips creation)
+
+### getTileMap
+
+```typescript
+import { getTileMap } from 'blecsd';
+
+const map = getTileMap(world, entity);
+if (map) {
+  console.log(`Map: ${map.width}x${map.height}`);
+}
+```
+
+**Returns:** `TileMapComponentData | undefined`
+
+### hasTileMap / removeTileMap / getTileMapDataId
+
+```typescript
+import { hasTileMap, removeTileMap, getTileMapDataId } from 'blecsd';
+
+if (hasTileMap(world, entity)) {
+  const dataId = getTileMapDataId(world, entity);
+  removeTileMap(world, entity);           // Removes component and tile data
+  removeTileMap(world, entity, true);     // Keeps tile data in store
+}
+```
+
+## Rendering
+
+### renderTileMapArea
+
+Renders a rectangular viewport of the tile map to a 2D array of cells. Composites all visible layers from bottom to top.
+
+```typescript
+import { renderTileMapArea } from 'blecsd';
+
+const cells = renderTileMapArea(dataId, tilesetId, viewX, viewY, viewWidth, viewHeight);
+for (let y = 0; y < cells.length; y++) {
+  for (let x = 0; x < cells[y].length; x++) {
+    const cell = cells[y][x];
+    // Render cell.char with cell.fg and cell.bg
+  }
+}
+```
+
+**Returns:** `RenderedTileCell[][]` (row-major: `[y][x]`)
+
+## Usage Example
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import {
+  registerTileset,
+  setTileMap,
+  getTileMapDataId,
+  fillTiles,
+  fillTileRect,
+  setTile,
+  renderTileMapArea,
+} from 'blecsd';
+
+const world = createWorld();
+const entity = addEntity(world);
+
+// Register tileset
+const tilesetId = registerTileset({
+  name: 'dungeon',
+  tiles: [
+    { char: ' ', fg: 0, bg: 0 },
+    { char: '.', fg: 0x888888ff, bg: 0 },
+    { char: '#', fg: 0xaaaaaaff, bg: 0x444444ff },
+  ],
+});
+
+// Create tile map
+setTileMap(world, entity, { width: 20, height: 15, tilesetId });
+const dataId = getTileMapDataId(world, entity);
+
+// Fill with floor, then add walls
+fillTiles(dataId, 0, 1);
+fillTileRect(dataId, 0, 0, 0, 20, 1, 2);   // Top wall
+fillTileRect(dataId, 0, 0, 14, 20, 1, 2);  // Bottom wall
+
+// Render viewport
+const cells = renderTileMapArea(dataId, tilesetId, 0, 0, 20, 15);
+```
+
+## Types
+
+### TileDefinition
+
+```typescript
+interface TileDefinition {
+  readonly char: string;
+  readonly fg: number;  // Packed RGBA
+  readonly bg: number;  // Packed RGBA
+}
+```
+
+### TileMapComponentData
+
+```typescript
+interface TileMapComponentData {
+  readonly width: number;
+  readonly height: number;
+  readonly tileWidth: number;
+  readonly tileHeight: number;
+  readonly dataId: number;
+  readonly tilesetId: number;
+}
+```
+
+### TileMapLayer
+
+```typescript
+interface TileMapLayer {
+  readonly tiles: Uint16Array;
+  visible: boolean;
+}
+```
+
+### RenderedTileCell
+
+```typescript
+interface RenderedTileCell {
+  readonly char: string;
+  readonly fg: number;
+  readonly bg: number;
+}
+```

--- a/docs/api/components/velocity.md
+++ b/docs/api/components/velocity.md
@@ -1,0 +1,295 @@
+# Velocity Components API
+
+ECS components for entity movement with velocity, acceleration, friction, and speed clamping.
+
+## Overview
+
+The velocity module provides two components:
+- **Velocity** - Per-entity speed (x/y cells per second) with max speed and friction
+- **Acceleration** - Per-entity acceleration (x/y cells per second squared)
+
+A complete movement update applies acceleration to velocity, friction, speed clamping, and then velocity to position, all in a single `updateEntityMovement` call.
+
+## Import
+
+```typescript
+import {
+  Velocity,
+  Acceleration,
+  setVelocity,
+  setVelocityOptions,
+  getVelocity,
+  hasVelocity,
+  setMaxSpeed,
+  setFriction,
+  addVelocity,
+  getSpeed,
+  stopEntity,
+  removeVelocity,
+  setAcceleration,
+  getAcceleration,
+  hasAcceleration,
+  clearAcceleration,
+  removeAcceleration,
+  updateEntityMovement,
+  applyAccelerationToEntity,
+  applyFrictionToEntity,
+  clampSpeedForEntity,
+  applyVelocityToEntity,
+} from 'blecsd';
+```
+
+## Velocity Component
+
+### Component Data Layout
+
+```typescript
+const Velocity = {
+  x:        Float32Array,  // X velocity in cells per second
+  y:        Float32Array,  // Y velocity in cells per second
+  maxSpeed: Float32Array,  // Maximum speed (0 = unlimited)
+  friction: Float32Array,  // Friction factor 0-1 (0 = none)
+};
+```
+
+### setVelocity
+
+Sets X/Y velocity on an entity. Adds the component if not present.
+
+```typescript
+import { setVelocity } from 'blecsd';
+
+setVelocity(world, entity, 5, -2); // Right 5, up 2 cells/sec
+```
+
+### setVelocityOptions
+
+Sets velocity with all options.
+
+```typescript
+import { setVelocityOptions } from 'blecsd';
+
+setVelocityOptions(world, entity, {
+  x: 5,
+  y: 0,
+  maxSpeed: 10,
+  friction: 0.1,
+});
+```
+
+### getVelocity
+
+Returns velocity state for an entity.
+
+```typescript
+import { getVelocity } from 'blecsd';
+
+const vel = getVelocity(world, entity);
+if (vel) {
+  const speed = Math.sqrt(vel.x * vel.x + vel.y * vel.y);
+  console.log(`Moving at ${speed} cells/sec`);
+}
+```
+
+**Returns:** `VelocityData | undefined`
+
+### hasVelocity
+
+```typescript
+import { hasVelocity } from 'blecsd';
+
+if (hasVelocity(world, entity)) {
+  // Entity has velocity
+}
+```
+
+### setMaxSpeed / setFriction
+
+```typescript
+import { setMaxSpeed, setFriction } from 'blecsd';
+
+setMaxSpeed(world, entity, 15);   // 0 = unlimited
+setFriction(world, entity, 0.05); // 0-1, clamped
+```
+
+### addVelocity
+
+Adds to current velocity (impulse).
+
+```typescript
+import { addVelocity } from 'blecsd';
+
+addVelocity(world, entity, 0, -10); // Jump impulse
+```
+
+### getSpeed
+
+Returns the magnitude of velocity.
+
+```typescript
+import { getSpeed } from 'blecsd';
+
+const speed = getSpeed(world, entity); // 0 if no component
+```
+
+### stopEntity / removeVelocity
+
+```typescript
+import { stopEntity, removeVelocity } from 'blecsd';
+
+stopEntity(world, entity);     // Sets velocity to zero
+removeVelocity(world, entity); // Resets all fields to zero
+```
+
+## Acceleration Component
+
+### Component Data Layout
+
+```typescript
+const Acceleration = {
+  x: Float32Array,  // X acceleration in cells/sec^2
+  y: Float32Array,  // Y acceleration in cells/sec^2
+};
+```
+
+### setAcceleration
+
+Sets acceleration on an entity. Adds the component if not present.
+
+```typescript
+import { setAcceleration } from 'blecsd';
+
+setAcceleration(world, entity, 0, 20); // Gravity
+```
+
+### getAcceleration
+
+```typescript
+import { getAcceleration } from 'blecsd';
+
+const accel = getAcceleration(world, entity);
+if (accel) {
+  console.log(`Accel: (${accel.x}, ${accel.y})`);
+}
+```
+
+**Returns:** `AccelerationData | undefined`
+
+### hasAcceleration / clearAcceleration / removeAcceleration
+
+```typescript
+import { hasAcceleration, clearAcceleration, removeAcceleration } from 'blecsd';
+
+if (hasAcceleration(world, entity)) {
+  clearAcceleration(world, entity);  // Set to (0, 0)
+  removeAcceleration(world, entity); // Reset all fields
+}
+```
+
+## Movement Update
+
+### updateEntityMovement
+
+Full movement update for a single entity. Applies: acceleration, friction, speed clamping, then velocity to position.
+
+```typescript
+import { updateEntityMovement } from 'blecsd';
+
+// In your update loop
+updateEntityMovement(world, entity, deltaTime);
+```
+
+### Individual Update Steps
+
+For finer control, use the individual functions:
+
+```typescript
+import {
+  applyAccelerationToEntity,
+  applyFrictionToEntity,
+  clampSpeedForEntity,
+  applyVelocityToEntity,
+} from 'blecsd';
+
+applyAccelerationToEntity(entity, deltaTime);
+applyFrictionToEntity(entity, deltaTime);
+clampSpeedForEntity(entity);
+applyVelocityToEntity(entity, deltaTime);
+```
+
+Note: These lower-level functions take only `Entity` (not `World`) and access typed arrays directly.
+
+## Usage Example
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import {
+  setVelocity,
+  setAcceleration,
+  setFriction,
+  setMaxSpeed,
+  updateEntityMovement,
+  getSpeed,
+} from 'blecsd';
+
+const world = createWorld();
+const entity = addEntity(world);
+
+// Set initial velocity and physics
+setVelocity(world, entity, 10, 0);
+setAcceleration(world, entity, 0, 20); // Gravity
+setFriction(world, entity, 0.02);
+setMaxSpeed(world, entity, 30);
+
+// Each frame
+updateEntityMovement(world, entity, deltaTime);
+console.log(`Speed: ${getSpeed(world, entity)}`);
+```
+
+## Direct Component Access
+
+For high-performance code in systems, access arrays directly:
+
+```typescript
+import { Velocity, Acceleration } from 'blecsd';
+
+for (const eid of entities) {
+  const vx = Velocity.x[eid];
+  const vy = Velocity.y[eid];
+  const ax = Acceleration.x[eid];
+  const ay = Acceleration.y[eid];
+}
+```
+
+## Types
+
+### VelocityData
+
+```typescript
+interface VelocityData {
+  readonly x: number;
+  readonly y: number;
+  readonly maxSpeed: number;
+  readonly friction: number;
+}
+```
+
+### VelocityOptions
+
+```typescript
+interface VelocityOptions {
+  x?: number;
+  y?: number;
+  maxSpeed?: number;
+  friction?: number;
+}
+```
+
+### AccelerationData
+
+```typescript
+interface AccelerationData {
+  readonly x: number;
+  readonly y: number;
+}
+```

--- a/docs/api/core/ecs.md
+++ b/docs/api/core/ecs.md
@@ -1,0 +1,200 @@
+# ECS API
+
+ECS primitives wrapper module. This is the only file in the codebase that imports directly from bitecs. All other code must import ECS primitives from `'blecsd'` or from `'../core/ecs'` for internal library code.
+
+## Quick Start
+
+```typescript
+import { createWorld, addEntity, addComponent, hasComponent, query, Position, Velocity } from 'blecsd';
+
+const world = createWorld();
+const entity = addEntity(world);
+addComponent(world, entity, Position);
+Position.x[entity] = 100;
+Position.y[entity] = 50;
+
+const entities = query(world, [Position, Velocity]);
+```
+
+## Entity Operations
+
+### addEntity
+
+Creates a new entity in the world.
+
+```typescript
+function addEntity(world: World): Entity;
+```
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+
+const world = createWorld();
+const player = addEntity(world);
+const enemy = addEntity(world);
+```
+
+### removeEntity
+
+Removes an entity and all its components from the world.
+
+```typescript
+function removeEntity(world: World, eid: Entity): void;
+```
+
+### entityExists
+
+Checks if an entity exists in the world.
+
+```typescript
+function entityExists(world: World, eid: Entity): boolean;
+```
+
+```typescript
+import { entityExists, addEntity, removeEntity } from 'blecsd';
+
+console.log(entityExists(world, entity)); // true
+removeEntity(world, entity);
+console.log(entityExists(world, entity)); // false
+```
+
+### getAllEntities
+
+Gets all entity IDs currently in the world.
+
+```typescript
+function getAllEntities(world: World): readonly Entity[];
+```
+
+## Component Operations
+
+### addComponent
+
+Adds a component to an entity.
+
+```typescript
+function addComponent(world: World, eid: Entity, component: ComponentRef): void;
+```
+
+```typescript
+import { addComponent, Position } from 'blecsd';
+
+addComponent(world, entity, Position);
+Position.x[entity] = 100;
+Position.y[entity] = 50;
+```
+
+### hasComponent
+
+Checks if an entity has a specific component.
+
+```typescript
+function hasComponent(world: World, eid: Entity, component: ComponentRef): boolean;
+```
+
+### removeComponent
+
+Removes a component from an entity.
+
+```typescript
+function removeComponent(world: World, eid: Entity, component: ComponentRef): void;
+```
+
+## Query Operations
+
+### query
+
+Queries the world for entities that have all specified components.
+
+```typescript
+function query(world: World, components: QueryTerm[]): QueryResult;
+```
+
+```typescript
+import { query, Position, Velocity } from 'blecsd';
+
+const movingEntities = query(world, [Position, Velocity]);
+for (const eid of movingEntities) {
+  Position.x[eid] += Velocity.x[eid];
+  Position.y[eid] += Velocity.y[eid];
+}
+```
+
+## Advanced
+
+### registerComponent
+
+Registers a component with the world. Typically called automatically when components are first used.
+
+```typescript
+const registerComponent: (world: World, component: ComponentRef) => void;
+```
+
+### withStore
+
+Creates a component with a custom backing store.
+
+```typescript
+const withStore: (store: Record<string, TypedArray>) => ComponentRef;
+```
+
+```typescript
+import { withStore } from 'blecsd';
+
+const CustomPosition = withStore({
+  x: new Float32Array(10000),
+  y: new Float32Array(10000),
+});
+```
+
+## Re-exports
+
+This module re-exports for convenience:
+- `Entity`, `World` types from `core/types`
+- `createWorld`, `resetWorld` from `core/world`
+- `ComponentRef`, `QueryResult`, `QueryTerm` types from bitecs
+
+## Usage Example
+
+```typescript
+import {
+  createWorld,
+  addEntity,
+  addComponent,
+  removeComponent,
+  hasComponent,
+  removeEntity,
+  query,
+  entityExists,
+  getAllEntities,
+} from 'blecsd';
+
+const world = createWorld();
+
+// Create entities with components
+const player = addEntity(world);
+addComponent(world, player, Position);
+addComponent(world, player, Velocity);
+Position.x[player] = 0;
+Velocity.x[player] = 1;
+
+const wall = addEntity(world);
+addComponent(world, wall, Position);
+Position.x[wall] = 100;
+
+// Query for moving entities
+const movers = query(world, [Position, Velocity]);
+for (const eid of movers) {
+  Position.x[eid] += Velocity.x[eid];
+}
+
+// Check components
+if (hasComponent(world, player, Velocity)) {
+  removeComponent(world, player, Velocity); // Stop moving
+}
+
+// Cleanup
+removeEntity(world, player);
+console.log(entityExists(world, player)); // false
+console.log(getAllEntities(world).length); // 1 (wall remains)
+```

--- a/docs/api/core/entity-data.md
+++ b/docs/api/core/entity-data.md
@@ -1,0 +1,220 @@
+# Entity Data API
+
+Arbitrary key-value data storage for entities. Store custom data on entities without creating new bitecs components. Useful for user-defined metadata, temporary state, or application-specific data.
+
+## Quick Start
+
+```typescript
+import { setEntityData, getEntityData, hasEntityData } from 'blecsd';
+
+// Store data on an entity
+setEntityData(entity, 'name', 'Player 1');
+setEntityData(entity, 'score', 100);
+
+// Retrieve data
+const name = getEntityData<string>(entity, 'name');
+const score = getEntityData<number>(entity, 'score', 0);
+```
+
+## Types
+
+### DataValue
+
+```typescript
+type DataValue = unknown;
+```
+
+### EntityDataMap
+
+```typescript
+type EntityDataMap = Map<string, DataValue>;
+```
+
+## Functions
+
+### getEntityData
+
+Gets a value stored on an entity.
+
+```typescript
+function getEntityData<T = DataValue>(eid: Entity, key: string, defaultValue?: T): T;
+```
+
+**Parameters:**
+- `eid` - The entity ID
+- `key` - The key to retrieve
+- `defaultValue` - Default value if key doesn't exist
+
+**Returns:** The stored value or defaultValue.
+
+```typescript
+import { getEntityData } from 'blecsd';
+
+const score = getEntityData<number>(entity, 'score', 0);
+```
+
+### setEntityData
+
+Sets a value on an entity.
+
+```typescript
+function setEntityData(eid: Entity, key: string, value: DataValue): void;
+```
+
+```typescript
+import { setEntityData } from 'blecsd';
+
+setEntityData(entity, 'name', 'Player 1');
+setEntityData(entity, 'inventory', { gold: 100, items: [] });
+setEntityData(entity, 'onDeath', () => console.log('Game over'));
+```
+
+### hasEntityData
+
+Checks if an entity has data stored for a specific key.
+
+```typescript
+function hasEntityData(eid: Entity, key: string): boolean;
+```
+
+### deleteEntityData
+
+Deletes a specific key from an entity's data.
+
+```typescript
+function deleteEntityData(eid: Entity, key: string): boolean;
+```
+
+### getEntityDataKeys
+
+Gets all keys stored on an entity.
+
+```typescript
+function getEntityDataKeys(eid: Entity): string[];
+```
+
+### getAllEntityData
+
+Gets all data stored on an entity as a plain object.
+
+```typescript
+function getAllEntityData(eid: Entity): Record<string, DataValue>;
+```
+
+### setEntityDataBulk
+
+Sets multiple values on an entity at once.
+
+```typescript
+function setEntityDataBulk(eid: Entity, data: Record<string, DataValue>): void;
+```
+
+```typescript
+import { setEntityDataBulk } from 'blecsd';
+
+setEntityDataBulk(entity, {
+  name: 'Player 1',
+  score: 0,
+  lives: 3,
+  powerups: [],
+});
+```
+
+### clearEntityData
+
+Clears all data stored on an entity.
+
+```typescript
+function clearEntityData(eid: Entity): void;
+```
+
+### clearAllEntityData
+
+Clears all entity data from the global store.
+
+```typescript
+function clearAllEntityData(): void;
+```
+
+### getEntityDataCount
+
+Gets the number of entities with stored data.
+
+```typescript
+function getEntityDataCount(): number;
+```
+
+### hasAnyEntityData
+
+Checks if an entity has any data stored.
+
+```typescript
+function hasAnyEntityData(eid: Entity): boolean;
+```
+
+### updateEntityData
+
+Updates a value on an entity using a transform function.
+
+```typescript
+function updateEntityData<T = DataValue>(
+  eid: Entity,
+  key: string,
+  transform: (current: T | undefined) => T
+): void;
+```
+
+```typescript
+import { updateEntityData } from 'blecsd';
+
+// Increment score
+updateEntityData<number>(entity, 'score', (current) => (current ?? 0) + 10);
+
+// Toggle boolean
+updateEntityData<boolean>(entity, 'visible', (current) => !current);
+
+// Append to array
+updateEntityData<string[]>(entity, 'items', (current) => [...(current ?? []), newItem]);
+```
+
+## Usage Example
+
+```typescript
+import {
+  setEntityData,
+  getEntityData,
+  setEntityDataBulk,
+  updateEntityData,
+  clearEntityData,
+  getAllEntityData,
+} from 'blecsd';
+
+// Initialize player data
+setEntityDataBulk(playerEntity, {
+  name: 'Hero',
+  hp: 100,
+  maxHp: 100,
+  inventory: [],
+  buffs: [],
+});
+
+// Game logic
+function takeDamage(entity: Entity, amount: number) {
+  updateEntityData<number>(entity, 'hp', (hp) => Math.max(0, (hp ?? 0) - amount));
+
+  if (getEntityData<number>(entity, 'hp', 0) <= 0) {
+    handleDeath(entity);
+  }
+}
+
+function collectItem(entity: Entity, item: string) {
+  updateEntityData<string[]>(entity, 'inventory', (inv) => [...(inv ?? []), item]);
+}
+
+// Debug: inspect entity
+const allData = getAllEntityData(playerEntity);
+console.log(allData);
+
+// Cleanup on entity destruction
+clearEntityData(playerEntity);
+```

--- a/docs/api/core/event-bubbling.md
+++ b/docs/api/core/event-bubbling.md
@@ -1,0 +1,197 @@
+# Event Bubbling API
+
+Hierarchical event propagation system. Events bubble up from a target entity through its ancestors, following DOM-like event propagation semantics with stopPropagation, stopImmediatePropagation, and preventDefault.
+
+## Quick Start
+
+```typescript
+import { createBubbleableEvent, bubbleEvent, createEntityEventBusStore } from 'blecsd';
+
+const store = createEntityEventBusStore<MyEvents>();
+const bus = store.getOrCreate(buttonEntity, createBus);
+bus.on('click', (e) => console.log('clicked!', e.payload));
+
+const event = createBubbleableEvent({
+  type: 'click',
+  target: buttonEntity,
+  payload: { x: 10, y: 20 },
+});
+
+const result = bubbleEvent(world, event, store.get);
+if (!result.defaultPrevented) {
+  // Perform default click behavior
+}
+```
+
+## Types
+
+### BubbleableEvent
+
+An event that can bubble up through the entity hierarchy.
+
+```typescript
+interface BubbleableEvent<T = unknown> {
+  readonly type: string;
+  readonly target: Entity;
+  currentTarget: Entity;
+  readonly bubbles: boolean;
+  defaultPrevented: boolean;
+  propagationStopped: boolean;
+  immediatePropagationStopped: boolean;
+  readonly payload: T;
+  stopPropagation(): void;
+  stopImmediatePropagation(): void;
+  preventDefault(): void;
+}
+```
+
+**Fields:**
+- `type` - The event type name
+- `target` - The entity where the event originated (stays fixed during bubbling)
+- `currentTarget` - The entity currently handling the event (changes during bubbling)
+- `bubbles` - Whether this event bubbles up through the hierarchy
+- `payload` - The event payload data
+
+**Methods:**
+- `stopPropagation()` - Stops bubbling to parent entities; handlers on the current entity still fire
+- `stopImmediatePropagation()` - Stops the event immediately; no more handlers fire
+- `preventDefault()` - Prevents default behavior; does not stop propagation
+
+### BubbleableEventOptions
+
+```typescript
+interface BubbleableEventOptions<T> {
+  type: string;
+  target: Entity;
+  payload: T;
+  bubbles?: boolean;  // default: true
+}
+```
+
+### GetEntityEventBus
+
+```typescript
+type GetEntityEventBus<T extends EventMap> = (
+  world: World,
+  eid: Entity
+) => EventBus<T> | undefined;
+```
+
+### BubbleResult
+
+```typescript
+interface BubbleResult {
+  defaultPrevented: boolean;
+  propagationStopped: boolean;
+  dispatchCount: number;
+}
+```
+
+## Functions
+
+### createBubbleableEvent
+
+Creates a new bubbleable event.
+
+```typescript
+function createBubbleableEvent<T>(options: BubbleableEventOptions<T>): BubbleableEvent<T>;
+```
+
+```typescript
+import { createBubbleableEvent } from 'blecsd';
+
+const event = createBubbleableEvent({
+  type: 'click',
+  target: buttonEntity,
+  payload: { x: 10, y: 20 },
+  bubbles: true,
+});
+```
+
+### bubbleEvent
+
+Bubbles an event up through the entity hierarchy. At each entity, the event is emitted to that entity's EventBus. Bubbling stops when the root is reached, stopPropagation() is called, or bubbles is false.
+
+```typescript
+function bubbleEvent<T, E extends EventMap>(
+  world: World,
+  event: BubbleableEvent<T>,
+  getEventBus: GetEntityEventBus<E>
+): BubbleResult;
+```
+
+**Parameters:**
+- `world` - The ECS world
+- `event` - The bubbleable event to dispatch
+- `getEventBus` - Function to get an entity's EventBus
+
+**Returns:** Result with defaultPrevented, propagationStopped, and dispatchCount.
+
+### createEntityEventBusStore
+
+Creates a simple entity event bus store for managing entity-to-bus mappings.
+
+```typescript
+function createEntityEventBusStore<E extends EventMap>(): {
+  get: GetEntityEventBus<E>;
+  getOrCreate: (eid: Entity, createBus: () => EventBus<E>) => EventBus<E>;
+  set: (eid: Entity, bus: EventBus<E>) => void;
+  delete: (eid: Entity) => boolean;
+  has: (eid: Entity) => boolean;
+  clear: () => void;
+};
+```
+
+## Usage Example
+
+```typescript
+import {
+  createBubbleableEvent,
+  bubbleEvent,
+  createEntityEventBusStore,
+} from 'blecsd';
+
+// Define event types
+interface UIEvents {
+  click: BubbleableEvent<{ x: number; y: number }>;
+  focus: BubbleableEvent<void>;
+  keydown: BubbleableEvent<{ key: string }>;
+}
+
+// Create event bus store
+const store = createEntityEventBusStore<UIEvents>();
+
+// Attach handlers to entities
+const buttonBus = store.getOrCreate(buttonEntity, createBus);
+buttonBus.on('click', (event) => {
+  console.log(`Button clicked at ${event.payload.x}, ${event.payload.y}`);
+  // Prevent default if handled
+  event.preventDefault();
+});
+
+const containerBus = store.getOrCreate(containerEntity, createBus);
+containerBus.on('click', (event) => {
+  console.log('Click bubbled to container');
+  // This fires unless button called stopPropagation()
+});
+
+const rootBus = store.getOrCreate(rootEntity, createBus);
+rootBus.on('click', (event) => {
+  console.log('Click reached root');
+});
+
+// Dispatch an event
+const clickEvent = createBubbleableEvent({
+  type: 'click',
+  target: buttonEntity,
+  payload: { x: 10, y: 20 },
+});
+
+const result = bubbleEvent(world, clickEvent, store.get);
+// result.dispatchCount = 3 (button, container, root)
+// result.defaultPrevented = true (button called preventDefault)
+
+// Cleanup
+store.delete(buttonEntity);
+store.clear();
+```

--- a/docs/api/core/game-loop.md
+++ b/docs/api/core/game-loop.md
@@ -1,0 +1,237 @@
+# Game Loop API
+
+Game loop with input priority, lifecycle management, fixed timestep support, and performance statistics.
+
+## Quick Start
+
+```typescript
+import { createGameLoop, createWorld, LoopPhase } from 'blecsd';
+
+const world = createWorld();
+const loop = createGameLoop(world, { targetFPS: 60 }, {
+  onStart: () => console.log('Game started!'),
+  onStop: () => console.log('Game stopped!'),
+});
+
+loop.registerSystem(LoopPhase.UPDATE, myUpdateSystem);
+loop.registerInputSystem(myInputSystem);
+
+loop.start();
+setTimeout(() => loop.stop(), 5000);
+```
+
+## Types
+
+### LoopHook
+
+```typescript
+type LoopHook = (world: World, deltaTime: number) => void;
+```
+
+### FixedUpdateHook
+
+```typescript
+type FixedUpdateHook = (world: World, fixedDeltaTime: number, tickNumber: number) => void;
+```
+
+### InterpolateHook
+
+```typescript
+type InterpolateHook = (world: World, alpha: number) => void;
+```
+
+### FixedTimestepConfig
+
+Configuration for fixed timestep mode. Essential for deterministic physics, network sync, and replays.
+
+```typescript
+interface FixedTimestepConfig {
+  readonly tickRate: number;             // default: 60
+  readonly maxUpdatesPerFrame: number;   // default: 5
+  readonly interpolate: boolean;         // default: true
+}
+```
+
+### GameLoopOptions
+
+```typescript
+interface GameLoopOptions {
+  targetFPS?: number;                   // default: 60
+  fixedTimestep?: boolean;              // default: true (deprecated, use fixedTimestepMode)
+  maxDeltaTime?: number;               // default: 0.1
+  fixedTimestepMode?: FixedTimestepConfig;
+}
+```
+
+### GameLoopHooks
+
+Lifecycle hooks for the game loop.
+
+```typescript
+interface GameLoopHooks {
+  onBeforeInput?: LoopHook;
+  onAfterInput?: LoopHook;
+  onBeforeUpdate?: LoopHook;
+  onAfterUpdate?: LoopHook;
+  onBeforeRender?: LoopHook;
+  onAfterRender?: LoopHook;
+  onStart?: () => void;
+  onStop?: () => void;
+  onPause?: () => void;
+  onResume?: () => void;
+  onBeforeFixedUpdate?: FixedUpdateHook;
+  onAfterFixedUpdate?: FixedUpdateHook;
+  onInterpolate?: InterpolateHook;
+}
+```
+
+### LoopStats
+
+```typescript
+interface LoopStats {
+  fps: number;
+  frameTime: number;
+  frameCount: number;
+  runningTime: number;
+  tickCount: number;
+  ticksPerSecond: number;
+  interpolationAlpha: number;
+  skippedUpdates: number;
+}
+```
+
+### LoopState
+
+```typescript
+enum LoopState {
+  STOPPED = 0,
+  RUNNING = 1,
+  PAUSED = 2,
+}
+```
+
+### GameLoop
+
+```typescript
+interface GameLoop {
+  getState(): LoopState;
+  isRunning(): boolean;
+  isPaused(): boolean;
+  isStopped(): boolean;
+  getStats(): LoopStats;
+  getInterpolationAlpha(): number;
+  getFixedTimestepConfig(): FixedTimestepConfig | undefined;
+  isFixedTimestepMode(): boolean;
+  getScheduler(): Scheduler;
+  getWorld(): World;
+  setWorld(world: World): void;
+  setTargetFPS(fps: number): void;
+  getTargetFPS(): number;
+  registerSystem(phase: number, system: System, priority?: number): void;
+  unregisterSystem(system: System): void;
+  registerInputSystem(system: System, priority?: number): void;
+  setHooks(hooks: GameLoopHooks): void;
+  start(): void;
+  stop(): void;
+  pause(): void;
+  resume(): void;
+  step(deltaTime?: number): void;
+  stepFixed(): void;
+}
+```
+
+## Functions
+
+### createGameLoop
+
+Creates a new game loop instance. Input is always processed first every frame.
+
+```typescript
+function createGameLoop(
+  initialWorld: World,
+  options?: GameLoopOptions,
+  initialHooks?: GameLoopHooks
+): GameLoop;
+```
+
+**Parameters:**
+- `initialWorld` - The ECS world to process
+- `options` - Loop configuration options
+- `initialHooks` - Lifecycle hooks
+
+**Returns:** A new GameLoop instance.
+
+### isLoopRunning
+
+Checks if a game loop exists and is running.
+
+```typescript
+function isLoopRunning(loop: GameLoop | undefined): boolean;
+```
+
+### isLoopPaused
+
+Checks if a game loop exists and is paused.
+
+```typescript
+function isLoopPaused(loop: GameLoop | undefined): boolean;
+```
+
+## Usage Example
+
+### Variable Timestep
+
+```typescript
+import { createGameLoop, createWorld, LoopPhase } from 'blecsd';
+
+const world = createWorld();
+const loop = createGameLoop(world, { targetFPS: 60 });
+
+loop.registerInputSystem(inputSystem);
+loop.registerSystem(LoopPhase.UPDATE, gameLogicSystem);
+loop.registerSystem(LoopPhase.RENDER, renderSystem);
+
+loop.start();
+```
+
+### Fixed Timestep with Interpolation
+
+```typescript
+import { createGameLoop, createWorld, LoopPhase } from 'blecsd';
+
+const world = createWorld();
+const loop = createGameLoop(world, {
+  fixedTimestepMode: {
+    tickRate: 60,
+    maxUpdatesPerFrame: 5,
+    interpolate: true,
+  },
+}, {
+  onInterpolate: (world, alpha) => {
+    // Smooth rendering between physics ticks
+    interpolatePositions(world, alpha);
+  },
+});
+
+loop.registerInputSystem(inputSystem);
+loop.registerSystem(LoopPhase.UPDATE, physicsSystem);
+loop.registerSystem(LoopPhase.RENDER, renderSystem);
+
+loop.start();
+```
+
+### Manual Stepping (Testing)
+
+```typescript
+import { createGameLoop, createWorld } from 'blecsd';
+
+const world = createWorld();
+const loop = createGameLoop(world);
+
+// Step manually for deterministic testing
+loop.step(1 / 60); // Advance one frame at 60fps
+loop.step(1 / 60);
+
+const stats = loop.getStats();
+console.log(`Frames: ${stats.frameCount}`);
+```

--- a/docs/api/core/input-actions.md
+++ b/docs/api/core/input-actions.md
@@ -1,0 +1,243 @@
+# Input Actions API
+
+Input action mapping system for game controls. Maps physical inputs (keys, mouse buttons) to logical game actions with support for multiple bindings per action, runtime rebinding, and save/load.
+
+## Quick Start
+
+```typescript
+import { createInputActionManager, ActionPresets } from 'blecsd';
+
+// Create with preset bindings
+const actions = createInputActionManager(ActionPresets.platformer);
+
+// Or define custom bindings
+const actions = createInputActionManager([
+  { action: 'jump', keys: ['space'] },
+  { action: 'attack', keys: ['j'], mouseButtons: ['left'] },
+  { action: 'move_left', keys: ['a', 'left'], continuous: true },
+]);
+
+// Query state each frame
+actions.update(inputState, deltaTime);
+if (actions.isJustActivated('jump')) {
+  performJump();
+}
+```
+
+## Types
+
+### ActionBinding
+
+Configuration for a single action binding.
+
+```typescript
+interface ActionBinding {
+  readonly action: string;
+  readonly keys: readonly string[];
+  readonly mouseButtons?: readonly MouseButton[];
+  readonly continuous?: boolean;
+  readonly deadzone?: number;
+}
+```
+
+**Fields:**
+- `action` - Unique action identifier (e.g., `'jump'`, `'attack'`, `'move_left'`)
+- `keys` - Keys that activate this action
+- `mouseButtons` - Mouse buttons that activate this action
+- `continuous` - Whether action fires continuously while held (default: `false`)
+- `deadzone` - Deadzone for analog inputs, 0-1 (default: `0.1`)
+
+### ActionState
+
+Runtime state of an action.
+
+```typescript
+interface ActionState {
+  readonly active: boolean;
+  readonly justActivated: boolean;
+  readonly justDeactivated: boolean;
+  readonly activeTime: number;
+  readonly value: number;
+}
+```
+
+**Fields:**
+- `active` - Action is currently active (input is held)
+- `justActivated` - Action was just activated this frame
+- `justDeactivated` - Action was just deactivated this frame
+- `activeTime` - How long the action has been active (ms)
+- `value` - Analog value (0-1), 1 when digital input is pressed
+
+### SerializedBindings
+
+Serialized action bindings for save/load.
+
+```typescript
+interface SerializedBindings {
+  readonly version: number;
+  readonly bindings: readonly {
+    readonly action: string;
+    readonly keys: readonly string[];
+    readonly mouseButtons?: readonly string[];
+    readonly continuous?: boolean;
+  }[];
+}
+```
+
+### ActionCallback
+
+```typescript
+type ActionCallback = (action: string, state: ActionState, inputState: InputState) => void;
+```
+
+### InputActionManager
+
+The full interface for the action manager.
+
+```typescript
+interface InputActionManager {
+  register(binding: ActionBinding): InputActionManager;
+  registerAll(bindings: readonly ActionBinding[]): InputActionManager;
+  unregister(action: string): boolean;
+  hasAction(action: string): boolean;
+  getActions(): string[];
+  getBinding(action: string): ActionBinding | undefined;
+  update(inputState: InputState, deltaTime: number): void;
+  isActive(action: string): boolean;
+  isJustActivated(action: string): boolean;
+  isJustDeactivated(action: string): boolean;
+  getValue(action: string): number;
+  getActiveTime(action: string): number;
+  getState(action: string): ActionState;
+  getActiveActions(): string[];
+  rebindKeys(action: string, keys: readonly string[]): boolean;
+  rebindMouseButtons(action: string, buttons: readonly MouseButton[]): boolean;
+  addKey(action: string, key: string): boolean;
+  removeKey(action: string, key: string): boolean;
+  getKeysForAction(action: string): string[];
+  getMouseButtonsForAction(action: string): MouseButton[];
+  getActionsForKey(key: string): string[];
+  onAction(action: string, callback: ActionCallback): () => void;
+  onAnyAction(callback: ActionCallback): () => void;
+  saveBindings(): SerializedBindings;
+  loadBindings(data: unknown): void;
+  toJSON(pretty?: boolean): string;
+  fromJSON(json: string): void;
+  resetStates(): void;
+  clear(): void;
+}
+```
+
+## Functions
+
+### createInputActionManager
+
+Creates a new InputActionManager.
+
+```typescript
+function createInputActionManager(
+  initialBindings?: readonly ActionBinding[]
+): InputActionManager;
+```
+
+**Parameters:**
+- `initialBindings` - Optional initial bindings to register
+
+**Returns:** A new InputActionManager instance.
+
+```typescript
+import { createInputActionManager } from 'blecsd';
+
+const actions = createInputActionManager([
+  { action: 'jump', keys: ['space'] },
+  { action: 'attack', keys: ['j'], mouseButtons: ['left'] },
+]);
+```
+
+## Validation Schemas
+
+### ActionBindingSchema
+
+Zod schema for validating action bindings at runtime.
+
+```typescript
+import { ActionBindingSchema } from 'blecsd';
+
+const result = ActionBindingSchema.parse({
+  action: 'jump',
+  keys: ['space'],
+  continuous: false,
+});
+```
+
+### SerializedBindingsSchema
+
+Zod schema for validating serialized binding data.
+
+```typescript
+import { SerializedBindingsSchema } from 'blecsd';
+
+const result = SerializedBindingsSchema.parse(loadedData);
+```
+
+## Presets
+
+### ActionPresets
+
+Common action presets for quick setup.
+
+```typescript
+import { ActionPresets, createInputActionManager } from 'blecsd';
+
+// Standard platformer controls (move_left, move_right, jump, crouch, attack)
+const platformer = createInputActionManager(ActionPresets.platformer);
+
+// Standard top-down controls (move_up, move_down, move_left, move_right, action)
+const topDown = createInputActionManager(ActionPresets.topDown);
+
+// Menu navigation controls (up, down, left, right, confirm, cancel)
+const menu = createInputActionManager(ActionPresets.menu);
+```
+
+## Usage Example
+
+```typescript
+import { createInputActionManager, createInputState } from 'blecsd';
+
+const inputState = createInputState();
+const actions = createInputActionManager([
+  { action: 'move_left', keys: ['a', 'left'], continuous: true },
+  { action: 'move_right', keys: ['d', 'right'], continuous: true },
+  { action: 'jump', keys: ['space', 'w', 'up'] },
+  { action: 'attack', keys: ['j', 'enter'] },
+]);
+
+// Listen for specific actions
+const unsub = actions.onAction('attack', (action, state) => {
+  if (state.justActivated) {
+    console.log('Attack!');
+  }
+});
+
+// In game loop
+function update(deltaTime: number) {
+  actions.update(inputState, deltaTime);
+
+  if (actions.isActive('move_left')) {
+    player.x -= speed * deltaTime;
+  }
+  if (actions.isJustActivated('jump')) {
+    player.vy = -jumpForce;
+  }
+}
+
+// Runtime rebinding
+actions.rebindKeys('jump', ['space', 'z']);
+
+// Save/load bindings
+const json = actions.toJSON(true);
+actions.fromJSON(json);
+
+// Cleanup
+unsub();
+```

--- a/docs/api/core/input-event-buffer.md
+++ b/docs/api/core/input-event-buffer.md
@@ -1,0 +1,323 @@
+# Input Event Buffer API
+
+Frame-independent input event buffering. Buffers keyboard and mouse events between frames so no input is lost. Events are collected asynchronously from stdin and drained synchronously each frame by the game loop.
+
+## Quick Start
+
+```typescript
+import { createInputEventBuffer, pushKeyEvent, drainKeys, drainMouse } from 'blecsd';
+
+const buffer = createInputEventBuffer({ maxBufferSize: 500 });
+
+// Push events from stdin handler
+pushKeyEvent(buffer, keyEvent);
+pushMouseEvent(buffer, mouseEvent);
+
+// Drain in game loop
+const keys = drainKeys(buffer);
+const mouse = drainMouse(buffer);
+```
+
+## Types
+
+### TimestampedKeyEvent
+
+```typescript
+interface TimestampedKeyEvent {
+  readonly type: 'key';
+  readonly event: KeyEvent;
+  readonly timestamp: number;
+}
+```
+
+### TimestampedMouseEvent
+
+```typescript
+interface TimestampedMouseEvent {
+  readonly type: 'mouse';
+  readonly event: MouseEvent;
+  readonly timestamp: number;
+}
+```
+
+### TimestampedInputEvent
+
+```typescript
+type TimestampedInputEvent = TimestampedKeyEvent | TimestampedMouseEvent;
+```
+
+### InputBufferStats
+
+```typescript
+interface InputBufferStats {
+  readonly totalKeyEvents: number;
+  readonly totalMouseEvents: number;
+  readonly pendingKeyEvents: number;
+  readonly pendingMouseEvents: number;
+  readonly droppedEvents: number;
+  readonly maxBufferSize: number;
+}
+```
+
+### InputLatencyStats
+
+Latency statistics for input processing. All values in milliseconds.
+
+```typescript
+interface InputLatencyStats {
+  readonly min: number;
+  readonly max: number;
+  readonly avg: number;
+  readonly p95: number;
+  readonly p99: number;
+  readonly sampleCount: number;
+  readonly lastFrameProcessingTime: number;
+  readonly avgFrameProcessingTime: number;
+}
+```
+
+### InputEventBufferOptions
+
+```typescript
+interface InputEventBufferOptions {
+  readonly maxBufferSize?: number;      // default: 1000
+  readonly warnOnOverflow?: boolean;    // default: true
+  readonly onOverflow?: (droppedCount: number) => void;
+  readonly maxLatencySamples?: number;  // default: 1000
+  readonly maxFrameSamples?: number;    // default: 100
+}
+```
+
+### InputEventBufferData
+
+The buffer data structure containing all state.
+
+```typescript
+interface InputEventBufferData {
+  keyEvents: TimestampedKeyEvent[];
+  mouseEvents: TimestampedMouseEvent[];
+  latencySamples: number[];
+  frameProcessingTimes: number[];
+  frameStartTime: number;
+  totalKeyEvents: number;
+  totalMouseEvents: number;
+  droppedEvents: number;
+  readonly config: { ... };
+}
+```
+
+## Functions
+
+### createInputEventBuffer
+
+Creates a new input event buffer.
+
+```typescript
+function createInputEventBuffer(options?: InputEventBufferOptions): InputEventBufferData;
+```
+
+**Parameters:**
+- `options` - Buffer configuration options
+
+**Returns:** A new InputEventBufferData.
+
+### pushKeyEvent
+
+Pushes a keyboard event to the buffer.
+
+```typescript
+function pushKeyEvent(buffer: InputEventBufferData, event: KeyEvent, timestamp?: number): void;
+```
+
+### pushMouseEvent
+
+Pushes a mouse event to the buffer.
+
+```typescript
+function pushMouseEvent(buffer: InputEventBufferData, event: MouseEvent, timestamp?: number): void;
+```
+
+### drainKeys
+
+Drains all keyboard events from the buffer. Returns events in order (oldest first) and clears the buffer.
+
+```typescript
+function drainKeys(buffer: InputEventBufferData): TimestampedKeyEvent[];
+```
+
+### drainMouse
+
+Drains all mouse events from the buffer. Returns events in order (oldest first) and clears the buffer.
+
+```typescript
+function drainMouse(buffer: InputEventBufferData): TimestampedMouseEvent[];
+```
+
+### drainAllEvents
+
+Drains all events (keys and mouse) from the buffer sorted by timestamp.
+
+```typescript
+function drainAllEvents(buffer: InputEventBufferData): TimestampedInputEvent[];
+```
+
+### peekEvents / peekKeys / peekMouse
+
+Peek at pending events without removing them.
+
+```typescript
+function peekEvents(buffer: InputEventBufferData): TimestampedInputEvent[];
+function peekKeys(buffer: InputEventBufferData): readonly TimestampedKeyEvent[];
+function peekMouse(buffer: InputEventBufferData): readonly TimestampedMouseEvent[];
+```
+
+### clearBuffer
+
+Clears all pending events from the buffer.
+
+```typescript
+function clearBuffer(buffer: InputEventBufferData): void;
+```
+
+### getPendingKeyCount / getPendingMouseCount / getPendingCount
+
+Get counts of pending events.
+
+```typescript
+function getPendingKeyCount(buffer: InputEventBufferData): number;
+function getPendingMouseCount(buffer: InputEventBufferData): number;
+function getPendingCount(buffer: InputEventBufferData): number;
+```
+
+### hasPendingEvents
+
+Checks if there are any pending events.
+
+```typescript
+function hasPendingEvents(buffer: InputEventBufferData): boolean;
+```
+
+### getStats
+
+Gets buffer statistics for debugging.
+
+```typescript
+function getStats(buffer: InputEventBufferData): InputBufferStats;
+```
+
+### resetStats
+
+Resets buffer statistics.
+
+```typescript
+function resetStats(buffer: InputEventBufferData): void;
+```
+
+### beginFrame / endFrame
+
+Marks the start and end of frame processing for latency tracking.
+
+```typescript
+function beginFrame(buffer: InputEventBufferData): void;
+function endFrame(buffer: InputEventBufferData): number;
+```
+
+### recordLatency / recordLatencyBatch
+
+Records latency for processed events.
+
+```typescript
+function recordLatency(buffer: InputEventBufferData, latencyMs: number): void;
+function recordLatencyBatch(buffer: InputEventBufferData, avgLatencyMs: number, eventCount: number): void;
+```
+
+### getLatencyStats
+
+Gets latency statistics for input processing.
+
+```typescript
+function getLatencyStats(buffer: InputEventBufferData): InputLatencyStats;
+```
+
+### resetLatencyStats
+
+Resets latency statistics.
+
+```typescript
+function resetLatencyStats(buffer: InputEventBufferData): void;
+```
+
+### isLatencyAcceptable
+
+Checks if p95 latency is within acceptable bounds (default: 16ms).
+
+```typescript
+function isLatencyAcceptable(buffer: InputEventBufferData, maxLatencyMs?: number): boolean;
+```
+
+### isProcessingTimeAcceptable
+
+Checks if average frame processing time is within budget (default: 1ms).
+
+```typescript
+function isProcessingTimeAcceptable(buffer: InputEventBufferData, maxProcessingTimeMs?: number): boolean;
+```
+
+## Constants
+
+### globalInputBuffer
+
+Global shared input buffer for simple use cases.
+
+```typescript
+import { globalInputBuffer, pushKeyEvent, drainAllEvents } from 'blecsd';
+
+pushKeyEvent(globalInputBuffer, event);
+const events = drainAllEvents(globalInputBuffer);
+```
+
+## Usage Example
+
+```typescript
+import {
+  createInputEventBuffer,
+  pushKeyEvent,
+  pushMouseEvent,
+  drainKeys,
+  drainMouse,
+  beginFrame,
+  endFrame,
+  getLatencyStats,
+} from 'blecsd';
+
+const buffer = createInputEventBuffer({
+  maxBufferSize: 500,
+  warnOnOverflow: true,
+});
+
+// Async: push events from stdin
+stdinHandler.onKey((event) => pushKeyEvent(buffer, event));
+stdinHandler.onMouse((event) => pushMouseEvent(buffer, event));
+
+// Game loop
+function update(deltaTime: number) {
+  beginFrame(buffer);
+
+  const keys = drainKeys(buffer);
+  const mouse = drainMouse(buffer);
+
+  for (const { event, timestamp } of keys) {
+    handleKey(event);
+    const latency = performance.now() - timestamp;
+    recordLatency(buffer, latency);
+  }
+
+  endFrame(buffer);
+
+  // Monitor latency
+  const stats = getLatencyStats(buffer);
+  if (stats.p95 > 16) {
+    console.warn(`Input latency: ${stats.p95.toFixed(2)}ms p95`);
+  }
+}
+```

--- a/docs/api/core/input-state.md
+++ b/docs/api/core/input-state.md
@@ -1,0 +1,263 @@
+# Input State API
+
+Frame-aware input state tracking for keyboard and mouse. Provides queries like `isKeyPressed` (just this frame), `isKeyReleased`, key hold time, and repeat handling.
+
+## Quick Start
+
+```typescript
+import { createInputState, getMovementDirection } from 'blecsd';
+
+const inputState = createInputState({ trackRepeats: true });
+
+// Each frame: update with buffered events
+inputState.update(keyEvents, mouseEvents, deltaTime);
+
+// Query state
+if (inputState.isKeyPressed('space')) {
+  jump();
+}
+
+const dir = getMovementDirection(inputState);
+player.x += dir.x * speed;
+player.y += dir.y * speed;
+```
+
+## Types
+
+### KeyState
+
+State of a single key.
+
+```typescript
+interface KeyState {
+  readonly pressed: boolean;
+  readonly justPressed: boolean;
+  readonly justReleased: boolean;
+  readonly heldTime: number;
+  readonly repeatCount: number;
+  readonly lastEventTime: number;
+}
+```
+
+### MouseButtonState
+
+State of a mouse button.
+
+```typescript
+interface MouseButtonState {
+  readonly pressed: boolean;
+  readonly justPressed: boolean;
+  readonly justReleased: boolean;
+  readonly heldTime: number;
+  readonly lastEventTime: number;
+}
+```
+
+### MouseState
+
+Current mouse position and state.
+
+```typescript
+interface MouseState {
+  readonly x: number;
+  readonly y: number;
+  readonly deltaX: number;
+  readonly deltaY: number;
+  readonly wheelDelta: number;
+  readonly buttons: Readonly<Record<MouseButton, MouseButtonState>>;
+}
+```
+
+### InputStateStats
+
+Input state statistics.
+
+```typescript
+interface InputStateStats {
+  readonly keysDown: number;
+  readonly keysPressed: number;
+  readonly keysReleased: number;
+  readonly keyEventsThisFrame: number;
+  readonly mouseEventsThisFrame: number;
+  readonly frameCount: number;
+}
+```
+
+### InputStateConfig
+
+Configuration for input state tracking.
+
+```typescript
+interface InputStateConfig {
+  readonly trackRepeats?: boolean;       // default: true
+  readonly debounceTime?: number;        // default: 0 (no debouncing)
+  readonly customRepeatRate?: number;    // default: undefined (use OS repeat)
+  readonly customRepeatDelay?: number;   // default: 500
+}
+```
+
+### InputState
+
+The full interface for the input state tracker.
+
+```typescript
+interface InputState {
+  update(keyEvents: readonly TimestampedKeyEvent[], mouseEvents: readonly TimestampedMouseEvent[], deltaTime: number): void;
+  isKeyDown(key: KeyName | string): boolean;
+  isKeyPressed(key: KeyName | string): boolean;
+  isKeyReleased(key: KeyName | string): boolean;
+  getKeyHeldTime(key: KeyName | string): number;
+  getKeyState(key: KeyName | string): KeyState;
+  getKeyRepeatCount(key: KeyName | string): number;
+  getPressedKeys(): string[];
+  getJustPressedKeys(): string[];
+  getJustReleasedKeys(): string[];
+  isCtrlDown(): boolean;
+  isAltDown(): boolean;
+  isShiftDown(): boolean;
+  hasModifier(): boolean;
+  isMouseButtonDown(button: MouseButton): boolean;
+  isMouseButtonPressed(button: MouseButton): boolean;
+  isMouseButtonReleased(button: MouseButton): boolean;
+  getMouseX(): number;
+  getMouseY(): number;
+  getMousePosition(): { x: number; y: number };
+  getMouseDelta(): { deltaX: number; deltaY: number };
+  getWheelDelta(): number;
+  getMouseState(): MouseState;
+  releaseKey(key: KeyName | string): void;
+  releaseAllKeys(): void;
+  releaseAllMouseButtons(): void;
+  releaseAll(): void;
+  getStats(): InputStateStats;
+  getFrameCount(): number;
+  reset(): void;
+}
+```
+
+## Functions
+
+### createInputState
+
+Creates a new InputState tracker.
+
+```typescript
+function createInputState(config?: InputStateConfig): InputState;
+```
+
+**Parameters:**
+- `config` - Optional configuration options
+
+**Returns:** A new InputState instance.
+
+```typescript
+import { createInputState } from 'blecsd';
+
+const inputState = createInputState({
+  trackRepeats: true,
+  debounceTime: 50,
+});
+```
+
+### isAnyKeyDown
+
+Checks if any of the specified keys are pressed.
+
+```typescript
+function isAnyKeyDown(inputState: InputState, keys: readonly (KeyName | string)[]): boolean;
+```
+
+```typescript
+import { isAnyKeyDown } from 'blecsd';
+
+if (isAnyKeyDown(inputState, ['w', 'up'])) {
+  moveForward();
+}
+```
+
+### isAllKeysDown
+
+Checks if all specified keys are pressed.
+
+```typescript
+function isAllKeysDown(inputState: InputState, keys: readonly (KeyName | string)[]): boolean;
+```
+
+```typescript
+import { isAllKeysDown } from 'blecsd';
+
+if (isAllKeysDown(inputState, ['ctrl', 's'])) {
+  save();
+}
+```
+
+### isAnyKeyPressed
+
+Checks if any of the specified keys were just pressed this frame.
+
+```typescript
+function isAnyKeyPressed(inputState: InputState, keys: readonly (KeyName | string)[]): boolean;
+```
+
+### getMovementDirection
+
+Gets the direction vector from WASD or arrow keys.
+
+```typescript
+function getMovementDirection(inputState: InputState): { x: number; y: number };
+```
+
+**Returns:** Object with `x` (-1, 0, or 1) and `y` (-1, 0, or 1).
+
+```typescript
+import { getMovementDirection } from 'blecsd';
+
+const dir = getMovementDirection(inputState);
+player.x += dir.x * speed;
+player.y += dir.y * speed;
+```
+
+## Usage Example
+
+```typescript
+import { createInputState, createInputEventBuffer, drainKeys, drainMouse } from 'blecsd';
+
+const inputState = createInputState({ trackRepeats: true });
+const buffer = createInputEventBuffer();
+
+// Each frame in your game loop
+function gameLoop(deltaTime: number) {
+  const keys = drainKeys(buffer);
+  const mouse = drainMouse(buffer);
+  inputState.update(keys, mouse, deltaTime);
+
+  // Check for single-frame events
+  if (inputState.isKeyPressed('escape')) {
+    openPauseMenu();
+  }
+
+  // Check for held keys
+  if (inputState.isKeyDown('shift')) {
+    sprint();
+  }
+
+  // Check hold duration
+  const holdTime = inputState.getKeyHeldTime('space');
+  if (holdTime > 1000) {
+    chargeAttack();
+  }
+
+  // Mouse state
+  const { x, y } = inputState.getMousePosition();
+  const { deltaX, deltaY } = inputState.getMouseDelta();
+
+  // Modifier queries
+  if (inputState.isCtrlDown() && inputState.isKeyPressed('z')) {
+    undo();
+  }
+
+  // Stats for debugging
+  const stats = inputState.getStats();
+  console.log(`Keys down: ${stats.keysDown}, Frame: ${stats.frameCount}`);
+}
+```

--- a/docs/api/core/lazy-init.md
+++ b/docs/api/core/lazy-init.md
@@ -1,0 +1,273 @@
+# Lazy Initialization API
+
+Startup time optimization through lazy loading and deferred initialization. Subsystems are initialized on first use rather than at import time, enabling fast time-to-first-render. Also provides terminal capability detection with caching.
+
+## Quick Start
+
+```typescript
+import { lazy, registerSubsystem, InitPriority, initSubsystemsUpTo } from 'blecsd';
+
+// Create a lazy value
+const config = lazy(() => parseTerminfo());
+const value = config.get(); // Only computed on first call
+
+// Register subsystems with priority
+registerSubsystem('input', InitPriority.CRITICAL, () => setupInput());
+registerSubsystem('debug', InitPriority.LOW, () => setupDebug());
+
+// Initialize critical systems first for fast startup
+initSubsystemsUpTo(InitPriority.CRITICAL);
+
+// Later, initialize everything else
+initSubsystemsUpTo(InitPriority.LOW);
+```
+
+## Types
+
+### InitPriority
+
+Initialization priority levels. Systems are initialized in priority order.
+
+```typescript
+const InitPriority = {
+  CRITICAL: 0,  // Input handling, must be ready immediately
+  HIGH: 1,      // Rendering, layout
+  NORMAL: 2,    // Widgets, interactions
+  LOW: 3,       // Debugging, profiling, optional features
+} as const;
+
+type InitPriorityLevel = 0 | 1 | 2 | 3;
+```
+
+### LazyInitFn
+
+```typescript
+type LazyInitFn<T> = () => T;
+```
+
+### LazyValue
+
+```typescript
+interface LazyValue<T> {
+  get(): T;
+  isInitialized(): boolean;
+  reset(): void;
+}
+```
+
+### SubsystemEntry
+
+```typescript
+interface SubsystemEntry {
+  readonly name: string;
+  readonly priority: InitPriorityLevel;
+  init(): void;
+  readonly initialized: boolean;
+  readonly initTimeMs: number | null;
+}
+```
+
+### StartupReport
+
+```typescript
+interface StartupReport {
+  readonly totalMs: number;
+  readonly subsystems: readonly {
+    readonly name: string;
+    readonly priority: InitPriorityLevel;
+    readonly initTimeMs: number;
+    readonly lazy: boolean;
+  }[];
+  readonly timeToFirstInit: number;
+}
+```
+
+### TerminalCapabilities
+
+```typescript
+interface TerminalCapabilities {
+  readonly term: string;
+  readonly trueColor: boolean;
+  readonly color256: boolean;
+  readonly unicode: boolean;
+  readonly width: number;
+  readonly height: number;
+  readonly cachedAt: number;
+}
+```
+
+## Lazy Value Functions
+
+### lazy
+
+Creates a lazily initialized value that is computed on first access.
+
+```typescript
+function lazy<T>(factory: LazyInitFn<T>): LazyValue<T>;
+```
+
+```typescript
+import { lazy } from 'blecsd';
+
+const expensiveConfig = lazy(() => {
+  return parseTerminfo(); // Only runs on first .get()
+});
+
+const config = expensiveConfig.get();
+console.log(expensiveConfig.isInitialized()); // true
+expensiveConfig.reset(); // Back to uninitialized
+```
+
+## Subsystem Registry Functions
+
+### registerSubsystem
+
+Registers a subsystem for managed initialization. Duplicate names are ignored.
+
+```typescript
+function registerSubsystem(name: string, priority: InitPriorityLevel, initFn: () => void): void;
+```
+
+### initSubsystem
+
+Initializes a specific subsystem by name.
+
+```typescript
+function initSubsystem(name: string): number | null;
+```
+
+**Returns:** Time taken in ms, or null if not found or already initialized.
+
+### initSubsystemsUpTo
+
+Initializes all subsystems up to and including the given priority level, in priority order.
+
+```typescript
+function initSubsystemsUpTo(maxPriority?: InitPriorityLevel): number;
+```
+
+**Returns:** Total time taken in ms.
+
+```typescript
+import { initSubsystemsUpTo, InitPriority } from 'blecsd';
+
+// Fast startup: only critical systems
+initSubsystemsUpTo(InitPriority.CRITICAL);
+
+// Later, initialize everything
+initSubsystemsUpTo(InitPriority.LOW);
+```
+
+### getStartupReport
+
+Gets a startup timing report.
+
+```typescript
+function getStartupReport(): StartupReport;
+```
+
+### formatStartupReport
+
+Formats a startup report as a human-readable string.
+
+```typescript
+function formatStartupReport(report: StartupReport): string;
+```
+
+```typescript
+import { getStartupReport, formatStartupReport } from 'blecsd';
+
+const report = getStartupReport();
+console.log(formatStartupReport(report));
+// Startup Report
+// ========================================
+// Total init time: 12.3ms
+// Time to first init: 0.5ms
+//
+//   [CRITICAL] input: 2.1ms
+//   [HIGH] renderer: 5.4ms
+//   [LOW] debug: (lazy)
+```
+
+### resetSubsystems
+
+Resets all subsystem registrations. Used for testing.
+
+```typescript
+function resetSubsystems(): void;
+```
+
+## Terminal Capability Functions
+
+### detectCapabilities
+
+Detects terminal capabilities, using cache if available and recent.
+
+```typescript
+function detectCapabilities(maxAge?: number): TerminalCapabilities;
+```
+
+**Parameters:**
+- `maxAge` - Maximum cache age in ms (default: 60000)
+
+```typescript
+import { detectCapabilities } from 'blecsd';
+
+const caps = detectCapabilities();
+if (caps.trueColor) {
+  enableTrueColorMode();
+}
+console.log(`Terminal: ${caps.width}x${caps.height}`);
+```
+
+### clearCapabilityCache
+
+Clears the terminal capability cache.
+
+```typescript
+function clearCapabilityCache(): void;
+```
+
+## Usage Example
+
+```typescript
+import {
+  lazy,
+  registerSubsystem,
+  InitPriority,
+  initSubsystemsUpTo,
+  getStartupReport,
+  formatStartupReport,
+  detectCapabilities,
+} from 'blecsd';
+
+// Lazy-load expensive resources
+const spriteSheet = lazy(() => loadSpriteSheet('assets/sprites.png'));
+const soundBank = lazy(() => loadSounds('assets/sounds/'));
+
+// Register subsystems
+registerSubsystem('terminal', InitPriority.CRITICAL, () => {
+  const caps = detectCapabilities();
+  configureTerminal(caps);
+});
+
+registerSubsystem('input', InitPriority.CRITICAL, () => {
+  setupInputHandling();
+});
+
+registerSubsystem('renderer', InitPriority.HIGH, () => {
+  initializeRenderer();
+});
+
+registerSubsystem('debug-overlay', InitPriority.LOW, () => {
+  setupDebugOverlay();
+});
+
+// Staged initialization for fast startup
+initSubsystemsUpTo(InitPriority.CRITICAL); // Input ready immediately
+renderFirstFrame(); // Can render before everything is loaded
+initSubsystemsUpTo(InitPriority.LOW); // Load the rest
+
+// Report
+console.log(formatStartupReport(getStartupReport()));
+```

--- a/docs/api/core/lifecycle-events.md
+++ b/docs/api/core/lifecycle-events.md
@@ -1,0 +1,290 @@
+# Lifecycle Events API
+
+Node lifecycle events for tracking entity hierarchy changes. These events integrate with the event bubbling system and provide per-entity event buses for reparenting, adoption, attachment, detachment, removal, and destruction.
+
+## Quick Start
+
+```typescript
+import { onReparent, onDestroy, createEventBus } from 'blecsd';
+
+// Listen for reparent events on an entity
+const unsub = onReparent(entity, (event) => {
+  console.log(`Moved from ${event.oldParent} to ${event.newParent}`);
+}, createEventBus);
+
+// Listen for destruction
+onDestroy(entity, (event) => {
+  console.log(`Entity ${event.entity} was destroyed`);
+}, createEventBus);
+```
+
+## Event Types
+
+### ReparentEvent
+
+Fired when an entity's parent changes.
+
+```typescript
+interface ReparentEvent {
+  readonly entity: Entity;
+  readonly oldParent: Entity;
+  readonly newParent: Entity;
+}
+```
+
+### AdoptEvent
+
+Fired when a child is added to a parent.
+
+```typescript
+interface AdoptEvent {
+  readonly parent: Entity;
+  readonly child: Entity;
+}
+```
+
+### AttachEvent
+
+Fired when an entity is attached to the screen tree.
+
+```typescript
+interface AttachEvent {
+  readonly entity: Entity;
+  readonly screen: Entity;
+}
+```
+
+### DetachEvent
+
+Fired when an entity is detached from the screen tree.
+
+```typescript
+interface DetachEvent {
+  readonly entity: Entity;
+  readonly screen: Entity;
+}
+```
+
+### RemoveEvent
+
+Fired when a child is removed from a parent.
+
+```typescript
+interface RemoveEvent {
+  readonly parent: Entity;
+  readonly child: Entity;
+}
+```
+
+### DestroyEvent
+
+Fired when an entity is destroyed.
+
+```typescript
+interface DestroyEvent {
+  readonly entity: Entity;
+}
+```
+
+### LifecycleEventMap
+
+Map of all lifecycle event names to their payload types.
+
+```typescript
+interface LifecycleEventMap {
+  reparent: ReparentEvent;
+  adopt: AdoptEvent;
+  attach: AttachEvent;
+  detach: DetachEvent;
+  remove: RemoveEvent;
+  destroy: DestroyEvent;
+}
+```
+
+### LifecycleEventName
+
+```typescript
+type LifecycleEventName = keyof LifecycleEventMap;
+```
+
+### LifecycleEvent
+
+```typescript
+type LifecycleEvent = ReparentEvent | AdoptEvent | AttachEvent | DetachEvent | RemoveEvent | DestroyEvent;
+```
+
+## Event Bus Management
+
+### getLifecycleEventBus
+
+Gets or creates an event bus for an entity.
+
+```typescript
+function getLifecycleEventBus(
+  entity: Entity,
+  createEventBus: () => EventBus<LifecycleEventMap>
+): EventBus<LifecycleEventMap>;
+```
+
+### removeLifecycleEventBus
+
+Removes an entity's event bus. Called when entity is destroyed.
+
+```typescript
+function removeLifecycleEventBus(entity: Entity): void;
+```
+
+### clearLifecycleEventBuses
+
+Clears all lifecycle event buses. Primarily used for testing.
+
+```typescript
+function clearLifecycleEventBuses(): void;
+```
+
+## Event Emitters
+
+### emitReparent
+
+```typescript
+function emitReparent(bus: EventBus<LifecycleEventMap>, entity: Entity, oldParent: Entity, newParent: Entity): void;
+```
+
+### emitAdopt
+
+```typescript
+function emitAdopt(bus: EventBus<LifecycleEventMap>, parent: Entity, child: Entity): void;
+```
+
+### emitAttach
+
+```typescript
+function emitAttach(bus: EventBus<LifecycleEventMap>, entity: Entity, screen: Entity): void;
+```
+
+### emitDetach
+
+```typescript
+function emitDetach(bus: EventBus<LifecycleEventMap>, entity: Entity, screen: Entity): void;
+```
+
+### emitRemove
+
+```typescript
+function emitRemove(bus: EventBus<LifecycleEventMap>, parent: Entity, child: Entity): void;
+```
+
+### emitDestroy
+
+```typescript
+function emitDestroy(bus: EventBus<LifecycleEventMap>, entity: Entity): void;
+```
+
+## Event Listeners
+
+Convenience functions that get or create an event bus and subscribe in one call. Each returns an unsubscribe function.
+
+### onReparent
+
+```typescript
+function onReparent(
+  entity: Entity,
+  handler: (event: ReparentEvent) => void,
+  createEventBus: () => EventBus<LifecycleEventMap>
+): () => void;
+```
+
+### onAdopt
+
+```typescript
+function onAdopt(
+  entity: Entity,
+  handler: (event: AdoptEvent) => void,
+  createEventBus: () => EventBus<LifecycleEventMap>
+): () => void;
+```
+
+### onAttach
+
+```typescript
+function onAttach(
+  entity: Entity,
+  handler: (event: AttachEvent) => void,
+  createEventBus: () => EventBus<LifecycleEventMap>
+): () => void;
+```
+
+### onDetach
+
+```typescript
+function onDetach(
+  entity: Entity,
+  handler: (event: DetachEvent) => void,
+  createEventBus: () => EventBus<LifecycleEventMap>
+): () => void;
+```
+
+### onRemove
+
+```typescript
+function onRemove(
+  entity: Entity,
+  handler: (event: RemoveEvent) => void,
+  createEventBus: () => EventBus<LifecycleEventMap>
+): () => void;
+```
+
+### onDestroy
+
+```typescript
+function onDestroy(
+  entity: Entity,
+  handler: (event: DestroyEvent) => void,
+  createEventBus: () => EventBus<LifecycleEventMap>
+): () => void;
+```
+
+## Usage Example
+
+```typescript
+import {
+  getLifecycleEventBus,
+  emitReparent,
+  emitAdopt,
+  emitDestroy,
+  onReparent,
+  onDestroy,
+  removeLifecycleEventBus,
+  createEventBus,
+} from 'blecsd';
+
+// Subscribe to events on a widget
+const unsub1 = onReparent(widgetEntity, (event) => {
+  console.log(`Widget moved from parent ${event.oldParent} to ${event.newParent}`);
+  invalidateLayout(event.entity);
+}, createEventBus);
+
+const unsub2 = onDestroy(widgetEntity, (event) => {
+  cleanupResources(event.entity);
+}, createEventBus);
+
+// Emit events when hierarchy changes
+function reparentEntity(entity: Entity, oldParent: Entity, newParent: Entity) {
+  const bus = getLifecycleEventBus(entity, createEventBus);
+  emitReparent(bus, entity, oldParent, newParent);
+
+  const parentBus = getLifecycleEventBus(newParent, createEventBus);
+  emitAdopt(parentBus, newParent, entity);
+}
+
+// Cleanup
+function destroyEntity(entity: Entity) {
+  const bus = getLifecycleEventBus(entity, createEventBus);
+  emitDestroy(bus, entity);
+  removeLifecycleEventBus(entity);
+}
+
+// Unsubscribe when done
+unsub1();
+unsub2();
+```

--- a/docs/api/core/phase-manager.md
+++ b/docs/api/core/phase-manager.md
@@ -1,0 +1,174 @@
+# Phase Manager API
+
+Configurable game loop execution order. Allows users to add custom phases between the default phases while ensuring INPUT always runs first.
+
+## Quick Start
+
+```typescript
+import { createPhaseManager, LoopPhase } from 'blecsd';
+
+const manager = createPhaseManager();
+
+// Add custom phases between built-in phases
+const preRender = manager.registerPhase('PRE_RENDER', LoopPhase.LAYOUT);
+const postPhysics = manager.registerPhase('POST_PHYSICS', LoopPhase.PHYSICS);
+
+// Get execution order
+console.log(manager.getPhaseOrder());
+```
+
+## Types
+
+### PhaseId
+
+A phase identifier, either a built-in LoopPhase or a custom string.
+
+```typescript
+type PhaseId = LoopPhase | string;
+```
+
+### PhaseManager
+
+```typescript
+interface PhaseManager {
+  registerPhase(name: string, afterPhase: PhaseId): string;
+  unregisterPhase(phaseId: PhaseId): boolean;
+  getPhaseOrder(): readonly PhaseId[];
+  getPhaseName(phaseId: PhaseId): string | undefined;
+  hasPhase(phaseId: PhaseId): boolean;
+  isBuiltin(phaseId: PhaseId): boolean;
+  getPhaseCount(): number;
+  getCustomPhaseCount(): number;
+  getCustomPhases(): string[];
+  clearCustomPhases(): void;
+  reset(): void;
+}
+```
+
+## Constants
+
+### BUILTIN_PHASE_NAMES
+
+Maps built-in LoopPhase values to their string names.
+
+```typescript
+import { BUILTIN_PHASE_NAMES, LoopPhase } from 'blecsd';
+
+console.log(BUILTIN_PHASE_NAMES[LoopPhase.INPUT]);  // 'INPUT'
+console.log(BUILTIN_PHASE_NAMES[LoopPhase.RENDER]); // 'RENDER'
+```
+
+Built-in phases (in order): INPUT, EARLY_UPDATE, UPDATE, LATE_UPDATE, PHYSICS, LAYOUT, RENDER, POST_RENDER.
+
+### defaultPhaseManager
+
+Default global phase manager for simple use cases.
+
+```typescript
+import { defaultPhaseManager } from 'blecsd';
+```
+
+## Functions
+
+### createPhaseManager
+
+Creates a new PhaseManager instance.
+
+```typescript
+function createPhaseManager(): PhaseManager;
+```
+
+**Returns:** A new PhaseManager initialized with all built-in phases.
+
+### isBuiltinPhase
+
+Checks if a phase ID is a built-in LoopPhase.
+
+```typescript
+function isBuiltinPhase(id: PhaseId): id is LoopPhase;
+```
+
+## PhaseManager Methods
+
+### registerPhase
+
+Registers a custom phase to run after a specific phase.
+
+```typescript
+registerPhase(name: string, afterPhase: PhaseId): string;
+```
+
+**Parameters:**
+- `name` - Name for the custom phase (for debugging)
+- `afterPhase` - The phase after which this custom phase should run
+
+**Returns:** The ID for the new custom phase.
+
+**Throws:** Error if the afterPhase is unknown.
+
+### unregisterPhase
+
+Unregisters a custom phase. Built-in phases cannot be removed.
+
+```typescript
+unregisterPhase(phaseId: PhaseId): boolean;
+```
+
+**Throws:** Error if attempting to remove a built-in phase.
+
+### getPhaseOrder
+
+Gets all phases in execution order.
+
+```typescript
+getPhaseOrder(): readonly PhaseId[];
+```
+
+### Other Methods
+
+- `getPhaseName(phaseId)` - Gets the display name for a phase
+- `hasPhase(phaseId)` - Checks if a phase exists
+- `isBuiltin(phaseId)` - Checks if a phase is built-in
+- `getPhaseCount()` - Total number of phases
+- `getCustomPhaseCount()` - Number of custom phases
+- `getCustomPhases()` - Array of custom phase IDs
+- `clearCustomPhases()` - Removes all custom phases
+- `reset()` - Resets to default built-in phases only
+
+## Usage Example
+
+```typescript
+import { createPhaseManager, LoopPhase } from 'blecsd';
+
+const phases = createPhaseManager();
+
+// Add custom phases for specific needs
+const aiPhase = phases.registerPhase('AI', LoopPhase.UPDATE);
+const particlePhase = phases.registerPhase('PARTICLES', LoopPhase.PHYSICS);
+const uiPhase = phases.registerPhase('UI_UPDATE', LoopPhase.LAYOUT);
+
+// Inspect execution order
+for (const phase of phases.getPhaseOrder()) {
+  const name = phases.getPhaseName(phase);
+  const builtin = phases.isBuiltin(phase) ? ' (built-in)' : '';
+  console.log(`${name}${builtin}`);
+}
+// OUTPUT:
+// INPUT (built-in)
+// EARLY_UPDATE (built-in)
+// UPDATE (built-in)
+// AI
+// LATE_UPDATE (built-in)
+// PHYSICS (built-in)
+// PARTICLES
+// LAYOUT (built-in)
+// UI_UPDATE
+// RENDER (built-in)
+// POST_RENDER (built-in)
+
+// Remove a custom phase
+phases.unregisterPhase(aiPhase);
+
+// Reset to defaults
+phases.reset();
+```

--- a/docs/api/core/scene.md
+++ b/docs/api/core/scene.md
@@ -1,0 +1,208 @@
+# Scene API
+
+Scene management for game screens. Provides a scene stack with lifecycle callbacks, scene transitions, and per-scene system registration. Scenes can be pushed/popped for overlays or switched directly.
+
+## Quick Start
+
+```typescript
+import { createSceneManager } from 'blecsd';
+
+const scenes = createSceneManager();
+
+scenes.registerScene({
+  name: 'menu',
+  onEnter(world) { console.log('Entering menu'); },
+});
+
+scenes.registerScene({
+  name: 'game',
+  onEnter(world) { console.log('Starting game'); },
+  onUpdate(world, dt) { /* game logic */ },
+});
+
+scenes.switchTo(world, 'menu');
+scenes.switchTo(world, 'game');
+```
+
+## Types
+
+### Scene
+
+A game scene with lifecycle callbacks and optional per-scene systems.
+
+```typescript
+interface Scene {
+  readonly name: string;
+  onCreate?(world: World): void;
+  onEnter?(world: World): void;
+  onExit?(world: World): void;
+  onDestroy?(world: World): void;
+  onUpdate?(world: World, delta: number): void;
+  systems?: readonly System[];
+}
+```
+
+**Lifecycle:**
+- `onCreate` - Called once when the scene is first entered (lazy initialization)
+- `onEnter` - Called each time the scene becomes active
+- `onExit` - Called when the scene is deactivated
+- `onDestroy` - Called when the scene is unregistered or manager is reset
+- `onUpdate` - Called each frame while the scene is active
+
+### SceneTransition
+
+A scene transition configuration.
+
+```typescript
+interface SceneTransition {
+  readonly duration: number;
+  onStart?(world: World): void;
+  onUpdate?(world: World, progress: number): void;
+  onComplete?(world: World): void;
+}
+```
+
+### TransitionState
+
+Current state of an active transition.
+
+```typescript
+interface TransitionState {
+  readonly transition: SceneTransition;
+  elapsed: number;
+  readonly fromScene: Scene | null;
+  readonly toScene: Scene;
+}
+```
+
+### SceneManager
+
+```typescript
+interface SceneManager {
+  registerScene(scene: Scene): boolean;
+  unregisterScene(world: World, name: string): boolean;
+  switchTo(world: World, name: string, transition?: SceneTransition): boolean;
+  push(world: World, name: string, transition?: SceneTransition): boolean;
+  pop(world: World, transition?: SceneTransition): boolean;
+  getCurrentScene(): Scene | null;
+  getSceneStack(): readonly Scene[];
+  getRegisteredScenes(): readonly string[];
+  isTransitioning(): boolean;
+  getTransitionState(): TransitionState | null;
+  updateTransition(world: World, delta: number): void;
+  reset(world: World): void;
+}
+```
+
+## Functions
+
+### createSceneManager
+
+Creates a new scene manager.
+
+```typescript
+function createSceneManager(): SceneManager;
+```
+
+**Returns:** A SceneManager instance.
+
+### createFadeTransition
+
+Creates a fade transition that calls onUpdate with progress 0-1.
+
+```typescript
+function createFadeTransition(
+  duration: number,
+  onProgress?: (world: World, progress: number) => void
+): SceneTransition;
+```
+
+```typescript
+import { createFadeTransition } from 'blecsd';
+
+sceneManager.switchTo(world, 'game', createFadeTransition(0.5));
+```
+
+### createSlideTransition
+
+Creates a slide transition in a given direction.
+
+```typescript
+function createSlideTransition(
+  duration: number,
+  direction: 'left' | 'right' | 'up' | 'down',
+  onProgress?: (world: World, progress: number, direction: string) => void
+): SceneTransition;
+```
+
+```typescript
+import { createSlideTransition } from 'blecsd';
+
+sceneManager.switchTo(world, 'settings', createSlideTransition(0.3, 'left'));
+```
+
+### createSceneSystem
+
+Creates a system that updates the scene manager each frame. Advances transitions and calls onUpdate on the active scene.
+
+```typescript
+function createSceneSystem(sceneManager: SceneManager, getDelta: () => number): System;
+```
+
+```typescript
+import { createSceneManager, createSceneSystem } from 'blecsd';
+
+const scenes = createSceneManager();
+const sceneSystem = createSceneSystem(scenes, getDeltaTime);
+scheduler.registerSystem(LoopPhase.UPDATE, sceneSystem);
+```
+
+## Usage Example
+
+```typescript
+import { createSceneManager, createFadeTransition, createWorld } from 'blecsd';
+
+const world = createWorld();
+const scenes = createSceneManager();
+
+// Register scenes
+scenes.registerScene({
+  name: 'title',
+  onEnter(world) { setupTitleScreen(world); },
+  onExit(world) { cleanupTitleScreen(world); },
+  onUpdate(world, dt) { updateTitleAnimations(world, dt); },
+});
+
+scenes.registerScene({
+  name: 'gameplay',
+  onCreate(world) { loadLevel(world); },
+  onEnter(world) { resumeGameplay(world); },
+  onUpdate(world, dt) { updateGameplay(world, dt); },
+  systems: [movementSystem, collisionSystem, aiSystem],
+});
+
+scenes.registerScene({
+  name: 'pause',
+  onEnter(world) { showPauseMenu(world); },
+  onExit(world) { hidePauseMenu(world); },
+});
+
+// Start at title
+scenes.switchTo(world, 'title');
+
+// Transition to gameplay with fade
+scenes.switchTo(world, 'gameplay', createFadeTransition(0.5));
+
+// Push pause overlay (gameplay stays underneath)
+scenes.push(world, 'pause');
+
+// Pop to return to gameplay
+scenes.pop(world);
+
+// Check current scene
+const current = scenes.getCurrentScene();
+console.log(current?.name); // 'gameplay'
+
+// Full stack
+console.log(scenes.getSceneStack().map(s => s.name));
+```

--- a/docs/api/core/serialization.md
+++ b/docs/api/core/serialization.md
@@ -1,0 +1,259 @@
+# Serialization API
+
+ECS world state serialization and deserialization. Serialize world state to JSON and restore it, with support for component data, entity relationships, and custom serializers for complex data.
+
+## Quick Start
+
+```typescript
+import {
+  registerSerializable,
+  serializeWorld,
+  deserializeWorld,
+  createWorld,
+  Position,
+} from 'blecsd';
+
+// Register components for serialization
+registerSerializable({ name: 'Position', store: Position });
+
+// Serialize
+const snapshot = serializeWorld(world);
+const json = JSON.stringify(snapshot);
+
+// Deserialize
+const newWorld = createWorld();
+const result = deserializeWorld(snapshot, newWorld);
+console.log(`Restored ${result.entityCount} entities`);
+```
+
+## Types
+
+### ComponentDescriptor
+
+A registered component descriptor for serialization.
+
+```typescript
+interface ComponentDescriptor {
+  readonly name: string;
+  readonly store: Record<string, any>;
+  readonly serialize?: (eid: Entity) => unknown;
+  readonly deserialize?: (eid: Entity, data: unknown) => void;
+}
+```
+
+### SerializedEntity
+
+```typescript
+interface SerializedEntity {
+  readonly id: number;
+  readonly components: Record<string, SerializedComponentData>;
+}
+```
+
+### SerializedComponentData
+
+```typescript
+interface SerializedComponentData {
+  readonly fields: Record<string, number>;
+  readonly custom?: unknown;
+}
+```
+
+### SerializedWorld
+
+Complete serialized world snapshot.
+
+```typescript
+interface SerializedWorld {
+  readonly version: number;
+  readonly timestamp: number;
+  readonly entities: readonly SerializedEntity[];
+  readonly metadata?: Record<string, unknown>;
+}
+```
+
+### SerializeOptions
+
+```typescript
+interface SerializeOptions {
+  readonly entityFilter?: readonly Entity[];
+  readonly componentFilter?: readonly string[];
+  readonly metadata?: Record<string, unknown>;
+}
+```
+
+### DeserializeOptions
+
+```typescript
+interface DeserializeOptions {
+  readonly clearWorld?: boolean;   // default: false
+  readonly createNew?: boolean;    // default: false
+}
+```
+
+### DeserializeResult
+
+```typescript
+interface DeserializeResult {
+  readonly world: World;
+  readonly entityMap: ReadonlyMap<number, Entity>;
+  readonly entityCount: number;
+  readonly componentCount: number;
+}
+```
+
+## Component Registry Functions
+
+### registerSerializable
+
+Registers a component for serialization.
+
+```typescript
+function registerSerializable(descriptor: ComponentDescriptor): void;
+```
+
+```typescript
+import { registerSerializable, Position } from 'blecsd';
+
+registerSerializable({ name: 'Position', store: Position });
+```
+
+### unregisterSerializable
+
+Unregisters a component from serialization.
+
+```typescript
+function unregisterSerializable(name: string): boolean;
+```
+
+### getSerializable
+
+Gets a registered component descriptor by name.
+
+```typescript
+function getSerializable(name: string): ComponentDescriptor | undefined;
+```
+
+### getRegisteredComponents
+
+Gets all registered component names.
+
+```typescript
+function getRegisteredComponents(): readonly string[];
+```
+
+### clearSerializableRegistry
+
+Clears all registered serializable components.
+
+```typescript
+function clearSerializableRegistry(): void;
+```
+
+## Serialization Functions
+
+### serializeWorld
+
+Serializes ECS world state to a snapshot object.
+
+```typescript
+function serializeWorld(world: World, options?: SerializeOptions): SerializedWorld;
+```
+
+### serializeWorldToJSON
+
+Serializes ECS world state to a JSON string.
+
+```typescript
+function serializeWorldToJSON(world: World, options?: SerializeOptions): string;
+```
+
+### deserializeWorld
+
+Deserializes a world snapshot back into an ECS world.
+
+```typescript
+function deserializeWorld(
+  snapshot: SerializedWorld,
+  world: World,
+  options?: DeserializeOptions
+): DeserializeResult;
+```
+
+### deserializeWorldFromJSON
+
+Deserializes a JSON string back into an ECS world.
+
+```typescript
+function deserializeWorldFromJSON(
+  json: string,
+  world: World,
+  options?: DeserializeOptions
+): DeserializeResult;
+```
+
+### cloneSnapshot
+
+Creates a deep clone of a serialized world snapshot.
+
+```typescript
+function cloneSnapshot(snapshot: SerializedWorld): SerializedWorld;
+```
+
+## Constants
+
+### SERIALIZATION_VERSION
+
+Current serialization format version (currently `1`).
+
+## Usage Example
+
+### Save/Load with Custom Serializers
+
+```typescript
+import {
+  registerSerializable,
+  serializeWorldToJSON,
+  deserializeWorldFromJSON,
+  createWorld,
+  addEntity,
+  setPosition,
+  Position,
+} from 'blecsd';
+
+// Register with custom serializer for non-typed-array data
+registerSerializable({
+  name: 'Position',
+  store: Position,
+});
+
+registerSerializable({
+  name: 'Inventory',
+  store: Inventory,
+  serialize: (eid) => getInventoryItems(eid),
+  deserialize: (eid, data) => setInventoryItems(eid, data as Item[]),
+});
+
+// Create and populate world
+const world = createWorld();
+const player = addEntity(world);
+setPosition(world, player, 100, 200);
+
+// Save to JSON
+const json = serializeWorldToJSON(world, {
+  metadata: { levelName: 'forest', saveSlot: 1 },
+});
+
+// Load into new world
+const newWorld = createWorld();
+const result = deserializeWorldFromJSON(json, newWorld);
+
+// Entity IDs may differ; use entityMap for relationship fixup
+const newPlayerId = result.entityMap.get(player);
+
+// Selective serialization
+const partialJson = serializeWorldToJSON(world, {
+  componentFilter: ['Position'],
+  entityFilter: [player],
+});
+```

--- a/docs/api/core/state-machine.md
+++ b/docs/api/core/state-machine.md
@@ -1,0 +1,188 @@
+# State Machine API
+
+Configurable state machine framework with typed states, events, guard conditions, and entry/exit actions. Used internally by widgets and available for user code.
+
+## Quick Start
+
+```typescript
+import { createStateMachine } from 'blecsd';
+
+const machine = createStateMachine({
+  initial: 'idle',
+  states: {
+    idle: { on: { start: 'running' } },
+    running: { on: { pause: 'paused', stop: 'idle' } },
+    paused: { on: { resume: 'running', stop: 'idle' } },
+  },
+});
+
+machine.send('start');   // -> 'running'
+machine.send('pause');   // -> 'paused'
+machine.send('resume');  // -> 'running'
+```
+
+## Types
+
+### Action
+
+Action function executed on state transitions.
+
+```typescript
+type Action<Context = unknown> = (context: Context) => void;
+```
+
+### TransitionConfig
+
+Transition target with optional actions and guard.
+
+```typescript
+interface TransitionConfig<S extends string, Context = unknown> {
+  target: S;
+  actions?: Action<Context>[];
+  guard?: (context: Context) => boolean;
+}
+```
+
+### StateConfig
+
+State configuration with entry/exit actions and transitions.
+
+```typescript
+interface StateConfig<S extends string, E extends string, Context = unknown> {
+  entry?: Action<Context>[];
+  exit?: Action<Context>[];
+  on?: Partial<Record<E, S | TransitionConfig<S, Context>>>;
+}
+```
+
+### StateMachineConfig
+
+Full state machine configuration.
+
+```typescript
+interface StateMachineConfig<S extends string, E extends string, Context = unknown> {
+  initial: S;
+  states: Record<S, StateConfig<S, E, Context>>;
+  context?: Context;
+}
+```
+
+### StateListener
+
+```typescript
+type StateListener<S extends string> = (current: S, previous: S) => void;
+```
+
+### StateMachine
+
+```typescript
+interface StateMachine<S extends string, E extends string, Context = unknown> {
+  readonly current: S;
+  readonly context: Context;
+  send(event: E): boolean;
+  can(event: E): boolean;
+  matches(state: S): boolean;
+  subscribe(listener: StateListener<S>): Unsubscribe;
+  validEvents(): E[];
+  reset(): void;
+}
+```
+
+## Functions
+
+### createStateMachine
+
+Creates a new state machine.
+
+```typescript
+function createStateMachine<S extends string, E extends string, Context = unknown>(
+  config: StateMachineConfig<S, E, Context>
+): StateMachine<S, E, Context>;
+```
+
+**Parameters:**
+- `config` - State machine configuration with initial state, state definitions, and optional context
+
+**Returns:** A new StateMachine instance.
+
+### validateStateMachineConfig
+
+Validates a state machine configuration object using Zod.
+
+```typescript
+function validateStateMachineConfig(config: unknown): z.infer<typeof StateMachineConfigSchema>;
+```
+
+## Validation Schemas
+
+### TransitionConfigSchema / StateConfigSchema / StateMachineConfigSchema
+
+Zod schemas for validating state machine configurations at runtime, useful for loading configs from JSON.
+
+## Usage Example
+
+### With Guards and Actions
+
+```typescript
+import { createStateMachine } from 'blecsd';
+
+type State = 'locked' | 'unlocked' | 'open';
+type Event = 'insertCoin' | 'push';
+
+interface Context {
+  coins: number;
+}
+
+const turnstile = createStateMachine<State, Event, Context>({
+  initial: 'locked',
+  context: { coins: 0 },
+  states: {
+    locked: {
+      on: {
+        insertCoin: {
+          target: 'unlocked',
+          actions: [(ctx) => { ctx.coins++; }],
+        },
+      },
+    },
+    unlocked: {
+      entry: [(ctx) => console.log(`Coins: ${ctx.coins}`)],
+      on: {
+        push: 'open',
+      },
+    },
+    open: {
+      exit: [() => console.log('Door closing')],
+      on: {
+        push: 'locked',
+      },
+    },
+  },
+});
+
+turnstile.send('insertCoin'); // -> 'unlocked', prints "Coins: 1"
+turnstile.can('push');        // true
+turnstile.matches('unlocked'); // true
+turnstile.validEvents();      // ['push']
+```
+
+### With Subscriptions
+
+```typescript
+import { createStateMachine } from 'blecsd';
+
+const machine = createStateMachine({
+  initial: 'off',
+  states: {
+    off: { on: { toggle: 'on' } },
+    on: { on: { toggle: 'off' } },
+  },
+});
+
+const unsub = machine.subscribe((current, previous) => {
+  console.log(`${previous} -> ${current}`);
+});
+
+machine.send('toggle'); // prints "off -> on"
+unsub(); // stop listening
+```

--- a/docs/api/core/types.md
+++ b/docs/api/core/types.md
@@ -1,0 +1,118 @@
+# Core Types API
+
+Core type definitions for blECSd. Defines the fundamental types used throughout the library.
+
+## Quick Start
+
+```typescript
+import type { Entity, World, System, Unsubscribe } from 'blecsd';
+import { LoopPhase } from 'blecsd';
+```
+
+## Types
+
+### Entity
+
+Branded entity type from bitecs. Prevents accidentally passing raw numbers where entities are expected.
+
+```typescript
+type Entity = EntityId;
+```
+
+```typescript
+import type { Entity } from 'blecsd';
+
+function moveEntity(eid: Entity, x: number, y: number): void {
+  // eid is guaranteed to be a valid entity reference
+}
+```
+
+### World
+
+The ECS World type from bitecs. Contains all entity and component data.
+
+```typescript
+type World = BitEcsWorld;
+```
+
+### System
+
+A System is a function that processes entities in the world. Systems should be pure functions that take a world and return it.
+
+```typescript
+type System = (world: World) => World;
+```
+
+```typescript
+import type { System } from 'blecsd';
+
+const movementSystem: System = (world) => {
+  // Process entities with Position and Velocity
+  return world;
+};
+```
+
+### Unsubscribe
+
+Function to unsubscribe from events or callbacks.
+
+```typescript
+type Unsubscribe = () => void;
+```
+
+### LoopPhase
+
+Loop phases for the game loop. INPUT is always first and cannot be reordered.
+
+```typescript
+enum LoopPhase {
+  INPUT = 0,        // Process all pending input - ALWAYS FIRST
+  EARLY_UPDATE = 1, // Pre-update logic
+  UPDATE = 2,       // Main game logic
+  LATE_UPDATE = 3,  // Post-update logic
+  PHYSICS = 4,      // Physics calculations
+  LAYOUT = 5,       // UI layout calculation
+  RENDER = 6,       // Render to screen buffer
+  POST_RENDER = 7,  // Output to terminal, cleanup
+}
+```
+
+```typescript
+import { LoopPhase } from 'blecsd';
+
+loop.registerSystem(LoopPhase.UPDATE, gameLogicSystem);
+loop.registerSystem(LoopPhase.RENDER, renderSystem);
+loop.registerInputSystem(inputSystem); // Always LoopPhase.INPUT
+```
+
+## Usage Example
+
+```typescript
+import type { Entity, World, System, Unsubscribe } from 'blecsd';
+import { LoopPhase, createWorld, addEntity } from 'blecsd';
+
+// Define a system
+const gravitySystem: System = (world: World): World => {
+  // Apply gravity to all entities with Velocity
+  return world;
+};
+
+// Use Entity type for function parameters
+function spawnEnemy(world: World, x: number, y: number): Entity {
+  const eid = addEntity(world);
+  // ... setup components ...
+  return eid;
+}
+
+// Use Unsubscribe for cleanup
+function setupEventHandlers(): Unsubscribe {
+  const handler = () => { /* ... */ };
+  eventBus.on('event', handler);
+  return () => eventBus.off('event', handler);
+}
+
+// Register systems at appropriate phases
+loop.registerSystem(LoopPhase.PHYSICS, gravitySystem);
+loop.registerSystem(LoopPhase.UPDATE, aiSystem);
+loop.registerSystem(LoopPhase.LATE_UPDATE, cleanupSystem);
+```

--- a/docs/api/core/world.md
+++ b/docs/api/core/world.md
@@ -1,0 +1,68 @@
+# World API
+
+ECS World creation and management. Wraps bitecs world primitives.
+
+## Quick Start
+
+```typescript
+import { createWorld, resetWorld } from 'blecsd';
+
+const world = createWorld();
+// ... use world for entities and components ...
+resetWorld(world); // Clear everything for new game
+```
+
+## Functions
+
+### createWorld
+
+Creates a new ECS world for the game.
+
+```typescript
+function createWorld(): World;
+```
+
+**Returns:** A new World instance.
+
+```typescript
+import { createWorld } from 'blecsd';
+
+const world = createWorld();
+```
+
+### resetWorld
+
+Resets an existing world, removing all entities and resetting component data. Useful for level reloading or game restart.
+
+```typescript
+function resetWorld(world: World): void;
+```
+
+**Parameters:**
+- `world` - The world to reset
+
+```typescript
+import { createWorld, resetWorld } from 'blecsd';
+
+const world = createWorld();
+// ... game runs ...
+resetWorld(world); // Clear everything for new game
+```
+
+## Usage Example
+
+```typescript
+import { createWorld, resetWorld, addEntity, addComponent, Position } from 'blecsd';
+
+// Create a world for each game session
+const world = createWorld();
+
+// Populate with entities
+const player = addEntity(world);
+addComponent(world, player, Position);
+
+// When restarting:
+resetWorld(world);
+// All entities are gone, component data is cleared
+// The world can now be reused for a new session
+```

--- a/docs/api/debug/memory-profiler.md
+++ b/docs/api/debug/memory-profiler.md
@@ -1,0 +1,247 @@
+# Memory Profiler API
+
+Memory profiling and leak detection for development. Tracks entity and component allocations, provides periodic snapshots, and detects common leak patterns.
+
+## Quick Start
+
+```typescript
+import { createMemoryProfiler } from 'blecsd';
+
+const profiler = createMemoryProfiler({
+  trackedComponents: [
+    { component: Position, name: 'Position' },
+    { component: Renderable, name: 'Renderable' },
+  ],
+});
+
+// Take snapshots
+const snap1 = profiler.snapshot(world);
+// ... do work ...
+const snap2 = profiler.snapshot(world);
+
+// Check for leaks
+const diff = profiler.diff(snap1, snap2);
+if (diff.possibleLeaks.length > 0) {
+  console.warn('Possible leaks:', diff.possibleLeaks);
+}
+
+// Get a formatted report
+console.log(profiler.getReport(world));
+```
+
+## Types
+
+### MemorySnapshot
+
+Memory snapshot at a point in time.
+
+```typescript
+interface MemorySnapshot {
+  readonly timestamp: number;
+  readonly entityCount: number;
+  readonly componentCounts: Record<string, number>;
+  readonly heapUsed: number;
+  readonly heapTotal: number;
+  readonly rss: number;
+  readonly external: number;
+}
+```
+
+### MemoryDiff
+
+Memory diff between two snapshots.
+
+```typescript
+interface MemoryDiff {
+  readonly elapsed: number;
+  readonly entityCountDelta: number;
+  readonly componentDeltas: Record<string, number>;
+  readonly heapUsedDelta: number;
+  readonly rssDelta: number;
+  readonly possibleLeaks: readonly LeakWarning[];
+}
+```
+
+### LeakWarning
+
+Warning about a potential memory leak.
+
+```typescript
+interface LeakWarning {
+  readonly type: 'entity' | 'component' | 'heap';
+  readonly message: string;
+  readonly growthRate: number;
+}
+```
+
+### AllocationTracker
+
+```typescript
+interface AllocationTracker {
+  readonly totalAllocated: number;
+  readonly totalDeallocated: number;
+  readonly currentCount: number;
+  readonly componentAllocations: Record<string, number>;
+}
+```
+
+### MemoryProfilerConfig
+
+```typescript
+interface MemoryProfilerConfig {
+  readonly snapshotInterval: number;       // default: 5000ms
+  readonly maxSnapshots: number;           // default: 100
+  readonly entityLeakThreshold: number;    // default: 10 entities/sec
+  readonly heapLeakThreshold: number;      // default: 1MB/sec
+  readonly trackedComponents: readonly { component: unknown; name: string }[];
+}
+```
+
+### MemoryProfiler
+
+```typescript
+interface MemoryProfiler {
+  snapshot(world: World): MemorySnapshot;
+  diff(older: MemorySnapshot, newer: MemorySnapshot): MemoryDiff;
+  getSnapshots(): readonly MemorySnapshot[];
+  getLatestSnapshot(): MemorySnapshot | null;
+  getReport(world: World): string;
+  startAutoSnapshot(world: World): void;
+  stopAutoSnapshot(): void;
+  reset(): void;
+}
+```
+
+## Functions
+
+### createMemoryProfiler
+
+Creates a memory profiler for tracking allocations and detecting leaks.
+
+```typescript
+function createMemoryProfiler(config?: Partial<MemoryProfilerConfig>): MemoryProfiler;
+```
+
+**Parameters:**
+- `config` - Optional configuration overrides
+
+**Returns:** Memory profiler instance.
+
+## MemoryProfiler Methods
+
+### snapshot
+
+Takes a snapshot of current memory state.
+
+```typescript
+snapshot(world: World): MemorySnapshot;
+```
+
+### diff
+
+Compares two snapshots and detects possible leaks.
+
+```typescript
+diff(older: MemorySnapshot, newer: MemorySnapshot): MemoryDiff;
+```
+
+### getSnapshots
+
+Gets all stored snapshots.
+
+```typescript
+getSnapshots(): readonly MemorySnapshot[];
+```
+
+### getLatestSnapshot
+
+Gets the most recent snapshot.
+
+```typescript
+getLatestSnapshot(): MemorySnapshot | null;
+```
+
+### getReport
+
+Gets a formatted memory report string with current stats, component counts, trends, and warnings.
+
+```typescript
+getReport(world: World): string;
+```
+
+### startAutoSnapshot / stopAutoSnapshot
+
+Starts or stops automatic periodic snapshotting.
+
+```typescript
+startAutoSnapshot(world: World): void;
+stopAutoSnapshot(): void;
+```
+
+### reset
+
+Resets all data and stops auto-snapshotting.
+
+```typescript
+reset(): void;
+```
+
+## Usage Example
+
+```typescript
+import { createMemoryProfiler, createWorld, addEntity, Position, Renderable } from 'blecsd';
+
+const profiler = createMemoryProfiler({
+  snapshotInterval: 5000,
+  maxSnapshots: 50,
+  entityLeakThreshold: 5,
+  heapLeakThreshold: 512 * 1024,
+  trackedComponents: [
+    { component: Position, name: 'Position' },
+    { component: Renderable, name: 'Renderable' },
+  ],
+});
+
+const world = createWorld();
+
+// Start automatic profiling
+profiler.startAutoSnapshot(world);
+
+// In your game loop, periodically check
+setInterval(() => {
+  const report = profiler.getReport(world);
+  console.log(report);
+  // Memory Profile Report
+  // ========================================
+  // Entities: 150
+  // Heap Used: 12.3MB
+  // ...
+  // Component Counts:
+  //   Position: 148
+  //   Renderable: 120
+  //
+  // Trends (over 30s):
+  //   Entity delta: +15
+  //   Heap delta: +256KB
+  //
+  // WARNINGS:
+  //   [entity] Entity count growing at 12.5/sec (100 -> 150)
+}, 10000);
+
+// Manual comparison
+const before = profiler.snapshot(world);
+spawnManyEntities(world, 1000);
+const after = profiler.snapshot(world);
+
+const diff = profiler.diff(before, after);
+console.log(`Entity delta: ${diff.entityCountDelta}`);
+console.log(`Heap delta: ${diff.heapUsedDelta} bytes`);
+
+for (const leak of diff.possibleLeaks) {
+  console.warn(`[${leak.type}] ${leak.message}`);
+}
+
+// Cleanup
+profiler.stopAutoSnapshot();
+profiler.reset();
+```

--- a/docs/api/debug/overlay.md
+++ b/docs/api/debug/overlay.md
@@ -1,0 +1,243 @@
+# Debug Overlay API
+
+Debug overlay widget for visual debugging. Displays real-time FPS, entity count, system timings, and memory usage. Also provides an input event logger, a mini profiler for measuring code sections, and a frame rate graph.
+
+## Quick Start
+
+```typescript
+import { createDebugOverlay } from 'blecsd';
+
+const overlay = createDebugOverlay(world, {
+  toggleKey: 'F12',
+  showSystemTimings: true,
+});
+
+// In game loop
+overlay.update(world, loop);
+
+// Toggle visibility
+overlay.toggle();
+```
+
+## Types
+
+### DebugOverlayConfig
+
+```typescript
+interface DebugOverlayConfig {
+  readonly x?: number;                  // default: 0
+  readonly y?: number;                  // default: 0
+  readonly width?: number;              // default: 35
+  readonly toggleKey?: string;          // default: 'F12'
+  readonly showFPS?: boolean;           // default: true
+  readonly showEntityCount?: boolean;   // default: true
+  readonly showMemory?: boolean;        // default: true
+  readonly showSystemTimings?: boolean; // default: true
+  readonly maxSystemsShown?: number;    // default: 5
+  readonly bgColor?: number;           // default: 0x000080ff (navy blue)
+  readonly fgColor?: number;           // default: 0xffffffff (white)
+  readonly visibleOnStart?: boolean;   // default: false
+}
+```
+
+### DebugOverlay
+
+```typescript
+interface DebugOverlay {
+  readonly visible: boolean;
+  readonly entity: Entity | null;
+  readonly config: Required<DebugOverlayConfig>;
+  show(): void;
+  hide(): void;
+  toggle(): void;
+  update(world: World, loop?: GameLoop): void;
+  destroy(): void;
+}
+```
+
+### MiniProfiler
+
+```typescript
+interface MiniProfiler {
+  start(name: string): void;
+  end(name: string): number;
+  getAverage(name: string): number;
+  getAll(): Record<string, { avg: number; min: number; max: number; count: number }>;
+  reset(): void;
+}
+```
+
+### FrameRateGraph
+
+```typescript
+interface FrameRateGraph {
+  addSample(frameTimeMs: number): void;
+  getSamples(): readonly number[];
+  getCurrentFPS(): number;
+  getAverageFPS(): number;
+  getMinMaxFPS(): { min: number; max: number };
+  reset(): void;
+}
+```
+
+## Functions
+
+### createDebugOverlay
+
+Creates a debug overlay for the given world. Displays real-time debugging information and can be toggled with a configurable key.
+
+```typescript
+function createDebugOverlay(world: World, config?: DebugOverlayConfig): DebugOverlay;
+```
+
+**Parameters:**
+- `world` - The ECS world
+- `config` - Optional configuration
+
+**Returns:** Debug overlay controller.
+
+```typescript
+import { createDebugOverlay } from 'blecsd';
+
+const overlay = createDebugOverlay(world, {
+  toggleKey: 'F12',
+  showSystemTimings: true,
+  visibleOnStart: true,
+});
+```
+
+### createInputLogger
+
+Creates an input event logger for debugging.
+
+```typescript
+function createInputLogger(maxEntries?: number): InputLogger;
+```
+
+**Parameters:**
+- `maxEntries` - Maximum entries to keep (default: 20)
+
+**Returns:** Input logger instance with `log`, `clear`, and `getRecentEntries` methods.
+
+```typescript
+import { createInputLogger } from 'blecsd';
+
+const logger = createInputLogger(10);
+
+// In input handler
+logger.log('key', `${event.name} ${event.ctrl ? '+Ctrl' : ''}`);
+logger.log('mouse', `${event.action} @ ${event.x},${event.y}`);
+
+// Get recent entries
+const recent = logger.getRecentEntries(5);
+```
+
+### createMiniProfiler
+
+Creates a mini profiler for measuring code sections.
+
+```typescript
+function createMiniProfiler(): MiniProfiler;
+```
+
+```typescript
+import { createMiniProfiler } from 'blecsd';
+
+const profiler = createMiniProfiler();
+
+profiler.start('render');
+// ... render code ...
+const elapsed = profiler.end('render');
+
+console.log(`Render avg: ${profiler.getAverage('render').toFixed(2)}ms`);
+
+// Get all timings
+const all = profiler.getAll();
+for (const [name, stats] of Object.entries(all)) {
+  console.log(`${name}: avg=${stats.avg.toFixed(2)}ms min=${stats.min.toFixed(2)}ms max=${stats.max.toFixed(2)}ms (${stats.count} samples)`);
+}
+```
+
+### createFrameRateGraph
+
+Creates a frame rate graph for visualizing performance over time.
+
+```typescript
+function createFrameRateGraph(sampleCount?: number): FrameRateGraph;
+```
+
+**Parameters:**
+- `sampleCount` - Number of samples to keep (default: 60)
+
+```typescript
+import { createFrameRateGraph } from 'blecsd';
+
+const graph = createFrameRateGraph(120); // 2 seconds at 60fps
+
+// In game loop
+graph.addSample(deltaTime * 1000);
+
+console.log(`Current FPS: ${graph.getCurrentFPS().toFixed(0)}`);
+console.log(`Average FPS: ${graph.getAverageFPS().toFixed(0)}`);
+
+const { min, max } = graph.getMinMaxFPS();
+console.log(`FPS range: ${min.toFixed(0)} - ${max.toFixed(0)}`);
+```
+
+## Usage Example
+
+```typescript
+import {
+  createDebugOverlay,
+  createInputLogger,
+  createMiniProfiler,
+  createFrameRateGraph,
+  createGameLoop,
+  createWorld,
+} from 'blecsd';
+
+const world = createWorld();
+const loop = createGameLoop(world, { targetFPS: 60 });
+
+// Debug overlay
+const overlay = createDebugOverlay(world, {
+  showFPS: true,
+  showEntityCount: true,
+  showMemory: true,
+  showSystemTimings: true,
+  visibleOnStart: false,
+});
+
+// Input logger
+const inputLog = createInputLogger(20);
+
+// Code profiler
+const profiler = createMiniProfiler();
+
+// FPS graph
+const fpsGraph = createFrameRateGraph(120);
+
+// In game loop
+function onUpdate(deltaTime: number) {
+  fpsGraph.addSample(deltaTime * 1000);
+
+  profiler.start('update');
+  // ... game logic ...
+  profiler.end('update');
+
+  profiler.start('render');
+  overlay.update(world, loop);
+  profiler.end('render');
+}
+
+// Toggle with key
+function onKey(event: KeyEvent) {
+  inputLog.log('key', event.name);
+  if (event.name === 'F12') {
+    overlay.toggle();
+  }
+}
+
+// Cleanup
+overlay.destroy();
+```

--- a/docs/api/input/vi-mode.md
+++ b/docs/api/input/vi-mode.md
@@ -1,0 +1,236 @@
+# Vi Mode API
+
+Vi-style navigation mode for scrollable elements. Provides vi key bindings for scrolling, cursor movement, and search within scrollable content.
+
+## Quick Start
+
+```typescript
+import { createViState, createViConfig, processViKey } from 'blecsd';
+
+const state = createViState();
+const config = createViConfig({ enabled: true, viewportHeight: 40 });
+
+// Process a key press
+const [action, newState] = processViKey(keyEvent, state, config);
+if (action.type === 'scroll') {
+  scrollBy(world, eid, 0, action.amount);
+}
+```
+
+## Types
+
+### ViModeState
+
+```typescript
+type ViModeState = 'normal' | 'search' | 'command';
+```
+
+### ViAction
+
+Actions produced by processing vi keys.
+
+```typescript
+type ViAction =
+  | { readonly type: 'scroll'; readonly direction: 'up' | 'down' | 'left' | 'right'; readonly amount: number }
+  | { readonly type: 'jump'; readonly target: 'top' | 'bottom' | 'high' | 'middle' | 'low' }
+  | { readonly type: 'page'; readonly direction: 'up' | 'down'; readonly amount: 'half' | 'full' }
+  | { readonly type: 'search'; readonly query: string; readonly direction: 'forward' | 'backward' }
+  | { readonly type: 'searchNext'; readonly direction: 'forward' | 'backward' }
+  | { readonly type: 'enterSearch' }
+  | { readonly type: 'exitSearch' }
+  | { readonly type: 'searchInput'; readonly char: string }
+  | { readonly type: 'none' };
+```
+
+### ViModeConfig
+
+```typescript
+interface ViModeConfig {
+  readonly enabled: boolean;         // default: false
+  readonly scrollStep: number;       // default: 1
+  readonly horizontalStep: number;   // default: 1
+  readonly viewportHeight: number;   // viewport lines for H/M/L calculations
+}
+```
+
+### ViState
+
+Internal vi mode state.
+
+```typescript
+interface ViState {
+  readonly mode: ViModeState;
+  readonly searchBuffer: string;
+  readonly lastSearch: string;
+  readonly lastSearchDirection: 'forward' | 'backward';
+  readonly countPrefix: number;
+  readonly gPending: boolean;
+}
+```
+
+## Functions
+
+### createViState
+
+Creates initial vi mode state.
+
+```typescript
+function createViState(): ViState;
+```
+
+### createViConfig
+
+Creates a vi mode configuration with defaults.
+
+```typescript
+function createViConfig(config?: Partial<ViModeConfig>): ViModeConfig;
+```
+
+### processViKey
+
+Processes a key event in vi mode and returns the resulting action and new state.
+
+```typescript
+function processViKey(
+  key: KeyEvent,
+  state: ViState,
+  config: ViModeConfig
+): [ViAction, ViState];
+```
+
+**Parameters:**
+- `key` - The key event to process
+- `state` - Current vi state
+- `config` - Vi mode configuration
+
+**Returns:** Tuple of `[action, newState]`.
+
+### isViKey
+
+Checks if a key event should be consumed by vi mode. Use this to prevent vi keys from bubbling to other handlers.
+
+```typescript
+function isViKey(key: KeyEvent, state: ViState, config: ViModeConfig): boolean;
+```
+
+### resolvePageAmount
+
+Resolves a vi page action to a concrete scroll amount.
+
+```typescript
+function resolvePageAmount(amount: 'half' | 'full', viewportHeight: number): number;
+```
+
+```typescript
+import { resolvePageAmount } from 'blecsd';
+
+const lines = resolvePageAmount('half', 40); // 20
+const fullPage = resolvePageAmount('full', 40); // 39
+```
+
+### resolveJumpTarget
+
+Resolves a vi jump target to a line number.
+
+```typescript
+function resolveJumpTarget(
+  target: 'top' | 'bottom' | 'high' | 'middle' | 'low',
+  scrollTop: number,
+  viewportHeight: number,
+  totalLines: number
+): number;
+```
+
+## Supported Key Bindings
+
+### Normal Mode
+
+| Key | Action |
+|-----|--------|
+| `j` | Scroll down |
+| `k` | Scroll up |
+| `h` | Scroll left |
+| `l` | Scroll right |
+| `gg` | Jump to top |
+| `G` | Jump to bottom |
+| `H` | Jump to high (top of viewport) |
+| `M` | Jump to middle of viewport |
+| `L` | Jump to low (bottom of viewport) |
+| `Ctrl+d` | Half page down |
+| `Ctrl+u` | Half page up |
+| `Ctrl+f` | Full page down |
+| `Ctrl+b` | Full page up |
+| `/` | Enter search mode |
+| `n` | Next search result |
+| `N` | Previous search result |
+| `1-9` | Count prefix (e.g., `5j` scrolls down 5) |
+
+### Search Mode
+
+| Key | Action |
+|-----|--------|
+| Characters | Append to search buffer |
+| `Enter` | Execute search |
+| `Escape` | Cancel search |
+| `Backspace` | Delete last character |
+
+## Usage Example
+
+```typescript
+import {
+  createViState,
+  createViConfig,
+  processViKey,
+  isViKey,
+  resolvePageAmount,
+  resolveJumpTarget,
+} from 'blecsd';
+
+let viState = createViState();
+const viConfig = createViConfig({
+  enabled: true,
+  scrollStep: 1,
+  viewportHeight: 40,
+});
+
+function handleKey(keyEvent: KeyEvent) {
+  // Check if vi mode wants this key
+  if (!isViKey(keyEvent, viState, viConfig)) {
+    handleNormalKey(keyEvent);
+    return;
+  }
+
+  const [action, newState] = processViKey(keyEvent, viState, viConfig);
+  viState = newState;
+
+  switch (action.type) {
+    case 'scroll':
+      scrollBy(action.direction, action.amount);
+      break;
+    case 'jump': {
+      const line = resolveJumpTarget(
+        action.target, scrollTop, viewportHeight, totalLines
+      );
+      scrollToLine(line);
+      break;
+    }
+    case 'page': {
+      const amount = resolvePageAmount(action.amount, viewportHeight);
+      scrollBy(action.direction, amount);
+      break;
+    }
+    case 'search':
+      performSearch(action.query, action.direction);
+      break;
+    case 'searchNext':
+      findNextMatch(action.direction);
+      break;
+    case 'enterSearch':
+      showSearchBar();
+      break;
+    case 'exitSearch':
+      hideSearchBar();
+      break;
+  }
+}
+```

--- a/docs/api/systems/animation.md
+++ b/docs/api/systems/animation.md
@@ -1,0 +1,178 @@
+# Animation System API
+
+ECS system for updating sprite animations based on frame timing and playback state.
+
+## Overview
+
+The animation system handles:
+- Advancing sprite animation frames based on elapsed time
+- Playback speed scaling
+- Looping and one-shot animation modes
+- Forward and reverse playback direction
+- Updating entity Sprite component frames
+
+## Quick Start
+
+```typescript
+import {
+  createScheduler,
+  registerAnimationSystem,
+  LoopPhase,
+} from 'blecsd';
+
+const scheduler = createScheduler();
+registerAnimationSystem(scheduler);
+
+// In game loop
+scheduler.run(world, deltaTime);
+```
+
+## Functions
+
+### animationSystem
+
+The animation system function. Reads delta time from the scheduler and updates all entities with the Animation component.
+
+For each playing animation, the system:
+1. Adds elapsed time (scaled by speed)
+2. Checks if the current frame duration is exceeded
+3. Advances to the next frame (respecting direction)
+4. Handles loop/stop when the animation completes
+5. Updates the entity's Sprite component frame
+
+```typescript
+const animationSystem: System
+```
+
+```typescript
+import { animationSystem, LoopPhase } from 'blecsd';
+
+scheduler.registerSystem(LoopPhase.UPDATE, animationSystem);
+```
+
+### createAnimationSystem
+
+Factory function that returns the animationSystem.
+
+```typescript
+function createAnimationSystem(): System
+```
+
+```typescript
+import { createAnimationSystem, createScheduler, LoopPhase } from 'blecsd';
+
+const scheduler = createScheduler();
+const system = createAnimationSystem();
+scheduler.registerSystem(LoopPhase.UPDATE, system);
+```
+
+### registerAnimationSystem
+
+Convenience function that registers the animation system in the UPDATE phase.
+
+```typescript
+function registerAnimationSystem(scheduler: Scheduler, priority?: number): void
+```
+
+**Parameters:**
+- `scheduler` - The scheduler to register with
+- `priority` - Optional priority within the UPDATE phase (default: 0)
+
+```typescript
+import { createScheduler, registerAnimationSystem } from 'blecsd';
+
+const scheduler = createScheduler();
+registerAnimationSystem(scheduler);
+```
+
+### queryAnimation
+
+Query all entities with the Animation component.
+
+```typescript
+function queryAnimation(world: World): number[]
+```
+
+### hasAnimationSystem
+
+Checks if an entity has the Animation component via the system store.
+
+```typescript
+function hasAnimationSystem(world: World, eid: number): boolean
+```
+
+### updateAnimations
+
+Manually update animations for specific entities. Useful for testing or custom update loops.
+
+```typescript
+function updateAnimations(
+  world: World,
+  entities: readonly number[],
+  deltaTime: number,
+): void
+```
+
+```typescript
+import { updateAnimations, queryAnimation } from 'blecsd';
+
+const entities = queryAnimation(world);
+updateAnimations(world, entities, 0.016); // ~60fps frame
+```
+
+## Usage Example
+
+Complete sprite animation setup:
+
+```typescript
+import {
+  createWorld,
+  addEntity,
+  createScheduler,
+  registerAnimationSystem,
+  queryAnimation,
+  updateAnimations,
+  setAnimation,
+  setSprite,
+  LoopPhase,
+} from 'blecsd';
+
+const world = createWorld();
+const scheduler = createScheduler();
+
+// Register animation system in UPDATE phase
+registerAnimationSystem(scheduler);
+
+// Create an animated entity
+const player = addEntity(world);
+
+// Set up sprite with initial frame
+setSprite(world, player, {
+  char: '@',
+  fg: 0xffffff,
+  bg: 0x000000,
+});
+
+// Set up walk animation
+setAnimation(world, player, {
+  animationId: walkAnimId,
+  playing: true,
+  loop: true,
+  speed: 1.0,
+  direction: 1,  // Forward
+});
+
+// Run in game loop
+let lastTime = Date.now();
+setInterval(() => {
+  const now = Date.now();
+  const dt = (now - lastTime) / 1000;
+  lastTime = now;
+
+  scheduler.run(world, dt);
+}, 16);
+
+// Or manually update specific entities
+const animatedEntities = queryAnimation(world);
+updateAnimations(world, animatedEntities, 1 / 60);
+```

--- a/docs/api/systems/behavior.md
+++ b/docs/api/systems/behavior.md
@@ -1,0 +1,179 @@
+# Behavior System API
+
+ECS system for processing AI behaviors each frame, including patrol, chase, flee, and custom behaviors.
+
+## Overview
+
+The behavior system handles:
+- Patrol movement along waypoints
+- Chase behavior toward a target entity
+- Flee behavior away from a target entity
+- Custom behavior callbacks
+- Wait timers between behavior actions
+- Pluggable position resolution and movement application
+
+## Quick Start
+
+```typescript
+import { createBehaviorSystem } from 'blecsd';
+
+const behaviorSystem = createBehaviorSystem(
+  { getDelta: () => 1 / 60 },
+  (world) => behaviorEntities,
+);
+
+// In your update loop
+behaviorSystem(world);
+```
+
+## Types
+
+### PositionResolver
+
+Function for getting entity positions. Allows the behavior system to work with any position storage.
+
+```typescript
+type PositionResolver = (
+  world: World,
+  eid: Entity,
+) => { x: number; y: number } | undefined;
+```
+
+### MovementApplier
+
+Function for applying computed movement. Allows the behavior system to work with any movement system.
+
+```typescript
+type MovementApplier = (
+  world: World,
+  eid: Entity,
+  dx: number,
+  dy: number,
+  delta: number,
+) => void;
+```
+
+### BehaviorSystemConfig
+
+Configuration for the behavior system.
+
+```typescript
+interface BehaviorSystemConfig {
+  /** Function to resolve entity positions (default: uses Position component) */
+  getPosition?: PositionResolver;
+  /** Function to apply movement (default: directly modifies Position) */
+  applyMovement?: MovementApplier;
+  /** Function to get delta time */
+  getDelta: () => number;
+}
+```
+
+## Functions
+
+### createBehaviorSystem
+
+Creates a behavior system that processes all entities with Behavior components. The system computes movement directions for patrol, chase, and flee behaviors and applies them via the configured movement applier.
+
+```typescript
+function createBehaviorSystem(
+  config: BehaviorSystemConfig,
+  entities: (world: World) => readonly Entity[],
+): System
+```
+
+**Parameters:**
+- `config` - System configuration (getDelta is required, others have defaults)
+- `entities` - Function returning entity IDs to process each frame
+
+**Returns:** A `System` function that processes behaviors when called with a world.
+
+```typescript
+import { createBehaviorSystem } from 'blecsd';
+
+// Basic setup with default position/movement handling
+const behaviorSystem = createBehaviorSystem(
+  { getDelta: () => 1 / 60 },
+  (world) => myBehaviorEntities,
+);
+
+// Custom position resolver and movement applier
+const customBehaviorSystem = createBehaviorSystem(
+  {
+    getDelta: () => deltaTime,
+    getPosition: (world, eid) => {
+      return { x: myPositions.x[eid], y: myPositions.y[eid] };
+    },
+    applyMovement: (world, eid, dx, dy, delta) => {
+      myPositions.x[eid] += dx * delta;
+      myPositions.y[eid] += dy * delta;
+    },
+  },
+  (world) => myBehaviorEntities,
+);
+```
+
+## Behavior Types
+
+The system processes entities based on their `BehaviorType`:
+
+| Type | Description |
+|------|-------------|
+| `Idle` | No movement, entity stands still |
+| `Patrol` | Moves between waypoints |
+| `Chase` | Moves toward a target entity |
+| `Flee` | Moves away from a target entity |
+| `Custom` | Executes a registered custom behavior callback |
+
+## Usage Example
+
+Complete example showing an enemy with patrol and chase behaviors:
+
+```typescript
+import {
+  createWorld,
+  addEntity,
+  createScheduler,
+  createBehaviorSystem,
+  setBehavior,
+  BehaviorType,
+  setPosition,
+  LoopPhase,
+} from 'blecsd';
+
+const world = createWorld();
+const scheduler = createScheduler();
+
+// Track behavior entities
+const behaviorEntities: Entity[] = [];
+
+// Create the behavior system
+const behaviorSystem = createBehaviorSystem(
+  { getDelta: () => 1 / 60 },
+  () => behaviorEntities,
+);
+
+scheduler.registerSystem(LoopPhase.UPDATE, behaviorSystem);
+
+// Create an enemy that patrols
+const enemy = addEntity(world);
+setPosition(world, enemy, 10, 5);
+setBehavior(world, enemy, {
+  behaviorType: BehaviorType.Patrol,
+  speed: 2,
+});
+behaviorEntities.push(enemy);
+
+// Create a player
+const player = addEntity(world);
+setPosition(world, player, 50, 10);
+
+// Switch enemy to chase when player is nearby
+setBehavior(world, enemy, {
+  behaviorType: BehaviorType.Chase,
+  targetEntity: player,
+  speed: 3,
+});
+
+// Run in game loop
+scheduler.run(world, 1 / 60);
+```

--- a/docs/api/systems/frame-budget.md
+++ b/docs/api/systems/frame-budget.md
@@ -1,0 +1,320 @@
+# Frame Budget System API
+
+Performance profiling and frame budget enforcement system with rolling statistics and per-phase budget tracking.
+
+## Overview
+
+The frame budget manager handles:
+- Per-system execution time measurement
+- Rolling statistics (average, p50, p95, p99)
+- Configurable per-phase time budgets
+- Budget overrun alerts with callbacks
+- Metrics export for external analysis
+
+## Quick Start
+
+```typescript
+import {
+  createFrameBudgetManager,
+  profiledSystem,
+  recordFrameTime,
+  getFrameBudgetStats,
+} from 'blecsd';
+
+const manager = createFrameBudgetManager({ targetFrameMs: 16.67 });
+
+// Wrap systems with profiling
+const timedMovement = profiledSystem('movement', movementSystem);
+
+// Record frame times in your loop
+recordFrameTime(frameTimeMs);
+
+// Check stats
+const stats = getFrameBudgetStats();
+console.log(`Avg FPS: ${stats.stats.avgFps.toFixed(1)}`);
+```
+
+## Types
+
+### FrameBudgetConfig
+
+```typescript
+interface FrameBudgetConfig {
+  /** Target frame time in ms (default: 16.67 = 60fps) */
+  readonly targetFrameMs: number;
+  /** Per-phase budget overrides in ms (phase -> budget) */
+  readonly phaseBudgets: Readonly<Partial<Record<LoopPhase, number>>>;
+  /** Number of frames to keep in rolling stats (default: 120) */
+  readonly rollingWindowSize: number;
+  /** Whether to emit warnings on budget overruns (default: true) */
+  readonly warnOnOverrun: boolean;
+}
+```
+
+### SystemTiming
+
+Per-system timing record with percentile statistics.
+
+```typescript
+interface SystemTiming {
+  readonly name: string;
+  readonly lastMs: number;
+  readonly avgMs: number;
+  readonly minMs: number;
+  readonly maxMs: number;
+  readonly p50Ms: number;
+  readonly p95Ms: number;
+  readonly p99Ms: number;
+  readonly count: number;
+}
+```
+
+### FrameStats
+
+Frame-level statistics aggregated from system timings.
+
+```typescript
+interface FrameStats {
+  readonly frameTimeMs: number;
+  readonly avgFrameMs: number;
+  readonly p50FrameMs: number;
+  readonly p95FrameMs: number;
+  readonly p99FrameMs: number;
+  readonly fps: number;
+  readonly avgFps: number;
+  readonly totalFrames: number;
+  readonly budgetOverruns: number;
+  readonly systemTimings: readonly SystemTiming[];
+  readonly phaseTimings: Readonly<Record<string, number>>;
+}
+```
+
+### BudgetAlert
+
+Alert emitted when a phase exceeds its budget.
+
+```typescript
+interface BudgetAlert {
+  readonly phase: LoopPhase;
+  readonly budgetMs: number;
+  readonly actualMs: number;
+  readonly frame: number;
+}
+```
+
+### FrameBudgetManager
+
+Top-level manager state returned by query functions.
+
+```typescript
+interface FrameBudgetManager {
+  readonly config: FrameBudgetConfig;
+  readonly stats: FrameStats;
+  readonly alerts: readonly BudgetAlert[];
+}
+```
+
+## Functions
+
+### createFrameBudgetManager
+
+Creates and activates the frame budget manager.
+
+```typescript
+function createFrameBudgetManager(config?: Partial<FrameBudgetConfig>): FrameBudgetManager
+```
+
+**Parameters:**
+- `config` - Optional configuration overrides
+
+**Returns:** The initial `FrameBudgetManager` state.
+
+```typescript
+import { createFrameBudgetManager, LoopPhase } from 'blecsd';
+
+const manager = createFrameBudgetManager({
+  targetFrameMs: 16.67,
+  rollingWindowSize: 240,
+  phaseBudgets: {
+    [LoopPhase.UPDATE]: 5,
+    [LoopPhase.RENDER]: 8,
+  },
+});
+```
+
+### profiledSystem
+
+Wraps a system with automatic timing. Each call records the system's execution time.
+
+```typescript
+function profiledSystem(name: string, system: System): System
+```
+
+**Parameters:**
+- `name` - The system name for profiling reports
+- `system` - The system function to wrap
+
+**Returns:** A wrapped `System` that records its execution time.
+
+```typescript
+import { profiledSystem } from 'blecsd';
+
+const timedMovement = profiledSystem('movement', movementSystem);
+const timedRender = profiledSystem('render', renderSystem);
+
+scheduler.registerSystem(LoopPhase.UPDATE, timedMovement);
+scheduler.registerSystem(LoopPhase.RENDER, timedRender);
+```
+
+### recordFrameBudgetSystemTime
+
+Records the execution time of a named system manually.
+
+```typescript
+function recordFrameBudgetSystemTime(name: string, timeMs: number): void
+```
+
+### recordPhaseTime
+
+Records phase completion time and checks against the phase budget.
+
+```typescript
+function recordPhaseTime(phase: LoopPhase, timeMs: number): void
+```
+
+### recordFrameTime
+
+Records a complete frame time for FPS tracking.
+
+```typescript
+function recordFrameTime(frameTimeMs: number): void
+```
+
+### getFrameBudgetStats
+
+Gets a snapshot of current frame budget statistics.
+
+```typescript
+function getFrameBudgetStats(): FrameBudgetManager
+```
+
+```typescript
+import { getFrameBudgetStats } from 'blecsd';
+
+const { stats, alerts } = getFrameBudgetStats();
+console.log(`FPS: ${stats.fps.toFixed(1)}, Avg: ${stats.avgFps.toFixed(1)}`);
+console.log(`p95 frame: ${stats.p95FrameMs.toFixed(2)}ms`);
+
+for (const timing of stats.systemTimings) {
+  console.log(`  ${timing.name}: avg=${timing.avgMs.toFixed(2)}ms p95=${timing.p95Ms.toFixed(2)}ms`);
+}
+```
+
+### onBudgetAlert
+
+Registers a callback for budget overrun alerts.
+
+```typescript
+function onBudgetAlert(callback: (alert: BudgetAlert) => void): void
+```
+
+```typescript
+import { onBudgetAlert } from 'blecsd';
+
+onBudgetAlert((alert) => {
+  console.warn(
+    `Phase ${alert.phase} exceeded budget: ${alert.actualMs.toFixed(2)}ms > ${alert.budgetMs}ms`
+  );
+});
+```
+
+### resetFrameBudget
+
+Resets all profiling data while keeping the configuration.
+
+```typescript
+function resetFrameBudget(): void
+```
+
+### destroyFrameBudgetManager
+
+Destroys the frame budget manager and clears all state.
+
+```typescript
+function destroyFrameBudgetManager(): void
+```
+
+### exportFrameBudgetMetrics
+
+Exports metrics as a JSON-serializable object for external analysis.
+
+```typescript
+function exportFrameBudgetMetrics(): Record<string, unknown>
+```
+
+```typescript
+import { exportFrameBudgetMetrics } from 'blecsd';
+
+const metrics = exportFrameBudgetMetrics();
+// Send to analytics, write to file, etc.
+```
+
+## Usage Example
+
+Complete example with budget alerts and profiled systems:
+
+```typescript
+import {
+  createWorld,
+  createScheduler,
+  createFrameBudgetManager,
+  profiledSystem,
+  recordFrameTime,
+  recordPhaseTime,
+  onBudgetAlert,
+  getFrameBudgetStats,
+  destroyFrameBudgetManager,
+  LoopPhase,
+} from 'blecsd';
+
+const world = createWorld();
+const scheduler = createScheduler();
+
+// Create budget manager with per-phase limits
+createFrameBudgetManager({
+  targetFrameMs: 16.67,
+  phaseBudgets: {
+    [LoopPhase.UPDATE]: 5,
+    [LoopPhase.RENDER]: 8,
+  },
+});
+
+// Alert on budget overruns
+onBudgetAlert((alert) => {
+  console.warn(`Budget exceeded in frame ${alert.frame}`);
+});
+
+// Wrap systems with profiling
+const timedUpdate = profiledSystem('gameLogic', myUpdateSystem);
+const timedRender = profiledSystem('renderer', myRenderSystem);
+
+scheduler.registerSystem(LoopPhase.UPDATE, timedUpdate);
+scheduler.registerSystem(LoopPhase.RENDER, timedRender);
+
+// Game loop
+let lastTime = performance.now();
+setInterval(() => {
+  const now = performance.now();
+  const dt = now - lastTime;
+  lastTime = now;
+
+  scheduler.run(world, dt / 1000);
+  recordFrameTime(dt);
+}, 16);
+
+// Periodically log stats
+setInterval(() => {
+  const { stats } = getFrameBudgetStats();
+  console.log(`FPS: ${stats.avgFps.toFixed(1)} | Overruns: ${stats.budgetOverruns}`);
+}, 5000);
+```

--- a/docs/api/systems/movement.md
+++ b/docs/api/systems/movement.md
@@ -1,0 +1,169 @@
+# Movement System API
+
+ECS system for updating entity positions based on velocity, acceleration, and friction.
+
+## Overview
+
+The movement system handles:
+- Applying acceleration to velocity
+- Applying friction for natural deceleration
+- Clamping velocity to a maximum speed
+- Applying velocity to update entity positions
+
+## Quick Start
+
+```typescript
+import {
+  createScheduler,
+  registerMovementSystem,
+  LoopPhase,
+} from 'blecsd';
+
+const scheduler = createScheduler();
+registerMovementSystem(scheduler);
+
+// In game loop
+scheduler.run(world, deltaTime);
+```
+
+## Functions
+
+### movementSystem
+
+The movement system function. Reads delta time from the scheduler and processes all entities with the Velocity component.
+
+For each entity, the system:
+1. Applies acceleration to velocity (if Acceleration component is present)
+2. Applies friction to velocity
+3. Clamps velocity to max speed
+4. Applies velocity to position (if Position component is present)
+
+```typescript
+const movementSystem: System
+```
+
+```typescript
+import { movementSystem, LoopPhase } from 'blecsd';
+
+scheduler.registerSystem(LoopPhase.PHYSICS, movementSystem);
+```
+
+### createMovementSystem
+
+Factory function that returns the movementSystem.
+
+```typescript
+function createMovementSystem(): System
+```
+
+```typescript
+import { createMovementSystem, createScheduler, LoopPhase } from 'blecsd';
+
+const scheduler = createScheduler();
+const system = createMovementSystem();
+scheduler.registerSystem(LoopPhase.PHYSICS, system);
+```
+
+### registerMovementSystem
+
+Convenience function that registers the movement system in the PHYSICS phase.
+
+```typescript
+function registerMovementSystem(scheduler: Scheduler, priority?: number): void
+```
+
+**Parameters:**
+- `scheduler` - The scheduler to register with
+- `priority` - Optional priority within the PHYSICS phase (default: 0)
+
+```typescript
+import { createScheduler, registerMovementSystem } from 'blecsd';
+
+const scheduler = createScheduler();
+registerMovementSystem(scheduler);
+```
+
+### queryMovement
+
+Query all entities with the Velocity component.
+
+```typescript
+function queryMovement(world: World): number[]
+```
+
+### hasMovementSystem
+
+Checks if an entity has the Velocity component via the system store.
+
+```typescript
+function hasMovementSystem(world: World, eid: number): boolean
+```
+
+### updateMovements
+
+Manually update movement for specific entities. Useful for testing or custom update loops.
+
+```typescript
+function updateMovements(
+  world: World,
+  entities: readonly number[],
+  deltaTime: number,
+): void
+```
+
+```typescript
+import { updateMovements, queryMovement } from 'blecsd';
+
+const entities = queryMovement(world);
+updateMovements(world, entities, 0.016); // ~60fps frame
+```
+
+## Usage Example
+
+Complete movement setup with velocity, acceleration, and friction:
+
+```typescript
+import {
+  createWorld,
+  addEntity,
+  createScheduler,
+  registerMovementSystem,
+  queryMovement,
+  updateMovements,
+  setPosition,
+  setVelocity,
+  setAcceleration,
+  LoopPhase,
+} from 'blecsd';
+
+const world = createWorld();
+const scheduler = createScheduler();
+
+// Register movement system in PHYSICS phase
+registerMovementSystem(scheduler);
+
+// Create a moving entity
+const projectile = addEntity(world);
+setPosition(world, projectile, 10, 5);
+setVelocity(world, projectile, 5, -2);  // Moving right and up
+
+// Create an entity with acceleration
+const rocket = addEntity(world);
+setPosition(world, rocket, 0, 20);
+setVelocity(world, rocket, 0, 0);
+setAcceleration(world, rocket, 1, -0.5);  // Accelerating right and up
+
+// Run in game loop
+let lastTime = Date.now();
+setInterval(() => {
+  const now = Date.now();
+  const dt = (now - lastTime) / 1000;
+  lastTime = now;
+
+  scheduler.run(world, dt);
+}, 16);
+
+// Or manually update specific entities
+const movingEntities = queryMovement(world);
+updateMovements(world, movingEntities, 1 / 60);
+```

--- a/docs/api/systems/panel-movement.md
+++ b/docs/api/systems/panel-movement.md
@@ -1,0 +1,364 @@
+# Panel Movement System API
+
+Fast panel movement and resizing system with constraint enforcement, dirty rect tracking, and keyboard support.
+
+## Overview
+
+The panel movement system handles:
+- Mouse-driven panel dragging and resizing
+- Keyboard-based panel movement and resizing
+- Resize handle detection (8 directions: corners and edges)
+- Constraint enforcement (min/max size, screen bounds, grid snap)
+- Dirty rectangle tracking for efficient redraws
+- Deferred content layout during drag for 60fps performance
+
+## Quick Start
+
+```typescript
+import {
+  createPanelMoveState,
+  createPanelConstraints,
+  beginMove,
+  updateMove,
+  endMoveOrResize,
+} from 'blecsd';
+
+let state = createPanelMoveState();
+const constraints = createPanelConstraints({ screenWidth: 80, screenHeight: 24 });
+
+// On drag start
+state = beginMove(state, entity, mouseX, mouseY, panelX, panelY, 30, 10);
+
+// On drag update
+const result = updateMove(state, mouseX, mouseY, constraints);
+// Apply result.x, result.y to entity position
+
+// On drag end
+state = endMoveOrResize(state);
+```
+
+## Types
+
+### ResizeHandle
+
+```typescript
+type ResizeHandle =
+  | 'top' | 'bottom' | 'left' | 'right'
+  | 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
+```
+
+### PanelConstraints
+
+```typescript
+interface PanelConstraints {
+  readonly minWidth: number;       // default: 4
+  readonly minHeight: number;      // default: 2
+  readonly maxWidth: number;       // 0 = no limit
+  readonly maxHeight: number;      // 0 = no limit
+  readonly constrainToScreen: boolean; // default: true
+  readonly screenWidth: number;    // default: 80
+  readonly screenHeight: number;   // default: 24
+  readonly snapGrid: number;       // 0 = no snap
+}
+```
+
+### PanelMoveState
+
+Tracks the current move or resize operation state.
+
+```typescript
+interface PanelMoveState {
+  readonly entity: Entity | undefined;
+  readonly isMoving: boolean;
+  readonly isResizing: boolean;
+  readonly resizeHandle: ResizeHandle | undefined;
+  readonly startX: number;
+  readonly startY: number;
+  readonly panelStartX: number;
+  readonly panelStartY: number;
+  readonly panelStartWidth: number;
+  readonly panelStartHeight: number;
+  readonly layoutDeferred: boolean;
+}
+```
+
+### PanelMoveConfig
+
+```typescript
+interface PanelMoveConfig {
+  readonly deferLayout: boolean;         // default: true
+  readonly outlineResize: boolean;       // default: false
+  readonly keyboardStep: number;         // default: 1
+  readonly keyboardResizeStep: number;   // default: 1
+}
+```
+
+### DirtyRect
+
+```typescript
+interface DirtyRect {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+```
+
+### MoveResult
+
+```typescript
+interface MoveResult {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly dirtyRects: readonly DirtyRect[];
+  readonly clamped: boolean;
+}
+```
+
+## Functions
+
+### createPanelMoveState
+
+Creates initial panel move state.
+
+```typescript
+function createPanelMoveState(): PanelMoveState
+```
+
+### createPanelMoveConfig
+
+Creates panel move configuration with defaults.
+
+```typescript
+function createPanelMoveConfig(config?: Partial<PanelMoveConfig>): PanelMoveConfig
+```
+
+### createPanelConstraints
+
+Creates panel constraints with defaults.
+
+```typescript
+function createPanelConstraints(constraints?: Partial<PanelConstraints>): PanelConstraints
+```
+
+### beginMove
+
+Begins a panel move operation.
+
+```typescript
+function beginMove(
+  state: PanelMoveState,
+  entity: Entity,
+  mouseX: number,
+  mouseY: number,
+  panelX: number,
+  panelY: number,
+  panelWidth: number,
+  panelHeight: number,
+  config?: Partial<PanelMoveConfig>,
+): PanelMoveState
+```
+
+### beginResize
+
+Begins a panel resize operation on a specific handle.
+
+```typescript
+function beginResize(
+  state: PanelMoveState,
+  entity: Entity,
+  handle: ResizeHandle,
+  mouseX: number,
+  mouseY: number,
+  panelX: number,
+  panelY: number,
+  panelWidth: number,
+  panelHeight: number,
+  config?: Partial<PanelMoveConfig>,
+): PanelMoveState
+```
+
+### updateMove
+
+Updates a panel move with a new cursor position. Returns the new position with constraints applied.
+
+```typescript
+function updateMove(
+  state: PanelMoveState,
+  mouseX: number,
+  mouseY: number,
+  constraints?: Partial<PanelConstraints>,
+): MoveResult
+```
+
+### updateResize
+
+Updates a panel resize with a new cursor position.
+
+```typescript
+function updateResize(
+  state: PanelMoveState,
+  mouseX: number,
+  mouseY: number,
+  constraints?: Partial<PanelConstraints>,
+): MoveResult
+```
+
+### endMoveOrResize
+
+Ends the current move or resize operation.
+
+```typescript
+function endMoveOrResize(state: PanelMoveState): PanelMoveState
+```
+
+### cancelMoveOrResize
+
+Cancels the current operation and returns original position data for restoration.
+
+```typescript
+function cancelMoveOrResize(state: PanelMoveState): {
+  state: PanelMoveState;
+  restoreX: number;
+  restoreY: number;
+  restoreWidth: number;
+  restoreHeight: number;
+}
+```
+
+### keyboardMove
+
+Moves a panel by a keyboard step amount in a given direction.
+
+```typescript
+function keyboardMove(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  direction: 'up' | 'down' | 'left' | 'right',
+  step: number,
+  constraints?: Partial<PanelConstraints>,
+): { x: number; y: number }
+```
+
+### keyboardResize
+
+Resizes a panel by a keyboard step amount.
+
+```typescript
+function keyboardResize(
+  width: number,
+  height: number,
+  direction: 'grow-horizontal' | 'shrink-horizontal' | 'grow-vertical' | 'shrink-vertical',
+  step: number,
+  constraints?: Partial<PanelConstraints>,
+): { width: number; height: number }
+```
+
+### detectResizeHandle
+
+Detects which resize handle a click position corresponds to.
+
+```typescript
+function detectResizeHandle(
+  clickX: number,
+  clickY: number,
+  panelWidth: number,
+  panelHeight: number,
+  borderSize?: number,
+): ResizeHandle | undefined
+```
+
+```typescript
+import { detectResizeHandle, beginResize } from 'blecsd';
+
+const handle = detectResizeHandle(localX, localY, panelWidth, panelHeight);
+if (handle) {
+  state = beginResize(state, entity, handle, mouseX, mouseY, px, py, pw, ph);
+}
+```
+
+### mergeDirtyRects
+
+Merges overlapping dirty rectangles into a single bounding rectangle.
+
+```typescript
+function mergeDirtyRects(rects: readonly DirtyRect[]): DirtyRect | undefined
+```
+
+## Usage Example
+
+Complete drag-to-move and resize workflow:
+
+```typescript
+import {
+  createPanelMoveState,
+  createPanelConstraints,
+  beginMove,
+  beginResize,
+  updateMove,
+  updateResize,
+  endMoveOrResize,
+  cancelMoveOrResize,
+  detectResizeHandle,
+  keyboardMove,
+  mergeDirtyRects,
+  setPosition,
+  setDimensions,
+} from 'blecsd';
+
+let moveState = createPanelMoveState();
+const constraints = createPanelConstraints({
+  screenWidth: 120,
+  screenHeight: 40,
+  minWidth: 10,
+  minHeight: 5,
+  snapGrid: 0,
+});
+
+// On mouse down
+function onMouseDown(eid: Entity, mouseX: number, mouseY: number, localX: number, localY: number) {
+  const handle = detectResizeHandle(localX, localY, 30, 10);
+  if (handle) {
+    moveState = beginResize(moveState, eid, handle, mouseX, mouseY, px, py, 30, 10);
+  } else {
+    moveState = beginMove(moveState, eid, mouseX, mouseY, px, py, 30, 10);
+  }
+}
+
+// On mouse move
+function onMouseMove(mouseX: number, mouseY: number) {
+  if (moveState.isMoving) {
+    const result = updateMove(moveState, mouseX, mouseY, constraints);
+    setPosition(world, moveState.entity!, result.x, result.y);
+    const merged = mergeDirtyRects(result.dirtyRects);
+    // Redraw merged area
+  } else if (moveState.isResizing) {
+    const result = updateResize(moveState, mouseX, mouseY, constraints);
+    setPosition(world, moveState.entity!, result.x, result.y);
+    setDimensions(world, moveState.entity!, result.width, result.height);
+  }
+}
+
+// On mouse up
+function onMouseUp() {
+  moveState = endMoveOrResize(moveState);
+}
+
+// On Escape (cancel)
+function onEscape() {
+  const restored = cancelMoveOrResize(moveState);
+  moveState = restored.state;
+  setPosition(world, entity, restored.restoreX, restored.restoreY);
+  setDimensions(world, entity, restored.restoreWidth, restored.restoreHeight);
+}
+
+// Keyboard movement
+function onArrowKey(direction: 'up' | 'down' | 'left' | 'right') {
+  const pos = keyboardMove(px, py, 30, 10, direction, 1, constraints);
+  setPosition(world, entity, pos.x, pos.y);
+}
+```

--- a/docs/api/systems/particle.md
+++ b/docs/api/systems/particle.md
@@ -1,0 +1,215 @@
+# Particle System API
+
+ECS system for spawning, updating, and removing particles with rate-based and burst-based emitters.
+
+## Overview
+
+The particle system handles:
+- Rate-based continuous particle spawning from emitters
+- Burst particle emission (one-shot effects)
+- Particle aging, gravity, and velocity-based movement
+- Automatic removal of dead particles
+- Configurable maximum particle limits
+- Random angle spread within emitter cone
+
+## Quick Start
+
+```typescript
+import { createParticleSystem } from 'blecsd';
+
+const particleSystem = createParticleSystem({
+  emitters: (world) => myEmitterEntities,
+  particles: (world) => myParticleEntities,
+  maxParticles: 500,
+});
+
+// In your game loop
+particleSystem(world);
+```
+
+## Types
+
+### EntityProvider
+
+Function that provides entity IDs to iterate over.
+
+```typescript
+type EntityProvider = (world: World) => ReadonlyArray<Entity>;
+```
+
+### ParticleSystemConfig
+
+```typescript
+interface ParticleSystemConfig {
+  /** Provides emitter entities each frame */
+  readonly emitters: EntityProvider;
+  /** Provides particle entities each frame */
+  readonly particles: EntityProvider;
+  /** Maximum concurrent particles (default: 1000) */
+  readonly maxParticles?: number;
+}
+```
+
+## Functions
+
+### createParticleSystem
+
+Creates a particle system that processes emitters and particles each frame. The system handles rate-based spawning from active emitters, ages particles, applies gravity, updates positions, and removes dead particles.
+
+```typescript
+function createParticleSystem(config: ParticleSystemConfig): System
+```
+
+**Parameters:**
+- `config` - System configuration with entity providers and particle limits
+
+**Returns:** A `System` function.
+
+```typescript
+import { createParticleSystem } from 'blecsd';
+
+const particleSystem = createParticleSystem({
+  emitters: (world) => activeEmitters,
+  particles: (world) => liveParticles,
+  maxParticles: 1000,
+});
+```
+
+### spawnParticle
+
+Spawns a single particle from an emitter at a random angle within the emitter's spread cone. Sets position to the emitter's position and velocity based on emitter speed and angle.
+
+```typescript
+function spawnParticle(
+  world: World,
+  emitterId: Entity,
+  appearance: EmitterAppearance,
+): Entity
+```
+
+**Parameters:**
+- `world` - The ECS world
+- `emitterId` - The emitter entity ID
+- `appearance` - Visual appearance config (chars, colors, fade)
+
+**Returns:** The spawned particle entity ID, or `-1` if spawn failed.
+
+### burstParticles
+
+Triggers a burst of particles from an emitter (one-shot effect).
+
+```typescript
+function burstParticles(
+  world: World,
+  emitterId: Entity,
+  count?: number,
+  maxParticles?: number,
+  currentCount?: number,
+): Entity[]
+```
+
+**Parameters:**
+- `world` - The ECS world
+- `emitterId` - The emitter entity ID
+- `count` - Number of particles to emit (default: emitter's burstCount)
+- `maxParticles` - Maximum total particles allowed (default: 1000)
+- `currentCount` - Current total particle count (default: 0)
+
+**Returns:** Array of spawned particle entity IDs.
+
+```typescript
+import { burstParticles } from 'blecsd';
+
+// Explosion effect
+const particles = burstParticles(world, explosionEmitter, 50);
+```
+
+### ageParticle
+
+Ages a particle and applies gravity from its emitter.
+
+```typescript
+function ageParticle(world: World, eid: Entity, delta: number): void
+```
+
+### moveParticle
+
+Updates a particle's position based on its velocity.
+
+```typescript
+function moveParticle(world: World, eid: Entity, delta: number): void
+```
+
+### killParticle
+
+Removes a dead particle and cleans up emitter tracking.
+
+```typescript
+function killParticle(world: World, eid: Entity): void
+```
+
+## Usage Example
+
+Complete particle effect setup with emitters:
+
+```typescript
+import {
+  createWorld,
+  addEntity,
+  createScheduler,
+  createParticleSystem,
+  burstParticles,
+  setPosition,
+  setEmitter,
+  LoopPhase,
+} from 'blecsd';
+
+const world = createWorld();
+const scheduler = createScheduler();
+
+// Track entities
+const emitterEntities: Entity[] = [];
+const particleEntities: Entity[] = [];
+
+// Create particle system
+const particleSystem = createParticleSystem({
+  emitters: () => emitterEntities,
+  particles: () => particleEntities,
+  maxParticles: 500,
+});
+
+scheduler.registerSystem(LoopPhase.UPDATE, particleSystem);
+
+// Create a fire emitter
+const fireEmitter = addEntity(world);
+setPosition(world, fireEmitter, 40, 20);
+setEmitter(world, fireEmitter, {
+  rate: 10,           // 10 particles per second
+  lifetime: 2.0,      // Each particle lives 2 seconds
+  speed: 3,           // Particle speed
+  angle: -Math.PI / 2, // Upward
+  spread: 0.5,        // Cone width
+  gravity: -0.5,      // Slight upward drift
+  active: true,
+});
+emitterEntities.push(fireEmitter);
+
+// One-shot explosion
+const explosionEmitter = addEntity(world);
+setPosition(world, explosionEmitter, 60, 12);
+setEmitter(world, explosionEmitter, {
+  rate: 0,
+  lifetime: 1.0,
+  speed: 8,
+  angle: 0,
+  spread: Math.PI * 2, // Full circle
+  gravity: 2,
+  active: true,
+});
+
+// Trigger burst
+burstParticles(world, explosionEmitter, 30);
+
+// Run in game loop
+scheduler.run(world, 1 / 60);
+```

--- a/docs/api/systems/smooth-scroll.md
+++ b/docs/api/systems/smooth-scroll.md
@@ -1,0 +1,324 @@
+# Smooth Scroll System API
+
+Physics-based smooth scrolling system with momentum, friction, and overscroll bounce.
+
+## Overview
+
+The smooth scroll system handles:
+- Velocity-based momentum scrolling
+- Configurable friction for natural deceleration
+- Spring-based overscroll bounce (iOS-style)
+- Smooth animated scroll-to-target
+- Immediate scroll position setting
+- User scroll tracking (drag start/end)
+- Per-entity scroll state management
+
+## Quick Start
+
+```typescript
+import {
+  createSmoothScrollSystem,
+  getScrollState,
+  applyScrollImpulse,
+  LoopPhase,
+} from 'blecsd';
+
+// Initialize scroll state for an entity
+const state = getScrollState(entity, contentWidth, contentHeight, 80, 24);
+
+// Apply scroll impulse (e.g., from mouse wheel)
+applyScrollImpulse(entity, 0, -3);
+
+// Create and register the system
+const scrollSystem = createSmoothScrollSystem({ friction: 0.92 });
+scheduler.registerSystem(LoopPhase.ANIMATION, scrollSystem);
+```
+
+## Types
+
+### ScrollPhysicsConfig
+
+```typescript
+interface ScrollPhysicsConfig {
+  /** Friction coefficient (0-1, lower = more momentum, default: 0.92) */
+  readonly friction: number;
+  /** Minimum velocity before stopping (default: 0.1) */
+  readonly minVelocity: number;
+  /** Maximum velocity (default: 200) */
+  readonly maxVelocity: number;
+  /** Velocity multiplier for input (default: 1) */
+  readonly sensitivity: number;
+  /** Spring stiffness for overscroll bounce (default: 0.3) */
+  readonly springStiffness: number;
+  /** Spring damping for overscroll bounce (default: 0.8) */
+  readonly springDamping: number;
+  /** Maximum overscroll distance (default: 50) */
+  readonly maxOverscroll: number;
+  /** Whether to enable momentum scrolling (default: true) */
+  readonly enableMomentum: boolean;
+  /** Whether to enable overscroll bounce (default: true) */
+  readonly enableBounce: boolean;
+}
+```
+
+### ScrollAnimationState
+
+Scroll animation state for a single entity.
+
+```typescript
+interface ScrollAnimationState {
+  scrollX: number;
+  scrollY: number;
+  velocityX: number;
+  velocityY: number;
+  contentWidth: number;
+  contentHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  isAnimating: boolean;
+  isUserScrolling: boolean;
+  targetX: number | null;
+  targetY: number | null;
+}
+```
+
+### ScrollEvent
+
+```typescript
+interface ScrollEvent {
+  readonly eid: Entity;
+  readonly deltaX: number;
+  readonly deltaY: number;
+  readonly scrollX: number;
+  readonly scrollY: number;
+  readonly isMomentum: boolean;
+}
+```
+
+## Functions
+
+### createSmoothScrollSystem
+
+Creates a smooth scroll system that updates all active scroll animations each frame.
+
+```typescript
+function createSmoothScrollSystem(physics?: Partial<ScrollPhysicsConfig>): System
+```
+
+**Parameters:**
+- `physics` - Optional physics configuration overrides
+
+**Returns:** A `System` function for the ANIMATION phase.
+
+```typescript
+import { createSmoothScrollSystem, LoopPhase } from 'blecsd';
+
+const scrollSystem = createSmoothScrollSystem({
+  friction: 0.92,
+  enableMomentum: true,
+  enableBounce: true,
+});
+
+scheduler.registerSystem(LoopPhase.ANIMATION, scrollSystem);
+```
+
+### getScrollState
+
+Creates or gets scroll animation state for an entity. Updates content/viewport dimensions on subsequent calls.
+
+```typescript
+function getScrollState(
+  eid: Entity,
+  contentWidth: number,
+  contentHeight: number,
+  viewportWidth: number,
+  viewportHeight: number,
+): ScrollAnimationState
+```
+
+### removeScrollState
+
+Removes scroll state for an entity.
+
+```typescript
+function removeScrollState(eid: Entity): void
+```
+
+### applyScrollImpulse
+
+Applies a scroll impulse (e.g., from mouse wheel or keyboard). Adds to the current velocity and starts animation.
+
+```typescript
+function applyScrollImpulse(
+  eid: Entity,
+  deltaX: number,
+  deltaY: number,
+  physics?: Partial<ScrollPhysicsConfig>,
+): void
+```
+
+```typescript
+import { applyScrollImpulse } from 'blecsd';
+
+// Mouse wheel scroll
+applyScrollImpulse(entity, 0, -3);
+
+// Page down
+applyScrollImpulse(entity, 0, 24);
+```
+
+### smoothScrollTo
+
+Smoothly scrolls to a target position with animation.
+
+```typescript
+function smoothScrollTo(
+  eid: Entity,
+  targetX: number | null,
+  targetY: number | null,
+): void
+```
+
+```typescript
+import { smoothScrollTo } from 'blecsd';
+
+// Scroll to top
+smoothScrollTo(entity, null, 0);
+
+// Scroll to specific position
+smoothScrollTo(entity, 0, 500);
+```
+
+### setScrollImmediate
+
+Sets scroll position immediately without animation.
+
+```typescript
+function setScrollImmediate(eid: Entity, x: number, y: number): void
+```
+
+### startUserScroll
+
+Marks the start of user scrolling (e.g., mouse drag). Resets velocity.
+
+```typescript
+function startUserScroll(eid: Entity): void
+```
+
+### endUserScroll
+
+Marks the end of user scrolling, enabling momentum with the given release velocity.
+
+```typescript
+function endUserScroll(eid: Entity, velocityX: number, velocityY: number): void
+```
+
+### updateScrollPhysics
+
+Updates scroll physics for a single entity. Handles scroll-to-target, velocity, friction, and bounce.
+
+```typescript
+function updateScrollPhysics(
+  state: ScrollAnimationState,
+  dt: number,
+  physics?: Partial<ScrollPhysicsConfig>,
+): boolean
+```
+
+**Returns:** `true` if the scroll position changed.
+
+### isScrolling
+
+Checks if an entity has an active scroll animation.
+
+```typescript
+function isScrolling(eid: Entity): boolean
+```
+
+### getScrollPosition
+
+Gets the current scroll position of an entity.
+
+```typescript
+function getScrollPosition(eid: Entity): { x: number; y: number } | null
+```
+
+### clearAllScrollStates
+
+Clears all scroll states. Primarily for testing.
+
+```typescript
+function clearAllScrollStates(): void
+```
+
+## Usage Example
+
+Complete scrollable content area with momentum:
+
+```typescript
+import {
+  createWorld,
+  addEntity,
+  createScheduler,
+  createSmoothScrollSystem,
+  getScrollState,
+  applyScrollImpulse,
+  smoothScrollTo,
+  startUserScroll,
+  endUserScroll,
+  isScrolling,
+  getScrollPosition,
+  LoopPhase,
+} from 'blecsd';
+
+const world = createWorld();
+const scheduler = createScheduler();
+
+// Create scroll system with custom physics
+const scrollSystem = createSmoothScrollSystem({
+  friction: 0.95,
+  enableMomentum: true,
+  enableBounce: true,
+  springStiffness: 0.3,
+  maxOverscroll: 30,
+});
+
+scheduler.registerSystem(LoopPhase.ANIMATION, scrollSystem);
+
+// Create a scrollable text area
+const textArea = addEntity(world);
+const scrollState = getScrollState(textArea, 80, 500, 80, 24);
+
+// Handle mouse wheel
+function onMouseWheel(delta: number) {
+  applyScrollImpulse(textArea, 0, delta * 3);
+}
+
+// Handle drag scrolling
+let lastDragY = 0;
+function onDragStart(y: number) {
+  startUserScroll(textArea);
+  lastDragY = y;
+}
+
+function onDragMove(y: number) {
+  const dy = y - lastDragY;
+  scrollState.scrollY -= dy;
+  lastDragY = y;
+}
+
+function onDragEnd(velocityY: number) {
+  endUserScroll(textArea, 0, velocityY);
+}
+
+// Scroll to top on Home key
+function onHomeKey() {
+  smoothScrollTo(textArea, null, 0);
+}
+
+// In render loop, use scroll position
+const pos = getScrollPosition(textArea);
+if (pos) {
+  // Render content offset by pos.x, pos.y
+}
+```

--- a/docs/api/systems/spatial-hash.md
+++ b/docs/api/systems/spatial-hash.md
@@ -1,0 +1,321 @@
+# Spatial Hash System API
+
+O(1) spatial hash grid for efficient broad-phase collision detection and spatial queries.
+
+## Overview
+
+The spatial hash system handles:
+- Partitioning 2D space into a uniform grid
+- O(1) entity insertion and removal
+- Area-based queries for nearby entities
+- Point queries for entities at a position
+- Automatic grid rebuilding from ECS world state
+- Statistics reporting for grid utilization
+
+## Quick Start
+
+```typescript
+import {
+  createSpatialHash,
+  setSpatialHashGrid,
+  spatialHashSystem,
+  queryArea,
+  getNearbyEntities,
+  LoopPhase,
+} from 'blecsd';
+
+const grid = createSpatialHash({ cellSize: 8 });
+setSpatialHashGrid(grid);
+
+scheduler.registerSystem(LoopPhase.EARLY_UPDATE, spatialHashSystem);
+
+// Query nearby entities
+const nearby = queryArea(grid, playerX, playerY, 2, 2);
+```
+
+## Types
+
+### SpatialHashConfig
+
+```typescript
+interface SpatialHashConfig {
+  /** Width of each cell in world units (default: 8) */
+  readonly cellSize: number;
+  /** Initial number of cells in the grid (default: 256) */
+  readonly initialCapacity: number;
+}
+```
+
+### CellCoord
+
+```typescript
+interface CellCoord {
+  readonly cx: number;
+  readonly cy: number;
+}
+```
+
+### SpatialHashGrid
+
+```typescript
+interface SpatialHashGrid {
+  readonly cellSize: number;
+  readonly cells: Map<number, Set<number>>;
+  readonly entityCells: Map<number, Set<number>>;
+}
+```
+
+### SpatialHashStats
+
+```typescript
+interface SpatialHashStats {
+  readonly cellCount: number;
+  readonly entityCount: number;
+  readonly averageEntitiesPerCell: number;
+  readonly maxEntitiesInCell: number;
+}
+```
+
+## Constants
+
+### DEFAULT_CELL_SIZE
+
+Default cell size for the spatial hash grid: `8`.
+
+```typescript
+import { DEFAULT_CELL_SIZE } from 'blecsd';
+```
+
+## Functions
+
+### createSpatialHash
+
+Creates a new spatial hash grid.
+
+```typescript
+function createSpatialHash(config?: Partial<SpatialHashConfig>): SpatialHashGrid
+```
+
+```typescript
+import { createSpatialHash } from 'blecsd';
+
+const grid = createSpatialHash({ cellSize: 4 });
+```
+
+### worldToCell
+
+Gets the cell coordinate for a world position.
+
+```typescript
+function worldToCell(grid: SpatialHashGrid, x: number, y: number): CellCoord
+```
+
+```typescript
+import { createSpatialHash, worldToCell } from 'blecsd';
+
+const grid = createSpatialHash({ cellSize: 8 });
+const cell = worldToCell(grid, 15, 23);
+// cell = { cx: 1, cy: 2 }
+```
+
+### insertEntity
+
+Inserts an entity into the spatial hash at the given position and size. Automatically removes the entity from its previous position first.
+
+```typescript
+function insertEntity(
+  grid: SpatialHashGrid,
+  eid: Entity,
+  x: number,
+  y: number,
+  width?: number,
+  height?: number,
+): void
+```
+
+### removeEntityFromGrid
+
+Removes an entity from the spatial hash.
+
+```typescript
+function removeEntityFromGrid(grid: SpatialHashGrid, eid: Entity): void
+```
+
+### queryArea
+
+Gets all entities in the cells that overlap the given area. This is the core broad-phase query for collision detection.
+
+```typescript
+function queryArea(
+  grid: SpatialHashGrid,
+  x: number,
+  y: number,
+  width?: number,
+  height?: number,
+): ReadonlySet<number>
+```
+
+```typescript
+import { queryArea } from 'blecsd';
+
+const nearby = queryArea(grid, playerX, playerY, 2, 2);
+for (const eid of nearby) {
+  // Narrow-phase collision check
+}
+```
+
+### getNearbyEntities
+
+Gets potential collision candidates for an entity. Returns all entities in the same cells, excluding the entity itself.
+
+```typescript
+function getNearbyEntities(grid: SpatialHashGrid, eid: Entity): ReadonlySet<number>
+```
+
+```typescript
+import { getNearbyEntities } from 'blecsd';
+
+const candidates = getNearbyEntities(grid, player);
+for (const other of candidates) {
+  // Check if actual collision
+}
+```
+
+### getEntitiesInCell
+
+Gets all entities at a specific cell coordinate.
+
+```typescript
+function getEntitiesInCell(grid: SpatialHashGrid, cx: number, cy: number): ReadonlySet<number>
+```
+
+### getEntitiesAtPoint
+
+Gets all entities at a world position.
+
+```typescript
+function getEntitiesAtPoint(grid: SpatialHashGrid, x: number, y: number): ReadonlySet<number>
+```
+
+### clearSpatialHash
+
+Clears all entities from the spatial hash grid.
+
+```typescript
+function clearSpatialHash(grid: SpatialHashGrid): void
+```
+
+### getSpatialHashStats
+
+Gets statistics about the spatial hash grid.
+
+```typescript
+function getSpatialHashStats(grid: SpatialHashGrid): SpatialHashStats
+```
+
+```typescript
+import { getSpatialHashStats } from 'blecsd';
+
+const stats = getSpatialHashStats(grid);
+console.log(`Cells: ${stats.cellCount}, Entities: ${stats.entityCount}`);
+console.log(`Max entities per cell: ${stats.maxEntitiesInCell}`);
+```
+
+### rebuildSpatialHash
+
+Rebuilds the spatial hash from all entities with Position and Collider components.
+
+```typescript
+function rebuildSpatialHash(grid: SpatialHashGrid, world: World): void
+```
+
+### setSpatialHashGrid
+
+Sets the spatial hash grid for the built-in system to use.
+
+```typescript
+function setSpatialHashGrid(grid: SpatialHashGrid): void
+```
+
+### getSpatialHashGrid
+
+Gets the current system spatial hash grid.
+
+```typescript
+function getSpatialHashGrid(): SpatialHashGrid | null
+```
+
+### spatialHashSystem
+
+The built-in system that rebuilds the grid each frame. Register in the EARLY_UPDATE phase.
+
+```typescript
+const spatialHashSystem: System
+```
+
+### createSpatialHashSystem
+
+Factory function that returns the spatialHashSystem.
+
+```typescript
+function createSpatialHashSystem(): System
+```
+
+## Usage Example
+
+Complete collision detection setup:
+
+```typescript
+import {
+  createWorld,
+  addEntity,
+  createScheduler,
+  createSpatialHash,
+  setSpatialHashGrid,
+  spatialHashSystem,
+  insertEntity,
+  queryArea,
+  getNearbyEntities,
+  getSpatialHashStats,
+  setPosition,
+  setCollider,
+  LoopPhase,
+} from 'blecsd';
+
+const world = createWorld();
+const scheduler = createScheduler();
+
+// Create spatial hash with small cells for precise collision
+const grid = createSpatialHash({ cellSize: 4 });
+setSpatialHashGrid(grid);
+
+// Register rebuild system in EARLY_UPDATE
+scheduler.registerSystem(LoopPhase.EARLY_UPDATE, spatialHashSystem);
+
+// Create entities with position and collider
+const player = addEntity(world);
+setPosition(world, player, 10, 5);
+setCollider(world, player, { width: 2, height: 2 });
+
+const enemy = addEntity(world);
+setPosition(world, enemy, 12, 5);
+setCollider(world, enemy, { width: 2, height: 2 });
+
+// After system runs, query for collisions
+scheduler.run(world, 1 / 60);
+
+const candidates = getNearbyEntities(grid, player);
+for (const other of candidates) {
+  // Narrow-phase AABB check
+  console.log(`Potential collision with entity ${other}`);
+}
+
+// Check for entities under mouse cursor
+const entitiesAtMouse = queryArea(grid, mouseX, mouseY, 1, 1);
+
+// Monitor grid efficiency
+const stats = getSpatialHashStats(grid);
+if (stats.maxEntitiesInCell > 50) {
+  console.warn('Consider using a smaller cell size');
+}
+```

--- a/docs/api/systems/state-machine.md
+++ b/docs/api/systems/state-machine.md
@@ -1,0 +1,218 @@
+# State Machine System API
+
+ECS system for tracking state age on entities with finite state machines.
+
+## Overview
+
+The state machine system handles:
+- Incrementing `stateAge` for all entities with a StateMachine component each frame
+- Enabling time-based state transitions and animations
+- Providing direct access to state age for game logic queries
+
+## Quick Start
+
+```typescript
+import {
+  createScheduler,
+  registerStateMachineSystem,
+  LoopPhase,
+} from 'blecsd';
+
+const scheduler = createScheduler();
+registerStateMachineSystem(scheduler);
+
+// In game loop
+scheduler.run(world, deltaTime);
+```
+
+## Functions
+
+### stateMachineSystem
+
+The state machine system function. Reads delta time from the scheduler and updates `stateAge` for all entities with a StateMachine component.
+
+```typescript
+const stateMachineSystem: System
+```
+
+```typescript
+import { stateMachineSystem, LoopPhase } from 'blecsd';
+
+scheduler.registerSystem(LoopPhase.UPDATE, stateMachineSystem);
+```
+
+### createStateMachineSystem
+
+Factory function that returns the stateMachineSystem.
+
+```typescript
+function createStateMachineSystem(): System
+```
+
+```typescript
+import { createStateMachineSystem, createScheduler, LoopPhase } from 'blecsd';
+
+const scheduler = createScheduler();
+const system = createStateMachineSystem();
+scheduler.registerSystem(LoopPhase.UPDATE, system);
+```
+
+### registerStateMachineSystem
+
+Convenience function that registers the state machine system in the UPDATE phase.
+
+```typescript
+function registerStateMachineSystem(scheduler: Scheduler, priority?: number): void
+```
+
+**Parameters:**
+- `scheduler` - The scheduler to register with
+- `priority` - Optional priority within the UPDATE phase (default: 0)
+
+```typescript
+import { createScheduler, registerStateMachineSystem } from 'blecsd';
+
+const scheduler = createScheduler();
+registerStateMachineSystem(scheduler);
+```
+
+### queryStateMachine
+
+Query all entities with the StateMachine component.
+
+```typescript
+function queryStateMachine(world: World): number[]
+```
+
+### hasStateMachineSystem
+
+Checks if an entity has the StateMachine component via the system store.
+
+```typescript
+function hasStateMachineSystem(world: World, eid: number): boolean
+```
+
+### getSystemStateAge
+
+Gets the state age for an entity from the system store.
+
+```typescript
+function getSystemStateAge(eid: number): number
+```
+
+**Returns:** Time in seconds the entity has been in its current state.
+
+```typescript
+import { getSystemStateAge } from 'blecsd';
+
+const age = getSystemStateAge(entityId);
+if (age > 5.0) {
+  // Entity has been in this state for over 5 seconds
+}
+```
+
+### resetStateAge
+
+Resets the state age for an entity to zero. Typically called when a state transition occurs.
+
+```typescript
+function resetStateAge(eid: number): void
+```
+
+```typescript
+import { resetStateAge } from 'blecsd';
+
+// After a manual state transition
+resetStateAge(entityId);
+```
+
+### updateStateAges
+
+Manually update state age for specific entities. Useful for testing or custom update loops.
+
+```typescript
+function updateStateAges(entities: readonly number[], deltaTime: number): void
+```
+
+```typescript
+import { updateStateAges, queryStateMachine } from 'blecsd';
+
+const entities = queryStateMachine(world);
+updateStateAges(entities, 0.016); // ~60fps frame
+```
+
+### getStateAgeStore
+
+Gets the raw state age typed array for direct access. Primarily for testing.
+
+```typescript
+function getStateAgeStore(): Float32Array
+```
+
+## Usage Example
+
+Complete state machine setup with time-based transitions:
+
+```typescript
+import {
+  createWorld,
+  addEntity,
+  createScheduler,
+  registerStateMachineSystem,
+  getSystemStateAge,
+  resetStateAge,
+  queryStateMachine,
+  defineStateMachine,
+  setStateMachine,
+  sendEvent,
+  getCurrentStateName,
+  LoopPhase,
+} from 'blecsd';
+
+const world = createWorld();
+const scheduler = createScheduler();
+
+// Register state machine system in UPDATE phase
+registerStateMachineSystem(scheduler);
+
+// Define a state machine
+const enemyFSM = defineStateMachine({
+  initialState: 'idle',
+  states: ['idle', 'patrol', 'chase', 'attack'],
+  transitions: [
+    { from: 'idle', to: 'patrol', event: 'startPatrol' },
+    { from: 'patrol', to: 'chase', event: 'spotPlayer' },
+    { from: 'chase', to: 'attack', event: 'inRange' },
+    { from: 'attack', to: 'chase', event: 'outOfRange' },
+    { from: 'chase', to: 'patrol', event: 'lostPlayer' },
+  ],
+});
+
+// Create an enemy entity
+const enemy = addEntity(world);
+setStateMachine(world, enemy, enemyFSM);
+
+// Run game loop
+let lastTime = Date.now();
+setInterval(() => {
+  const now = Date.now();
+  const dt = (now - lastTime) / 1000;
+  lastTime = now;
+
+  scheduler.run(world, dt);
+
+  // Check state age for time-based transitions
+  const age = getSystemStateAge(enemy);
+  const currentState = getCurrentStateName(world, enemy);
+
+  if (currentState === 'idle' && age > 3.0) {
+    sendEvent(world, enemy, 'startPatrol');
+    resetStateAge(enemy);
+  }
+
+  if (currentState === 'attack' && age > 1.0) {
+    // Attack cooldown expired
+    sendEvent(world, enemy, 'outOfRange');
+  }
+}, 16);
+```

--- a/docs/api/systems/tilemap-renderer.md
+++ b/docs/api/systems/tilemap-renderer.md
@@ -1,0 +1,265 @@
+# Tilemap Renderer System API
+
+ECS system for rendering tile maps to a 2D character buffer with camera support and layer compositing.
+
+## Overview
+
+The tilemap renderer handles:
+- Rendering tile map entities to a character buffer
+- Camera offset for scrolling/panning
+- Multi-layer compositing (bottom-to-top)
+- Visible tile range calculation for efficient rendering
+- Configurable viewport dimensions
+- Per-tile character, foreground, and background colors
+
+## Quick Start
+
+```typescript
+import {
+  setTileMapRendererConfig,
+  tilemapRenderSystem,
+  getTileMapRenderBuffer,
+  LoopPhase,
+} from 'blecsd';
+
+setTileMapRendererConfig({
+  viewportWidth: 80,
+  viewportHeight: 24,
+  camera: { x: 0, y: 0 },
+});
+
+scheduler.registerSystem(LoopPhase.RENDER, tilemapRenderSystem);
+
+// After system runs, read the buffer
+const buffer = getTileMapRenderBuffer();
+```
+
+## Types
+
+### TileMapBuffer
+
+A rendered tile map buffer storing the composited output.
+
+```typescript
+interface TileMapBuffer {
+  readonly width: number;
+  readonly height: number;
+  readonly cells: RenderedTileCell[][];  // row-major: [y][x]
+}
+```
+
+### TileMapCamera
+
+```typescript
+interface TileMapCamera {
+  x: number;  // Camera X offset in world units
+  y: number;  // Camera Y offset in world units
+}
+```
+
+### TileMapRendererConfig
+
+```typescript
+interface TileMapRendererConfig {
+  viewportWidth: number;
+  viewportHeight: number;
+  camera: TileMapCamera;
+}
+```
+
+## Functions
+
+### setTileMapRendererConfig
+
+Sets the tile map renderer configuration. Must be called before the system runs.
+
+```typescript
+function setTileMapRendererConfig(config: TileMapRendererConfig): void
+```
+
+```typescript
+import { setTileMapRendererConfig } from 'blecsd';
+
+setTileMapRendererConfig({
+  viewportWidth: 80,
+  viewportHeight: 24,
+  camera: { x: 0, y: 0 },
+});
+```
+
+### getTileMapRendererConfig
+
+Gets the current renderer configuration.
+
+```typescript
+function getTileMapRendererConfig(): TileMapRendererConfig | null
+```
+
+### getTileMapRenderBuffer
+
+Gets the current render buffer after the system has run.
+
+```typescript
+function getTileMapRenderBuffer(): TileMapBuffer | null
+```
+
+```typescript
+import { getTileMapRenderBuffer } from 'blecsd';
+
+const buffer = getTileMapRenderBuffer();
+if (buffer) {
+  for (let y = 0; y < buffer.height; y++) {
+    for (let x = 0; x < buffer.width; x++) {
+      const cell = buffer.cells[y][x];
+      // Use cell.char, cell.fg, cell.bg for rendering
+    }
+  }
+}
+```
+
+### clearTileMapRenderBuffer
+
+Clears the render buffer.
+
+```typescript
+function clearTileMapRenderBuffer(): void
+```
+
+### resetTileMapRenderer
+
+Resets the tile map renderer state (config and buffer). Useful for testing.
+
+```typescript
+function resetTileMapRenderer(): void
+```
+
+### createEmptyBuffer
+
+Creates an empty tile map buffer filled with space characters.
+
+```typescript
+function createEmptyBuffer(width: number, height: number): TileMapBuffer
+```
+
+### renderTileMapToBuffer
+
+Renders a single tile map entity into a buffer with camera offset.
+
+```typescript
+function renderTileMapToBuffer(
+  buffer: TileMapBuffer,
+  eid: Entity,
+  cameraX: number,
+  cameraY: number,
+): void
+```
+
+```typescript
+import { createEmptyBuffer, renderTileMapToBuffer } from 'blecsd';
+
+const buffer = createEmptyBuffer(80, 24);
+renderTileMapToBuffer(buffer, mapEntity, cameraX, cameraY);
+```
+
+### renderAllTileMaps
+
+Renders all tile map entities in the world to the render buffer using the configured viewport and camera.
+
+```typescript
+function renderAllTileMaps(world: World): TileMapBuffer | null
+```
+
+### tilemapRenderSystem
+
+The built-in system that renders all tile maps each frame. Register in the RENDER phase.
+
+```typescript
+const tilemapRenderSystem: System
+```
+
+### createTilemapRenderSystem
+
+Factory function that returns the tilemapRenderSystem.
+
+```typescript
+function createTilemapRenderSystem(): System
+```
+
+## Usage Example
+
+Complete tilemap rendering with camera scrolling:
+
+```typescript
+import {
+  createWorld,
+  addEntity,
+  createScheduler,
+  setTileMapRendererConfig,
+  tilemapRenderSystem,
+  getTileMapRenderBuffer,
+  setPosition,
+  setTileMap,
+  createTileset,
+  createTileMapData,
+  LoopPhase,
+} from 'blecsd';
+
+const world = createWorld();
+const scheduler = createScheduler();
+
+// Configure renderer
+const camera = { x: 0, y: 0 };
+setTileMapRendererConfig({
+  viewportWidth: 80,
+  viewportHeight: 24,
+  camera,
+});
+
+// Register in RENDER phase
+scheduler.registerSystem(LoopPhase.RENDER, tilemapRenderSystem);
+
+// Create a tileset
+const tilesetId = createTileset([
+  { char: '.', fg: 0x666666, bg: 0x000000 },  // Floor
+  { char: '#', fg: 0xaaaaaa, bg: 0x333333 },  // Wall
+  { char: '~', fg: 0x3333ff, bg: 0x000066 },  // Water
+]);
+
+// Create tile map data
+const mapData = createTileMapData(20, 15, [
+  { name: 'ground', tiles: groundTiles, visible: true },
+  { name: 'objects', tiles: objectTiles, visible: true },
+]);
+
+// Create tile map entity
+const mapEntity = addEntity(world);
+setPosition(world, mapEntity, 0, 0);
+setTileMap(world, mapEntity, {
+  width: 20,
+  height: 15,
+  tileWidth: 1,
+  tileHeight: 1,
+  dataId: mapData,
+  tilesetId: tilesetId,
+});
+
+// Camera follows player
+function updateCamera(playerX: number, playerY: number) {
+  camera.x = playerX - 40;
+  camera.y = playerY - 12;
+}
+
+// After system runs, use the buffer for terminal output
+scheduler.run(world, 1 / 60);
+
+const buffer = getTileMapRenderBuffer();
+if (buffer) {
+  for (let y = 0; y < buffer.height; y++) {
+    let line = '';
+    for (let x = 0; x < buffer.width; x++) {
+      line += buffer.cells[y][x].char;
+    }
+    // Write line to terminal at row y
+  }
+}
+```

--- a/docs/api/systems/visibility-culling.md
+++ b/docs/api/systems/visibility-culling.md
@@ -1,0 +1,271 @@
+# Visibility Culling System API
+
+Efficient entity visibility determination using spatial indexing with incremental update support.
+
+## Overview
+
+The visibility culling system handles:
+- Determining which entities overlap the current viewport
+- Incremental spatial hash updates (only re-indexes moved entities)
+- Position caching for change detection
+- Viewport-based area queries via spatial hash
+- Culling statistics (visible count, culled count)
+
+## Quick Start
+
+```typescript
+import {
+  createSpatialHash,
+  createPositionCache,
+  createIncrementalSpatialSystem,
+  createVisibilityCullingSystem,
+  queryVisibleEntities,
+  LoopPhase,
+} from 'blecsd';
+
+const grid = createSpatialHash({ cellSize: 8 });
+const cache = createPositionCache();
+
+// Incremental update (only re-indexes moved entities)
+const spatialSystem = createIncrementalSpatialSystem(grid, cache);
+scheduler.registerSystem(LoopPhase.EARLY_UPDATE, spatialSystem);
+
+// Query visible entities
+const visible = queryVisibleEntities(grid, {
+  x: 0, y: 0, width: 80, height: 24,
+});
+```
+
+## Types
+
+### Viewport
+
+```typescript
+interface Viewport {
+  readonly x: number;      // Left edge
+  readonly y: number;      // Top edge
+  readonly width: number;
+  readonly height: number;
+}
+```
+
+### CullingResult
+
+```typescript
+interface CullingResult {
+  readonly visible: readonly Entity[];
+  readonly total: number;
+  readonly culled: number;
+}
+```
+
+### PositionCache
+
+Entity position cache for incremental updates. Tracks previous position and dimensions per entity.
+
+```typescript
+interface PositionCache {
+  readonly prevX: Map<number, number>;
+  readonly prevY: Map<number, number>;
+  readonly prevW: Map<number, number>;
+  readonly prevH: Map<number, number>;
+}
+```
+
+## Functions
+
+### createPositionCache
+
+Creates a position cache for tracking entity movement.
+
+```typescript
+function createPositionCache(): PositionCache
+```
+
+### updateEntityIfMoved
+
+Updates a single entity in the spatial hash only if it has moved. Returns `true` if the entity was updated.
+
+```typescript
+function updateEntityIfMoved(
+  grid: SpatialHashGrid,
+  cache: PositionCache,
+  eid: Entity,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): boolean
+```
+
+### removeFromCache
+
+Removes an entity from the position cache.
+
+```typescript
+function removeFromCache(cache: PositionCache, eid: Entity): void
+```
+
+### clearPositionCache
+
+Clears the entire position cache.
+
+```typescript
+function clearPositionCache(cache: PositionCache): void
+```
+
+### queryVisibleEntities
+
+Queries which entities are visible within the given viewport using the spatial hash.
+
+```typescript
+function queryVisibleEntities(
+  grid: SpatialHashGrid,
+  viewport: Viewport,
+): ReadonlySet<number>
+```
+
+```typescript
+import { queryVisibleEntities } from 'blecsd';
+
+const visible = queryVisibleEntities(grid, {
+  x: cameraX, y: cameraY,
+  width: terminalCols, height: terminalRows,
+});
+```
+
+### performCulling
+
+Performs full visibility culling and returns categorized results with statistics.
+
+```typescript
+function performCulling(
+  grid: SpatialHashGrid,
+  viewport: Viewport,
+  totalEntities: number,
+): CullingResult
+```
+
+```typescript
+import { performCulling } from 'blecsd';
+
+const result = performCulling(grid, viewport, 10000);
+console.log(`Visible: ${result.visible.length}, Culled: ${result.culled}`);
+```
+
+### createIncrementalSpatialSystem
+
+Creates an incremental spatial hash update system. Instead of rebuilding the entire grid each frame, it only updates entities that have moved. Much faster for scenes where most entities are static.
+
+```typescript
+function createIncrementalSpatialSystem(
+  grid: SpatialHashGrid,
+  cache: PositionCache,
+): System
+```
+
+**Parameters:**
+- `grid` - Spatial hash grid to update
+- `cache` - Position cache for change detection
+
+**Returns:** A `System` function.
+
+```typescript
+import {
+  createSpatialHash,
+  createPositionCache,
+  createIncrementalSpatialSystem,
+  LoopPhase,
+} from 'blecsd';
+
+const grid = createSpatialHash({ cellSize: 4 });
+const cache = createPositionCache();
+const system = createIncrementalSpatialSystem(grid, cache);
+
+scheduler.registerSystem(LoopPhase.EARLY_UPDATE, system);
+```
+
+### createVisibilityCullingSystem
+
+Creates a visibility culling system that queries the spatial hash each frame with the current viewport.
+
+```typescript
+function createVisibilityCullingSystem(
+  grid: SpatialHashGrid,
+  getViewport: () => Viewport,
+): System
+```
+
+```typescript
+import { createVisibilityCullingSystem } from 'blecsd';
+
+const cullSystem = createVisibilityCullingSystem(grid, () => ({
+  x: scrollX,
+  y: scrollY,
+  width: terminalCols,
+  height: terminalRows,
+}));
+```
+
+## Usage Example
+
+Complete visibility culling pipeline with incremental updates:
+
+```typescript
+import {
+  createWorld,
+  addEntity,
+  createScheduler,
+  createSpatialHash,
+  createPositionCache,
+  createIncrementalSpatialSystem,
+  createVisibilityCullingSystem,
+  performCulling,
+  queryVisibleEntities,
+  setPosition,
+  setDimensions,
+  LoopPhase,
+} from 'blecsd';
+
+const world = createWorld();
+const scheduler = createScheduler();
+
+// Set up spatial indexing
+const grid = createSpatialHash({ cellSize: 8 });
+const cache = createPositionCache();
+
+// Incremental update: only re-indexes moved entities
+const spatialSystem = createIncrementalSpatialSystem(grid, cache);
+scheduler.registerSystem(LoopPhase.EARLY_UPDATE, spatialSystem);
+
+// Create many entities
+for (let i = 0; i < 10000; i++) {
+  const eid = addEntity(world);
+  setPosition(world, eid, Math.random() * 1000, Math.random() * 1000);
+  setDimensions(world, eid, 1, 1);
+}
+
+// Camera viewport
+let cameraX = 0;
+let cameraY = 0;
+const viewportWidth = 80;
+const viewportHeight = 24;
+
+// In render loop: only render visible entities
+scheduler.run(world, 1 / 60);
+
+const result = performCulling(grid, {
+  x: cameraX,
+  y: cameraY,
+  width: viewportWidth,
+  height: viewportHeight,
+}, 10000);
+
+console.log(`Rendering ${result.visible.length} of ${result.total} entities`);
+console.log(`Culled: ${result.culled}`);
+
+// Render only visible entities
+for (const eid of result.visible) {
+  // renderEntity(world, eid, cameraX, cameraY);
+}
+```

--- a/docs/api/systems/worker-pool.md
+++ b/docs/api/systems/worker-pool.md
@@ -1,0 +1,314 @@
+# Worker Pool System API
+
+Concurrent task processing with a priority queue, synchronous fallback handlers, and graceful degradation.
+
+## Overview
+
+The worker pool handles:
+- Priority-based task queuing (high, normal, low)
+- Synchronous fallback execution on the main thread
+- Task timeouts with configurable limits
+- Task cancellation (by ID or by type)
+- Pool statistics and monitoring
+- Graceful degradation when worker threads are unavailable
+
+## Quick Start
+
+```typescript
+import {
+  createWorkerPool,
+  registerTaskHandler,
+  submitTask,
+} from 'blecsd';
+
+createWorkerPool({ maxWorkers: 4 });
+
+registerTaskHandler('highlight', (input: { code: string }) => {
+  return highlightSyntax(input.code);
+});
+
+const result = await submitTask('highlight', { code: 'const x = 1;' });
+if (!result.error) {
+  console.log(result.output);
+}
+```
+
+## Types
+
+### WorkerPoolConfig
+
+```typescript
+interface WorkerPoolConfig {
+  /** Maximum number of worker threads (default: cpuCount - 1 or 2) */
+  readonly maxWorkers: number;
+  /** Task timeout in milliseconds (default: 5000) */
+  readonly taskTimeout: number;
+  /** Whether to enable the pool (false = run everything synchronously) */
+  readonly enabled: boolean;
+}
+```
+
+### TaskPriority
+
+```typescript
+type TaskPriority = 'high' | 'normal' | 'low';
+```
+
+### PoolTask
+
+```typescript
+interface PoolTask<TInput = unknown> {
+  readonly id: string;
+  readonly type: string;
+  readonly input: TInput;
+  readonly priority: TaskPriority;
+  readonly queuedAt: number;
+}
+```
+
+### TaskResult
+
+```typescript
+interface TaskResult<TOutput = unknown> {
+  readonly id: string;
+  readonly type: string;
+  readonly output: TOutput | undefined;
+  readonly cancelled: boolean;
+  readonly error: string | undefined;
+  readonly durationMs: number;
+}
+```
+
+### PoolStats
+
+```typescript
+interface PoolStats {
+  readonly activeWorkers: number;
+  readonly idleWorkers: number;
+  readonly queuedTasks: number;
+  readonly runningTasks: number;
+  readonly completedTasks: number;
+  readonly cancelledTasks: number;
+  readonly failedTasks: number;
+  readonly avgDurationMs: number;
+  readonly enabled: boolean;
+}
+```
+
+### SyncHandler
+
+```typescript
+type SyncHandler<TInput = unknown, TOutput = unknown> = (input: TInput) => TOutput;
+```
+
+### WorkerPoolState
+
+```typescript
+interface WorkerPoolState {
+  readonly config: WorkerPoolConfig;
+  readonly stats: PoolStats;
+}
+```
+
+## Functions
+
+### createWorkerPool
+
+Creates and initializes the worker pool. Uses synchronous fallback handlers on the main thread with a priority queue.
+
+```typescript
+function createWorkerPool(config?: Partial<WorkerPoolConfig>): WorkerPoolState
+```
+
+```typescript
+import { createWorkerPool } from 'blecsd';
+
+createWorkerPool({
+  maxWorkers: 4,
+  taskTimeout: 5000,
+  enabled: true,
+});
+```
+
+### registerTaskHandler
+
+Registers a synchronous handler for a task type.
+
+```typescript
+function registerTaskHandler<TInput = unknown, TOutput = unknown>(
+  type: string,
+  handler: SyncHandler<TInput, TOutput>,
+): void
+```
+
+```typescript
+import { registerTaskHandler } from 'blecsd';
+
+registerTaskHandler('search', (input: { query: string; text: string }) => {
+  return input.text.indexOf(input.query);
+});
+
+registerTaskHandler('diff', (input: { a: string; b: string }) => {
+  return computeDiff(input.a, input.b);
+});
+```
+
+### submitTask
+
+Submits a task to the worker pool. Returns a promise that resolves when the task completes.
+
+```typescript
+function submitTask<TInput = unknown, TOutput = unknown>(
+  type: string,
+  input: TInput,
+  priority?: TaskPriority,
+): Promise<TaskResult<TOutput>>
+```
+
+**Parameters:**
+- `type` - Task type (must have a registered handler)
+- `input` - Input data for the task
+- `priority` - Task priority (default: `'normal'`)
+
+**Returns:** Promise resolving to `TaskResult`.
+
+```typescript
+import { submitTask } from 'blecsd';
+
+// Normal priority
+const result = await submitTask('highlight', { code: sourceCode, lang: 'ts' });
+
+// High priority (processed before normal/low)
+const urgent = await submitTask('search', { query, text }, 'high');
+
+// Check result
+if (result.cancelled) {
+  console.log('Task was cancelled');
+} else if (result.error) {
+  console.error(`Task failed: ${result.error}`);
+} else {
+  console.log(`Completed in ${result.durationMs}ms`, result.output);
+}
+```
+
+### cancelTask
+
+Cancels a pending task by ID.
+
+```typescript
+function cancelTask(taskId: string): boolean
+```
+
+**Returns:** Whether the task was found and cancelled.
+
+### cancelAllOfType
+
+Cancels all pending tasks of a given type.
+
+```typescript
+function cancelAllOfType(type: string): number
+```
+
+**Returns:** Number of tasks cancelled.
+
+```typescript
+import { cancelAllOfType } from 'blecsd';
+
+// Cancel all pending search tasks when query changes
+const cancelled = cancelAllOfType('search');
+console.log(`Cancelled ${cancelled} search tasks`);
+```
+
+### getWorkerPoolState
+
+Gets the current worker pool state and statistics.
+
+```typescript
+function getWorkerPoolState(): WorkerPoolState
+```
+
+```typescript
+import { getWorkerPoolState } from 'blecsd';
+
+const { stats } = getWorkerPoolState();
+console.log(`Active: ${stats.activeWorkers}, Queued: ${stats.queuedTasks}`);
+console.log(`Completed: ${stats.completedTasks}, Failed: ${stats.failedTasks}`);
+console.log(`Avg duration: ${stats.avgDurationMs.toFixed(1)}ms`);
+```
+
+### destroyWorkerPool
+
+Destroys the worker pool and cancels all pending tasks.
+
+```typescript
+function destroyWorkerPool(): void
+```
+
+## Usage Example
+
+Complete worker pool setup for text processing tasks:
+
+```typescript
+import {
+  createWorkerPool,
+  registerTaskHandler,
+  submitTask,
+  cancelAllOfType,
+  getWorkerPoolState,
+  destroyWorkerPool,
+} from 'blecsd';
+
+// Initialize pool
+createWorkerPool({
+  maxWorkers: 4,
+  taskTimeout: 3000,
+});
+
+// Register handlers for different task types
+registerTaskHandler('highlight', (input: { code: string; lang: string }) => {
+  // Syntax highlighting logic
+  return applyHighlighting(input.code, input.lang);
+});
+
+registerTaskHandler('search', (input: { query: string; lines: string[] }) => {
+  // Search through lines
+  return input.lines
+    .map((line, i) => ({ line: i, text: line }))
+    .filter((entry) => entry.text.includes(input.query));
+});
+
+registerTaskHandler('diff', (input: { before: string; after: string }) => {
+  return computeLineDiff(input.before, input.after);
+});
+
+// Submit tasks with priorities
+async function onFileOpen(code: string, lang: string) {
+  const result = await submitTask('highlight', { code, lang }, 'high');
+  if (!result.error && !result.cancelled) {
+    applyHighlightedOutput(result.output);
+  }
+}
+
+async function onSearch(query: string, lines: string[]) {
+  // Cancel previous search tasks
+  cancelAllOfType('search');
+
+  const result = await submitTask('search', { query, lines }, 'normal');
+  if (!result.cancelled && !result.error) {
+    displaySearchResults(result.output);
+  }
+}
+
+// Monitor pool health
+setInterval(() => {
+  const { stats } = getWorkerPoolState();
+  if (stats.queuedTasks > 10) {
+    console.warn(`Task queue backing up: ${stats.queuedTasks} pending`);
+  }
+}, 1000);
+
+// Cleanup on exit
+process.on('exit', () => {
+  destroyWorkerPool();
+});
+```

--- a/docs/api/terminal/bracketed-paste.md
+++ b/docs/api/terminal/bracketed-paste.md
@@ -1,0 +1,266 @@
+# Bracketed Paste
+
+Distinguishes pasted text from typed input by detecting ESC[200~ / ESC[201~ markers that terminals send when bracketed paste mode is enabled. Provides paste event parsing, sanitization, and a stateful paste buffer for multi-chunk paste operations.
+
+## Quick Start
+
+```typescript
+import {
+  createPasteState,
+  processPasteBuffer,
+  enableBracketedPaste,
+  disableBracketedPaste,
+  sanitizePastedText,
+  extractPasteContent,
+  isPasteStart,
+} from 'blecsd';
+
+// Enable bracketed paste mode in the terminal
+process.stdout.write(enableBracketedPaste());
+
+// Create paste state machine
+let state = createPasteState({ sanitize: true, maxLength: 1024 });
+
+// Process incoming data through the paste state machine
+const result = processPasteBuffer(state, inputBuffer);
+state = result.state;
+
+if (result.event) {
+  console.log('Pasted:', result.event.text);
+}
+
+// Disable when done
+process.stdout.write(disableBracketedPaste());
+```
+
+## Types
+
+### PasteEvent
+
+A paste event detected from bracketed paste mode markers.
+
+```typescript
+interface PasteEvent {
+  readonly type: 'paste';
+  readonly text: string;
+  readonly timestamp: number;
+  readonly sanitized: boolean;
+  readonly originalLength: number;
+}
+```
+
+### PasteConfig
+
+Configuration for paste handling.
+
+```typescript
+interface PasteConfig {
+  readonly sanitize: boolean;   // Strip escape sequences (default: true)
+  readonly maxLength: number;   // Max paste length in bytes (default: 1MB, 0 = unlimited)
+  readonly enabled: boolean;    // Whether bracketed paste mode is enabled (default: true)
+}
+```
+
+### PasteParseResult
+
+Result of parsing a buffer for paste sequences.
+
+```typescript
+interface PasteParseResult {
+  readonly pasteStarted: boolean;
+  readonly pasteEnded: boolean;
+  readonly text: string | null;
+  readonly consumed: number;
+}
+```
+
+### PasteState
+
+State for tracking an ongoing paste operation.
+
+```typescript
+interface PasteState {
+  readonly isPasting: boolean;
+  readonly buffer: string;
+  readonly config: PasteConfig;
+}
+```
+
+### PasteProcessResult
+
+Result of processing a buffer chunk through the paste state machine.
+
+```typescript
+interface PasteProcessResult {
+  readonly state: PasteState;
+  readonly event: PasteEvent | null;
+  readonly consumed: number;
+  readonly remaining: Uint8Array;
+}
+```
+
+### PasteHandler
+
+```typescript
+type PasteHandler = (event: PasteEvent) => void;
+```
+
+## Functions
+
+### sanitizePastedText
+
+Strips ANSI escape sequences from pasted text, preventing escape sequence injection.
+
+```typescript
+function sanitizePastedText(text: string): string
+```
+
+```typescript
+import { sanitizePastedText } from 'blecsd';
+
+const clean = sanitizePastedText('Hello\x1b[31mRed\x1b[0m World');
+// 'HelloRed World'
+```
+
+### truncatePaste
+
+Truncates text to the maximum allowed paste length.
+
+```typescript
+function truncatePaste(text: string, maxLength: number): string
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | `string` | Text to truncate |
+| `maxLength` | `number` | Maximum length (0 = no limit) |
+
+### isPasteStart
+
+Checks if a buffer starts with the paste start marker (ESC[200~).
+
+```typescript
+function isPasteStart(buffer: Uint8Array): boolean
+```
+
+```typescript
+import { isPasteStart } from 'blecsd';
+
+const buf = Buffer.from('\x1b[200~Hello\x1b[201~');
+console.log(isPasteStart(buf)); // true
+```
+
+### mightBePasteStart
+
+Checks if a buffer might be the beginning of a paste start marker. Used for incomplete sequence detection.
+
+```typescript
+function mightBePasteStart(buffer: Uint8Array): boolean
+```
+
+### findPasteEnd
+
+Finds the paste end marker in a buffer.
+
+```typescript
+function findPasteEnd(buffer: Uint8Array): number
+```
+
+**Returns:** Index of the end marker, or -1 if not found.
+
+### extractPasteContent
+
+Extracts pasted text from a buffer containing paste markers. Returns the text between ESC[200~ and ESC[201~.
+
+```typescript
+function extractPasteContent(
+  buffer: Uint8Array,
+  config?: Partial<PasteConfig>,
+): PasteParseResult
+```
+
+```typescript
+import { extractPasteContent } from 'blecsd';
+
+const buf = Buffer.from('\x1b[200~Hello World\x1b[201~');
+const result = extractPasteContent(buf);
+// { pasteStarted: true, pasteEnded: true, text: 'Hello World', consumed: 24 }
+```
+
+### createPasteState
+
+Creates initial paste state for the multi-chunk state machine.
+
+```typescript
+function createPasteState(config?: Partial<PasteConfig>): PasteState
+```
+
+```typescript
+import { createPasteState } from 'blecsd';
+
+const state = createPasteState({ sanitize: true, maxLength: 1024 });
+```
+
+### processPasteBuffer
+
+Processes a buffer chunk through the paste state machine. Handles multi-chunk paste content, accumulating until the end marker arrives.
+
+```typescript
+function processPasteBuffer(state: PasteState, buffer: Uint8Array): PasteProcessResult
+```
+
+```typescript
+import { createPasteState, processPasteBuffer } from 'blecsd';
+
+let state = createPasteState();
+
+// First chunk: paste start + partial content
+const result1 = processPasteBuffer(state, Buffer.from('\x1b[200~Hello'));
+state = result1.state;
+// state.isPasting === true, no event yet
+
+// Second chunk: rest of content + paste end
+const result2 = processPasteBuffer(state, Buffer.from(' World\x1b[201~'));
+state = result2.state;
+// result2.event.text === 'Hello World'
+```
+
+### enableBracketedPaste
+
+Returns the escape sequence to enable bracketed paste mode.
+
+```typescript
+function enableBracketedPaste(): string
+```
+
+```typescript
+import { enableBracketedPaste } from 'blecsd';
+
+process.stdout.write(enableBracketedPaste());
+```
+
+### disableBracketedPaste
+
+Returns the escape sequence to disable bracketed paste mode.
+
+```typescript
+function disableBracketedPaste(): string
+```
+
+## Zod Schemas
+
+### PasteEventSchema / PasteConfigSchema
+
+```typescript
+import { PasteEventSchema, PasteConfigSchema } from 'blecsd';
+
+const result = PasteEventSchema.safeParse(event);
+if (result.success) {
+  console.log('Valid paste event');
+}
+```
+
+## See Also
+
+- [Input Sanitize](./input-sanitize.md) - Sanitizing untrusted text input
+- [Key Parser](./key-parser.md) - Keyboard event parsing

--- a/docs/api/terminal/capability-negotiation.md
+++ b/docs/api/terminal/capability-negotiation.md
@@ -1,0 +1,274 @@
+# Capability Negotiation
+
+Dynamic terminal capability negotiation that queries the terminal for modern features at startup. Detects advanced capabilities like truecolor, Kitty keyboard protocol, graphics protocols, synchronized output, hyperlinks, and styled underlines.
+
+Supports three timing strategies:
+- **eager**: Query immediately on creation (default)
+- **lazy**: Query on first capability access
+- **skip**: Use environment detection only, no escape sequence queries
+
+## Quick Start
+
+```typescript
+import {
+  createCapabilityNegotiator,
+  getTerminalCapabilities,
+  hasCapability,
+} from 'blecsd';
+
+// Simple: use the default negotiator
+const caps = await getTerminalCapabilities();
+console.log(`Truecolor: ${caps.truecolor}`);
+console.log(`Graphics: ${caps.graphics}`);
+
+// Check a single capability
+if (await hasCapability('truecolor')) {
+  // Use 24-bit colors
+}
+
+// Advanced: custom negotiator
+const negotiator = createCapabilityNegotiator({
+  timing: 'lazy',
+  timeout: 200,
+});
+const caps2 = await negotiator.getCapabilities();
+negotiator.destroy();
+```
+
+## Constants
+
+```typescript
+import {
+  DEFAULT_QUERY_TIMEOUT,
+  MIN_QUERY_TIMEOUT,
+  MAX_QUERY_TIMEOUT,
+  KittyKeyboardLevel,
+  GraphicsProtocol,
+  NegotiationTiming,
+} from 'blecsd';
+
+DEFAULT_QUERY_TIMEOUT; // 100ms
+MIN_QUERY_TIMEOUT;     // 10ms
+MAX_QUERY_TIMEOUT;     // 5000ms
+```
+
+### KittyKeyboardLevel
+
+```typescript
+const KittyKeyboardLevel = {
+  DISABLED: 0,
+  DISAMBIGUATE: 1,
+  REPORT_EVENTS: 2,
+  REPORT_ALTERNATES: 4,
+  REPORT_ALL: 8,
+  REPORT_TEXT: 16,
+} as const;
+```
+
+### GraphicsProtocol
+
+```typescript
+const GraphicsProtocol = {
+  NONE: 'none',
+  KITTY: 'kitty',
+  ITERM2: 'iterm2',
+  SIXEL: 'sixel',
+} as const;
+```
+
+### NegotiationTiming
+
+```typescript
+const NegotiationTiming = {
+  EAGER: 'eager',
+  LAZY: 'lazy',
+  SKIP: 'skip',
+} as const;
+```
+
+## Types
+
+### TerminalCapabilities
+
+The full set of detected terminal capabilities.
+
+```typescript
+interface TerminalCapabilities {
+  readonly truecolor: boolean;
+  readonly kittyKeyboard: KittyKeyboardLevelValue | false;
+  readonly graphics: GraphicsProtocolValue | false;
+  readonly focusEvents: boolean;
+  readonly bracketedPaste: boolean;
+  readonly synchronizedOutput: boolean;
+  readonly hyperlinks: boolean;
+  readonly styledUnderlines: boolean;
+  readonly primaryDA: PrimaryDAResponse | null;
+  readonly secondaryDA: SecondaryDAResponse | null;
+  readonly terminalType: number | null;
+  readonly firmwareVersion: number | null;
+}
+```
+
+### NegotiatorConfig
+
+```typescript
+interface NegotiatorConfig {
+  readonly timeout?: number;                              // Query timeout in ms (default: 100)
+  readonly timing?: NegotiationTimingValue;               // Timing strategy (default: 'eager')
+  readonly input?: NodeJS.ReadStream;                     // Custom input stream
+  readonly output?: NodeJS.WriteStream;                   // Custom output stream
+  readonly forceCapabilities?: Partial<TerminalCapabilities>; // Force specific capabilities (testing)
+}
+```
+
+### CapabilityNegotiator
+
+```typescript
+interface CapabilityNegotiator {
+  getCapabilities(): Promise<TerminalCapabilities>;
+  getCachedCapabilities(): TerminalCapabilities | null;
+  renegotiate(): Promise<TerminalCapabilities>;
+  isNegotiated(): boolean;
+  getTimeout(): number;
+  setTimeout(timeout: number): void;
+  destroy(): void;
+}
+```
+
+## Functions
+
+### createCapabilityNegotiator
+
+Creates a capability negotiator that queries the terminal for capabilities and caches the results.
+
+```typescript
+function createCapabilityNegotiator(config?: NegotiatorConfig): CapabilityNegotiator
+```
+
+```typescript
+import { createCapabilityNegotiator } from 'blecsd';
+
+// Eager negotiation (default)
+const negotiator = createCapabilityNegotiator();
+const caps = await negotiator.getCapabilities();
+
+if (caps.truecolor) {
+  console.log('Truecolor supported!');
+}
+if (caps.kittyKeyboard) {
+  console.log(`Kitty keyboard level: ${caps.kittyKeyboard}`);
+}
+
+negotiator.destroy();
+```
+
+```typescript
+// Lazy negotiation
+const negotiator = createCapabilityNegotiator({
+  timing: 'lazy',
+  timeout: 200,
+});
+const caps = await negotiator.getCapabilities(); // Negotiated on first access
+```
+
+```typescript
+// Skip negotiation, environment detection only
+const negotiator = createCapabilityNegotiator({ timing: 'skip' });
+const caps = await negotiator.getCapabilities(); // Returns immediately
+```
+
+```typescript
+// Force capabilities for testing
+const negotiator = createCapabilityNegotiator({
+  forceCapabilities: { truecolor: true, kittyKeyboard: 8 },
+});
+```
+
+### getDefaultNegotiator
+
+Gets the default (singleton) capability negotiator. Creates one with eager timing on first call.
+
+```typescript
+function getDefaultNegotiator(): CapabilityNegotiator
+```
+
+### resetDefaultNegotiator
+
+Resets the default negotiator. For testing purposes.
+
+```typescript
+function resetDefaultNegotiator(): void
+```
+
+### getTerminalCapabilities
+
+Gets terminal capabilities using the default negotiator.
+
+```typescript
+function getTerminalCapabilities(): Promise<TerminalCapabilities>
+```
+
+```typescript
+import { getTerminalCapabilities } from 'blecsd';
+
+const caps = await getTerminalCapabilities();
+console.log(`Truecolor: ${caps.truecolor}`);
+console.log(`Graphics: ${caps.graphics}`);
+```
+
+### hasCapability
+
+Checks if a specific capability is supported.
+
+```typescript
+function hasCapability(capability: keyof TerminalCapabilities): Promise<boolean>
+```
+
+```typescript
+import { hasCapability } from 'blecsd';
+
+if (await hasCapability('truecolor')) {
+  // Use 24-bit colors
+}
+```
+
+### capabilityQuery
+
+Query generators for manual terminal probing.
+
+```typescript
+const capabilityQuery = {
+  primaryDA: () => string,
+  secondaryDA: () => string,
+  xtversion: () => string,
+  kittyKeyboard: () => string,
+} as const;
+```
+
+## Environment Detection
+
+The negotiator detects capabilities from environment variables before sending any queries:
+
+| Capability | Detection Method |
+|-----------|-----------------|
+| Truecolor | `COLORTERM=truecolor/24bit`, known terminals (iTerm, Kitty, Alacritty, etc.), VTE 3600+ |
+| Kitty Keyboard | `KITTY_WINDOW_ID`, WezTerm, foot terminal |
+| Graphics (Kitty) | `KITTY_WINDOW_ID` |
+| Graphics (iTerm2) | `TERM_PROGRAM=iTerm.app` |
+| Graphics (Sixel) | TERM containing "sixel", DA1 attribute 4 |
+| Sync Output | Known modern terminals, Kitty, Windows Terminal |
+| Hyperlinks | Known modern terminals, VTE 5000+ |
+
+## Zod Schema
+
+```typescript
+import { NegotiatorConfigSchema } from 'blecsd';
+
+NegotiatorConfigSchema.safeParse({ timeout: 200, timing: 'lazy' });
+```
+
+## See Also
+
+- [GPU Probe](./gpu-probe.md) - GPU-accelerated terminal detection
+- [Kitty Protocol](./kitty-protocol.md) - Kitty keyboard protocol
+- [Graphics Backend](./graphics-backend.md) - Terminal graphics protocols

--- a/docs/api/terminal/clipboard.md
+++ b/docs/api/terminal/clipboard.md
@@ -1,0 +1,150 @@
+# Clipboard Manager
+
+Efficient, async clipboard operations that never block the UI. Supports large text selections (1MB+) with progress tracking and streaming paste for huge content. Uses the OSC 52 protocol for system clipboard access.
+
+## Quick Start
+
+```typescript
+import {
+  createClipboardManager,
+  chunkText,
+  streamPaste,
+} from 'blecsd';
+
+const cm = createClipboardManager();
+
+// Copy small text (instant)
+await cm.copy('Hello World');
+
+// Copy large text with progress tracking
+await cm.copy(largeText, (progress) => {
+  console.log(`${progress.percentage}% complete`);
+});
+
+// Read internal buffer
+console.log(cm.getBuffer());
+
+// Clean up
+cm.cancel();
+```
+
+## Types
+
+### ClipboardProgress
+
+```typescript
+interface ClipboardProgress {
+  readonly processed: number;
+  readonly total: number;
+  readonly percentage: number;    // 0-100
+  readonly complete: boolean;
+}
+```
+
+### ClipboardResult
+
+```typescript
+interface ClipboardResult {
+  readonly success: boolean;
+  readonly error?: string;
+  readonly bytesProcessed: number;
+  readonly elapsedMs: number;
+}
+```
+
+### ClipboardManagerConfig
+
+```typescript
+interface ClipboardManagerConfig {
+  readonly chunkSize: number;   // Chunk size for large ops (default: 64KB)
+  readonly maxSize: number;     // Max clipboard size (default: 10MB)
+  readonly useOSC52: boolean;   // Use OSC 52 for system clipboard (default: true)
+}
+```
+
+### ClipboardManager
+
+```typescript
+interface ClipboardManager {
+  copy(text: string, onProgress?: (progress: ClipboardProgress) => void): Promise<ClipboardResult>;
+  writeToTerminal(text: string): ClipboardResult;
+  requestRead(): void;
+  clear(): void;
+  getBuffer(): string;
+  cancel(): void;
+}
+```
+
+## Functions
+
+### createClipboardManager
+
+Creates a clipboard manager for efficient copy/paste operations.
+
+```typescript
+function createClipboardManager(config?: Partial<ClipboardManagerConfig>): ClipboardManager
+```
+
+```typescript
+import { createClipboardManager } from 'blecsd';
+
+const cm = createClipboardManager({ chunkSize: 32 * 1024, maxSize: 5 * 1024 * 1024 });
+
+// Copy with progress
+await cm.copy(largeText, (progress) => {
+  renderProgressBar(progress.percentage);
+});
+```
+
+The manager's methods:
+
+| Method | Description |
+|--------|-------------|
+| `copy(text, onProgress?)` | Async copy, chunks large text with progress |
+| `writeToTerminal(text)` | Sync write via OSC 52 |
+| `requestRead()` | Request clipboard read from terminal |
+| `clear()` | Clear clipboard |
+| `getBuffer()` | Get internal buffer content |
+| `cancel()` | Cancel any ongoing operation |
+
+### chunkText
+
+Splits text into chunks for streaming paste.
+
+```typescript
+function chunkText(text: string, chunkSize: number): readonly string[]
+```
+
+```typescript
+import { chunkText } from 'blecsd';
+
+const chunks = chunkText(largeText, 64 * 1024);
+for (const chunk of chunks) {
+  await processChunk(chunk);
+}
+```
+
+### streamPaste
+
+Streams text content in chunks, yielding to the event loop between chunks. Useful for pasting large content without blocking the UI.
+
+```typescript
+function streamPaste(
+  text: string,
+  onChunk: (chunk: string, progress: ClipboardProgress) => void,
+  chunkSize?: number,
+): Promise<void>
+```
+
+```typescript
+import { streamPaste } from 'blecsd';
+
+await streamPaste(largeText, (chunk, progress) => {
+  insertText(chunk);
+  updateProgressBar(progress);
+});
+```
+
+## See Also
+
+- [Bracketed Paste](./bracketed-paste.md) - Paste event detection and parsing

--- a/docs/api/terminal/gpm-client.md
+++ b/docs/api/terminal/gpm-client.md
@@ -9,172 +9,261 @@ GPM provides mouse input in Linux virtual consoles (TTYs) where xterm-style mous
 ```typescript
 import {
   createGpmClient,
-  connectGpm,
-  disconnectGpm,
-  onGpmMouse,
   isGpmAvailable,
-} from 'blecsd/terminal';
+  parseGpmEventBuffer,
+  gpmEventToMouseEvent,
+} from 'blecsd';
 
 if (isGpmAvailable()) {
   const client = createGpmClient();
-  const unsub = onGpmMouse(client, (event) => {
-    console.log(`${event.action} ${event.button} at (${event.x}, ${event.y})`);
+
+  client.onMouse((event) => {
+    console.log(`${event.action} ${event.button} at ${event.x},${event.y}`);
   });
 
-  await connectGpm(client);
-
-  // Later: cleanup
-  unsub();
-  disconnectGpm(client);
-}
-```
-
-## API Reference
-
-### `createGpmClient(config?)`
-
-Creates a new GPM client. The client is not connected until `connectGpm()` is called.
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `config.socketPath` | `string` | `'/dev/gpmctl'` | Path to GPM daemon socket |
-| `config.connectTimeout` | `number` | `1000` | Connection timeout in ms |
-
-**Returns:** `GpmClientState`
-
-```typescript
-const client = createGpmClient();
-const custom = createGpmClient({ connectTimeout: 500 });
-```
-
-### `connectGpm(state)`
-
-Connects to the GPM daemon. Sends the connect packet and begins receiving mouse events.
-
-**Returns:** `Promise<void>` - Resolves when connected, rejects on error or timeout.
-
-```typescript
-try {
-  await connectGpm(client);
-} catch (err) {
-  console.log('GPM not available:', err.message);
-}
-```
-
-### `disconnectGpm(state)`
-
-Disconnects from the GPM daemon. Safe to call even if not connected.
-
-```typescript
-disconnectGpm(client);
-```
-
-### `onGpmMouse(state, handler)`
-
-Registers a handler for mouse events. Returns an unsubscribe function.
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `state` | `GpmClientState` | The client state |
-| `handler` | `(event: MouseEvent) => void` | Event callback |
-
-**Returns:** `() => void` - Unsubscribe function
-
-```typescript
-const unsub = onGpmMouse(client, (event) => {
-  if (event.action === 'press') {
-    console.log(`Clicked at ${event.x}, ${event.y}`);
+  if (client.connect()) {
+    console.log('GPM connected');
   }
-});
-unsub(); // Stop listening
-```
 
-### `isGpmConnected(state)`
-
-Returns `true` if the client is currently connected.
-
-```typescript
-if (isGpmConnected(client)) {
-  console.log('GPM active');
+  // Clean up
+  client.disconnect();
 }
 ```
 
-### `isGpmAvailable(socketPath?)`
+## Types
 
-Checks whether the GPM socket file exists. Does not verify the daemon is running.
+### GpmEventType
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `socketPath` | `string` | `'/dev/gpmctl'` | Socket path to check |
-
-**Returns:** `boolean`
+GPM event type constants (from gpm.h).
 
 ```typescript
+const GpmEventType = {
+  MOVE: 1,
+  DRAG: 2,
+  DOWN: 4,
+  UP: 8,
+  SINGLE: 16,
+  DOUBLE: 32,
+  TRIPLE: 64,
+  MFLAG: 128,
+  HARD: 256,
+  ENTER: 512,
+  LEAVE: 1024,
+} as const;
+```
+
+### GpmButton
+
+GPM button mask constants (from gpm.h).
+
+```typescript
+const GpmButton = {
+  NONE: 0,
+  LEFT: 4,
+  MIDDLE: 2,
+  RIGHT: 1,
+  FOURTH: 8,
+  UP: 16,
+  DOWN: 32,
+} as const;
+```
+
+### GpmClientConfig
+
+```typescript
+interface GpmClientConfig {
+  readonly socketPath: string;    // Default: '/dev/gpmctl'
+  readonly eventMask: number;     // Default: 0xffff (all events)
+  readonly defaultMask: number;   // Default: 0
+  readonly minMod: number;        // Default: 0
+  readonly maxMod: number;        // Default: 0xffff
+  readonly pid: number;           // Default: process.pid
+  readonly vc: number;            // Default: auto-detect
+}
+```
+
+### GpmRawEvent
+
+Raw GPM event structure (20 bytes), matching the C struct `Gpm_Event`.
+
+```typescript
+interface GpmRawEvent {
+  readonly buttons: number;
+  readonly modifiers: number;
+  readonly vc: number;
+  readonly dx: number;
+  readonly dy: number;
+  readonly x: number;
+  readonly y: number;
+  readonly type: number;
+  readonly clicks: number;
+}
+```
+
+### GpmClientState
+
+```typescript
+interface GpmClientState {
+  readonly connected: boolean;
+  readonly available: boolean;
+  readonly config: GpmClientConfig;
+}
+```
+
+### GpmClient
+
+```typescript
+interface GpmClient {
+  readonly state: GpmClientState;
+  onMouse(handler: (event: MouseEvent) => void): () => void;
+  onConnectionChange(handler: (connected: boolean) => void): () => void;
+  connect(): boolean;
+  disconnect(): void;
+  isAvailable(): boolean;
+}
+```
+
+## Functions
+
+### parseGpmEventBuffer
+
+Parses a raw GPM event buffer (20 bytes) into a `GpmRawEvent`.
+
+```typescript
+function parseGpmEventBuffer(buffer: Uint8Array): GpmRawEvent | null
+```
+
+```typescript
+import { parseGpmEventBuffer } from 'blecsd';
+
+const raw = parseGpmEventBuffer(buffer);
+if (raw) {
+  console.log(`Mouse at ${raw.x}, ${raw.y}`);
+}
+```
+
+### gpmButtonToMouseButton
+
+Converts GPM button flags to a `MouseButton` identifier.
+
+```typescript
+function gpmButtonToMouseButton(buttons: number): MouseButton
+```
+
+### gpmTypeToMouseAction
+
+Converts GPM event type to a `MouseAction`.
+
+```typescript
+function gpmTypeToMouseAction(type: number, buttons: number): MouseAction
+```
+
+### parseGpmModifiers
+
+Extracts modifier state from GPM modifier byte.
+
+```typescript
+function parseGpmModifiers(modifiers: number): { shift: boolean; meta: boolean; ctrl: boolean }
+```
+
+### gpmEventToMouseEvent
+
+Converts a GPM raw event to a standard `MouseEvent`. Coordinates are converted from 1-indexed (GPM) to 0-indexed.
+
+```typescript
+function gpmEventToMouseEvent(raw: GpmRawEvent): MouseEvent
+```
+
+```typescript
+import { parseGpmEventBuffer, gpmEventToMouseEvent } from 'blecsd';
+
+const raw = parseGpmEventBuffer(buffer);
+if (raw) {
+  const event = gpmEventToMouseEvent(raw);
+  console.log(`${event.action} at ${event.x}, ${event.y}`);
+}
+```
+
+### buildGpmConnectPacket
+
+Builds the 16-byte GPM connection request packet.
+
+```typescript
+function buildGpmConnectPacket(config: GpmClientConfig): Uint8Array
+```
+
+### detectVirtualConsole
+
+Detects the virtual console number from the `GPM_TTY` environment variable.
+
+```typescript
+function detectVirtualConsole(): number
+```
+
+**Returns:** The VC number, or 0 if not on a Linux console.
+
+### isGpmAvailable
+
+Checks if GPM is likely available on this system (Linux-only, virtual console).
+
+```typescript
+function isGpmAvailable(): boolean
+```
+
+```typescript
+import { isGpmAvailable } from 'blecsd';
+
 if (isGpmAvailable()) {
-  // GPM daemon is likely running
+  const client = createGpmClient();
+  client.connect();
 }
 ```
 
-### `parseGpmEvent(data)`
+### createGpmClient
 
-Parses a raw 28-byte GPM event buffer into a `MouseEvent`.
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `data` | `Buffer` | Raw 28-byte GPM event |
-
-**Returns:** `MouseEvent | null`
-
-### `buildConnectPacket(pid, vc)`
-
-Builds the 16-byte GPM connect packet.
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `pid` | `number` | Client process ID |
-| `vc` | `number` | Virtual console number |
-
-**Returns:** `Buffer`
-
-### `detectVirtualConsole()`
-
-Detects the current virtual console number from the `XDG_VTNR` environment variable.
-
-**Returns:** `number` (0 if detection fails)
-
-## Mouse Event Shape
-
-GPM events are converted to the standard `MouseEvent` interface:
+Creates a GPM mouse client for Linux console mouse support.
 
 ```typescript
-interface MouseEvent {
-  readonly x: number;        // 0-indexed column
-  readonly y: number;        // 0-indexed row
-  readonly button: MouseButton;  // 'left' | 'middle' | 'right' | 'unknown'
-  readonly action: MouseAction;  // 'press' | 'release' | 'move' | 'wheel'
-  readonly ctrl: boolean;
-  readonly meta: boolean;    // Always false for GPM
-  readonly shift: boolean;
-  readonly protocol: 'x10';  // GPM maps to X10 protocol semantics
-  readonly raw: Uint8Array;
+function createGpmClient(config?: Partial<GpmClientConfig>): GpmClient
+```
+
+```typescript
+import { createGpmClient, isGpmAvailable } from 'blecsd';
+
+if (isGpmAvailable()) {
+  const client = createGpmClient();
+
+  client.onMouse((event) => {
+    console.log(`${event.action} ${event.button} at ${event.x},${event.y}`);
+  });
+
+  if (client.connect()) {
+    console.log('GPM connected');
+  }
+
+  client.disconnect();
 }
 ```
 
 ## GPM Protocol Details
 
 - **Socket:** `/dev/gpmctl` (Unix domain socket)
-- **Connect packet:** 16 bytes (event mask, default mask, min/max modifiers, PID, VC)
-- **Event packet:** 28 bytes (buttons, modifiers, position, type, clicks, margin, wheel)
+- **Connect packet:** 16 bytes (eventMask, defaultMask, minMod, maxMod, pid, vc)
+- **Event packet:** 20 bytes (buttons, modifiers, vc, dx, dy, x, y, type, clicks)
 - **Coordinates:** 1-based from GPM, converted to 0-based in `MouseEvent`
-- **Modifiers:** Shift and Ctrl are supported; Alt/Meta is not reported by GPM
+- **Protocol mapping:** GPM events map to `x10` protocol semantics
 
-## Configuration Schema
+## Zod Schema
 
 ```typescript
-import { GpmClientConfigSchema } from 'blecsd/terminal';
+import { GpmClientConfigSchema } from 'blecsd';
 
 const config = GpmClientConfigSchema.parse({
   socketPath: '/dev/gpmctl',
-  connectTimeout: 2000,
+  eventMask: 0xffff,
 });
 ```
+
+## See Also
+
+- [Mouse Parser](./mouse-parser.md) - Terminal mouse protocol parsing

--- a/docs/api/terminal/gpu-probe.md
+++ b/docs/api/terminal/gpu-probe.md
@@ -1,0 +1,157 @@
+# GPU Probe
+
+Detects whether the host terminal is GPU-accelerated and reports which optimization strategies are supported. This is the practical approach to GPU rendering for a terminal library: detect the host's capabilities and optimize output accordingly.
+
+## Quick Start
+
+```typescript
+import {
+  detectGpuCapabilities,
+  formatGpuReport,
+  wrapSyncOutput,
+} from 'blecsd';
+
+const caps = detectGpuCapabilities();
+
+if (caps.isGpuAccelerated) {
+  console.log(`GPU terminal: ${caps.terminal}`);
+  console.log('Strategies:', caps.strategies.join(', '));
+}
+
+// Wrap frame output in synchronized output to prevent tearing
+const frame = buildFrameContent();
+process.stdout.write(wrapSyncOutput(frame));
+```
+
+## Types
+
+### GpuTerminal
+
+Known GPU-accelerated terminal emulators.
+
+```typescript
+type GpuTerminal =
+  | 'alacritty'
+  | 'kitty'
+  | 'ghostty'
+  | 'warp'
+  | 'wezterm'
+  | 'contour'
+  | 'rio'
+  | 'unknown';
+```
+
+### GpuCapabilities
+
+GPU rendering capabilities detected from the host terminal.
+
+```typescript
+interface GpuCapabilities {
+  readonly isGpuAccelerated: boolean;
+  readonly terminal: GpuTerminal;
+  readonly syncOutput: boolean;
+  readonly kittyGraphics: boolean;
+  readonly sixelGraphics: boolean;
+  readonly unicodeSupport: boolean;
+  readonly strategies: readonly RenderStrategy[];
+}
+```
+
+### RenderStrategy
+
+Rendering strategies recommended based on terminal capabilities.
+
+```typescript
+type RenderStrategy =
+  | 'sync-output'
+  | 'diff-rendering'
+  | 'cursor-jump'
+  | 'sgr-coalesce'
+  | 'kitty-graphics'
+  | 'sixel-graphics'
+  | 'bulk-scroll';
+```
+
+## Functions
+
+### detectGpuCapabilities
+
+Detects GPU-accelerated terminal capabilities from environment variables. This is a synchronous, best-effort detection that checks known environment variables. No escape sequences are sent.
+
+```typescript
+function detectGpuCapabilities(): GpuCapabilities
+```
+
+```typescript
+import { detectGpuCapabilities } from 'blecsd';
+
+const caps = detectGpuCapabilities();
+if (caps.isGpuAccelerated) {
+  console.log(`GPU terminal detected: ${caps.terminal}`);
+  console.log('Strategies:', caps.strategies.join(', '));
+}
+```
+
+### formatGpuReport
+
+Returns a human-readable report of GPU capabilities.
+
+```typescript
+function formatGpuReport(caps: GpuCapabilities): string
+```
+
+```typescript
+import { detectGpuCapabilities, formatGpuReport } from 'blecsd';
+
+console.log(formatGpuReport(detectGpuCapabilities()));
+```
+
+### syncOutputBegin
+
+Generates the synchronized output begin sequence (CSI ?2026h). Supported by all GPU-accelerated terminals.
+
+```typescript
+function syncOutputBegin(): string
+```
+
+### syncOutputEnd
+
+Generates the synchronized output end sequence (CSI ?2026l).
+
+```typescript
+function syncOutputEnd(): string
+```
+
+### wrapSyncOutput
+
+Wraps content in synchronized output sequences. This prevents tearing when the terminal redraws mid-frame.
+
+```typescript
+function wrapSyncOutput(content: string): string
+```
+
+```typescript
+import { wrapSyncOutput } from 'blecsd';
+
+const frame = buildFrameContent();
+process.stdout.write(wrapSyncOutput(frame));
+```
+
+## Terminal Detection
+
+The probe detects terminals by checking environment variables:
+
+| Terminal | Detection Method |
+|----------|-----------------|
+| Alacritty | `ALACRITTY_LOG` or `ALACRITTY_SOCKET` |
+| Kitty | `KITTY_PID` or `KITTY_WINDOW_ID` |
+| Ghostty | `GHOSTTY_RESOURCES_DIR` |
+| Warp | `TERM_PROGRAM=WarpTerminal` |
+| WezTerm | `TERM_PROGRAM=WezTerm` |
+| Contour | `TERM_PROGRAM=contour` |
+| Rio | `TERM_PROGRAM=rio` |
+
+## See Also
+
+- [Capability Negotiation](./capability-negotiation.md) - Dynamic terminal capability detection
+- [Optimized Output](./optimized-output.md) - Output buffer with escape sequence optimization

--- a/docs/api/terminal/graphics-backend.md
+++ b/docs/api/terminal/graphics-backend.md
@@ -1,0 +1,234 @@
+# Graphics Backend
+
+Pluggable terminal graphics backend system for image rendering. Provides a unified interface for different terminal graphics protocols (Kitty, iTerm2, Sixel, ANSI art, ASCII) with automatic backend selection and a fallback chain.
+
+## Quick Start
+
+```typescript
+import {
+  createGraphicsManager,
+  registerBackend,
+  renderImage,
+  clearImage,
+  getActiveBackend,
+  selectBackend,
+} from 'blecsd';
+
+// Create a graphics manager
+const manager = createGraphicsManager();
+
+// Register backends (see protocol-specific docs)
+registerBackend(manager, kittyBackend);
+registerBackend(manager, sixelBackend);
+
+// Render an image (uses the best available backend)
+const output = renderImage(manager, imageData, { x: 10, y: 5 });
+process.stdout.write(output);
+
+// Clear
+process.stdout.write(clearImage(manager, 1));
+```
+
+## Types
+
+### BackendName
+
+```typescript
+type BackendName = 'kitty' | 'iterm2' | 'sixel' | 'ansi' | 'ascii';
+```
+
+### GraphicsCapabilities
+
+```typescript
+interface GraphicsCapabilities {
+  readonly staticImages: boolean;
+  readonly animation: boolean;
+  readonly alphaChannel: boolean;
+  readonly maxWidth: number | null;    // null = unlimited
+  readonly maxHeight: number | null;   // null = unlimited
+}
+```
+
+### ImageData
+
+```typescript
+interface ImageData {
+  readonly width: number;
+  readonly height: number;
+  readonly data: Uint8Array;
+  readonly format: 'rgba' | 'rgb' | 'png';
+}
+```
+
+### RenderOptions
+
+```typescript
+interface RenderOptions {
+  readonly x: number;
+  readonly y: number;
+  readonly width?: number;
+  readonly height?: number;
+  readonly id?: number;
+  readonly preserveAspectRatio?: boolean;
+}
+```
+
+### GraphicsBackend
+
+A backend that can render images to the terminal.
+
+```typescript
+interface GraphicsBackend {
+  readonly name: BackendName;
+  readonly capabilities: GraphicsCapabilities;
+  readonly render: (image: ImageData, options: RenderOptions) => string;
+  readonly clear: (id?: number) => string;
+  readonly isSupported: () => boolean;
+}
+```
+
+### GraphicsManagerConfig
+
+```typescript
+interface GraphicsManagerConfig {
+  readonly preferenceOrder?: readonly BackendName[];
+  readonly backends?: readonly GraphicsBackend[];
+}
+```
+
+### GraphicsManagerState
+
+```typescript
+interface GraphicsManagerState {
+  readonly backends: Map<BackendName, GraphicsBackend>;
+  activeBackend: GraphicsBackend | undefined;
+  readonly preferenceOrder: readonly BackendName[];
+}
+```
+
+## Constants
+
+### DEFAULT_FALLBACK_CHAIN
+
+Default backend preference order (highest fidelity first).
+
+```typescript
+const DEFAULT_FALLBACK_CHAIN: readonly BackendName[] = [
+  'kitty', 'iterm2', 'sixel', 'ansi', 'ascii',
+];
+```
+
+## Functions
+
+### selectBackend
+
+Selects the best available backend from a list of registered backends.
+
+```typescript
+function selectBackend(
+  backends: ReadonlyMap<BackendName, GraphicsBackend>,
+  preferenceOrder?: readonly BackendName[],
+): GraphicsBackend | undefined
+```
+
+```typescript
+import { selectBackend } from 'blecsd';
+
+const backend = selectBackend(registeredBackends);
+if (backend) {
+  const output = backend.render(imageData, { x: 0, y: 0 });
+}
+```
+
+### createGraphicsManager
+
+Creates a graphics manager state.
+
+```typescript
+function createGraphicsManager(config?: GraphicsManagerConfig): GraphicsManagerState
+```
+
+```typescript
+import { createGraphicsManager, registerBackend } from 'blecsd';
+
+const manager = createGraphicsManager();
+registerBackend(manager, ansiBackend);
+```
+
+### registerBackend
+
+Registers a graphics backend with the manager.
+
+```typescript
+function registerBackend(manager: GraphicsManagerState, backend: GraphicsBackend): void
+```
+
+### getActiveBackend
+
+Gets the active graphics backend, selecting the best one if needed.
+
+```typescript
+function getActiveBackend(manager: GraphicsManagerState): GraphicsBackend | undefined
+```
+
+### renderImage
+
+Renders an image using the active backend.
+
+```typescript
+function renderImage(
+  manager: GraphicsManagerState,
+  image: ImageData,
+  options: RenderOptions,
+): string
+```
+
+```typescript
+import { renderImage } from 'blecsd';
+
+const output = renderImage(manager, imageData, { x: 10, y: 5 });
+process.stdout.write(output);
+```
+
+### clearImage
+
+Clears an image (or all images) using the active backend.
+
+```typescript
+function clearImage(manager: GraphicsManagerState, id?: number): string
+```
+
+### refreshBackend
+
+Re-selects the active backend. Call after terminal resize or when capabilities change.
+
+```typescript
+function refreshBackend(manager: GraphicsManagerState): GraphicsBackend | undefined
+```
+
+### getBackendCapabilities
+
+Gets the capabilities of the active backend.
+
+```typescript
+function getBackendCapabilities(manager: GraphicsManagerState): GraphicsCapabilities | undefined
+```
+
+## Zod Schemas
+
+```typescript
+import {
+  GraphicsCapabilitiesSchema,
+  ImageDataSchema,
+  RenderOptionsSchema,
+  GraphicsManagerConfigSchema,
+} from 'blecsd';
+
+const result = RenderOptionsSchema.safeParse({ x: 0, y: 0 });
+```
+
+## See Also
+
+- [Graphics Kitty](./graphics-kitty.md) - Kitty graphics protocol backend
+- [Graphics Sixel](./graphics-sixel.md) - Sixel graphics protocol backend
+- [Graphics iTerm2](./graphics-iterm2.md) - iTerm2 inline images backend

--- a/docs/api/terminal/graphics-iterm2.md
+++ b/docs/api/terminal/graphics-iterm2.md
@@ -1,0 +1,213 @@
+# Graphics iTerm2
+
+Implements the iTerm2 inline images protocol (OSC 1337) for displaying images directly in the terminal. Works with iTerm2 and compatible terminals (WezTerm, Konsole, mintty).
+
+## Quick Start
+
+```typescript
+import {
+  createITerm2Backend,
+  buildImageSequence,
+  isITerm2Supported,
+  createGraphicsManager,
+  registerBackend,
+} from 'blecsd';
+
+// Register the iTerm2 backend
+const manager = createGraphicsManager();
+registerBackend(manager, createITerm2Backend());
+
+// Build and display an image directly
+const seq = buildImageSequence(pngData, { inline: true });
+process.stdout.write(seq);
+```
+
+## Constants
+
+```typescript
+import { OSC_1337_PREFIX, ST, ST_ALT, ITERM2_BACKEND_NAME } from 'blecsd';
+
+OSC_1337_PREFIX;     // '\x1b]1337;File=' - OSC 1337 prefix
+ST;                  // '\x07' - String terminator (BEL)
+ST_ALT;              // '\x1b\\' - Alternative ST (for tmux)
+ITERM2_BACKEND_NAME; // 'iterm2'
+```
+
+## Types
+
+### SizeUnit
+
+```typescript
+type SizeUnit = 'px' | 'cells' | 'auto' | '%';
+```
+
+### ITerm2Size
+
+```typescript
+interface ITerm2Size {
+  readonly value: number;
+  readonly unit: SizeUnit;
+}
+```
+
+### ITerm2ImageConfig
+
+```typescript
+interface ITerm2ImageConfig {
+  readonly inline?: boolean;                  // Display inline vs downloadable (default: true)
+  readonly name?: string;                     // Image name
+  readonly width?: ITerm2Size;
+  readonly height?: ITerm2Size;
+  readonly preserveAspectRatio?: boolean;     // Default: true
+}
+```
+
+### ITerm2EnvChecker
+
+```typescript
+interface ITerm2EnvChecker {
+  readonly getEnv: (name: string) => string | undefined;
+}
+```
+
+## Functions
+
+### Encoding
+
+#### encodeBase64
+
+Encodes binary data to base64.
+
+```typescript
+function encodeBase64(data: Uint8Array): string
+```
+
+### Size Formatting
+
+#### formatSize
+
+Formats a size value for the OSC 1337 protocol.
+
+```typescript
+function formatSize(size: ITerm2Size): string
+```
+
+```typescript
+import { formatSize } from 'blecsd';
+
+formatSize({ value: 40, unit: 'cells' }); // '40'
+formatSize({ value: 100, unit: 'px' });   // '100px'
+formatSize({ value: 50, unit: '%' });     // '50%'
+formatSize({ value: 0, unit: 'auto' });   // 'auto'
+```
+
+### Sequence Building
+
+#### buildParams
+
+Builds the parameter string for an OSC 1337 image sequence.
+
+```typescript
+function buildParams(config: ITerm2ImageConfig, dataSize: number): string
+```
+
+```typescript
+import { buildParams } from 'blecsd';
+
+const params = buildParams({ inline: true, name: 'test.png' }, 1024);
+// 'name=dGVzdC5wbmc=;size=1024;inline=1'
+```
+
+#### buildImageSequence
+
+Builds a complete OSC 1337 image sequence.
+
+```typescript
+function buildImageSequence(data: Uint8Array, config?: ITerm2ImageConfig): string
+```
+
+```typescript
+import { buildImageSequence } from 'blecsd';
+
+const seq = buildImageSequence(pngData, { inline: true });
+process.stdout.write(seq);
+```
+
+### Rendering
+
+#### renderITerm2Image
+
+Renders image data using the iTerm2 protocol with cursor positioning.
+
+```typescript
+function renderITerm2Image(image: ImageData, options: RenderOptions): string
+```
+
+```typescript
+import { renderITerm2Image } from 'blecsd';
+
+const output = renderITerm2Image(
+  { width: 100, height: 50, data: pngBytes, format: 'png' },
+  { x: 0, y: 0, width: 40, height: 20 },
+);
+process.stdout.write(output);
+```
+
+#### clearITerm2Image
+
+Clears an image area by overwriting with spaces (iTerm2 has no dedicated clear command).
+
+```typescript
+function clearITerm2Image(options?: { x: number; y: number; width: number; height: number }): string
+```
+
+#### cursorPosition
+
+Builds a cursor positioning escape sequence.
+
+```typescript
+function cursorPosition(x: number, y: number): string
+```
+
+### Detection
+
+#### isITerm2Supported
+
+Checks if the current terminal supports iTerm2 inline images.
+
+```typescript
+function isITerm2Supported(env?: ITerm2EnvChecker): boolean
+```
+
+Detected terminals: iTerm.app, WezTerm, mintty (via TERM_PROGRAM or LC_TERMINAL).
+
+### Backend Factory
+
+#### createITerm2Backend
+
+Creates an iTerm2 graphics backend for use with the graphics manager.
+
+```typescript
+function createITerm2Backend(envChecker?: ITerm2EnvChecker): GraphicsBackend
+```
+
+```typescript
+import { createITerm2Backend, createGraphicsManager, registerBackend } from 'blecsd';
+
+const manager = createGraphicsManager();
+registerBackend(manager, createITerm2Backend());
+```
+
+## Zod Schemas
+
+```typescript
+import { ITerm2SizeSchema, ITerm2ImageConfigSchema } from 'blecsd';
+
+ITerm2ImageConfigSchema.safeParse({ inline: true });
+```
+
+## See Also
+
+- [Graphics Backend](./graphics-backend.md) - Pluggable graphics backend system
+- [Graphics Kitty](./graphics-kitty.md) - Kitty graphics protocol
+- [Graphics Sixel](./graphics-sixel.md) - Sixel graphics protocol

--- a/docs/api/terminal/graphics-kitty.md
+++ b/docs/api/terminal/graphics-kitty.md
@@ -1,0 +1,357 @@
+# Graphics Kitty
+
+Implements the Kitty terminal graphics protocol for high-fidelity raster image display with animation support. Uses APC escape sequences (`ESC _G ... ESC \`) for image transmission, placement, and deletion.
+
+See the [Kitty graphics protocol specification](https://sw.kovidgoyal.net/kitty/graphics-protocol/) for the full protocol reference.
+
+## Quick Start
+
+```typescript
+import {
+  createKittyBackend,
+  buildTransmitAndDisplay,
+  buildDeleteAll,
+  buildDeleteById,
+  buildQuery,
+  isKittySupported,
+  createGraphicsManager,
+  registerBackend,
+} from 'blecsd';
+
+// Register the Kitty backend
+const manager = createGraphicsManager();
+registerBackend(manager, createKittyBackend());
+
+// Transmit and display an image
+const output = buildTransmitAndDisplay(
+  { width: 100, height: 50, data: pngBytes, format: 'png' },
+  { x: 0, y: 0, width: 40, height: 20 },
+);
+process.stdout.write(output);
+
+// Delete all images
+process.stdout.write(buildDeleteAll());
+```
+
+## Constants
+
+```typescript
+import { APC_PREFIX, KITTY_ST, MAX_CHUNK_SIZE, KITTY_BACKEND_NAME } from 'blecsd';
+
+APC_PREFIX;       // '\x1b_G' - APC escape prefix
+KITTY_ST;         // '\x1b\\' - String terminator
+MAX_CHUNK_SIZE;   // 4096 - Max base64 payload per chunk
+KITTY_BACKEND_NAME; // 'kitty'
+```
+
+## Types
+
+### KittyAction
+
+```typescript
+type KittyAction = 'T' | 't' | 'p' | 'd' | 'q' | 'f' | 'a';
+// T=transmit+display, t=transmit, p=place, d=delete, q=query, f=frame, a=animate
+```
+
+### KittyFormat
+
+```typescript
+type KittyFormat = 24 | 32 | 100;
+// 24=RGB, 32=RGBA, 100=PNG
+```
+
+### KittyTransmission
+
+```typescript
+type KittyTransmission = 'd' | 'f' | 't' | 's';
+// d=direct inline, f=file path, t=temp file, s=shared memory
+```
+
+### KittyDeleteMode
+
+```typescript
+type KittyDeleteMode = 'a' | 'A' | 'i' | 'I' | 'c' | 'C' | 'x' | 'X' | 'y' | 'Y' | 'z' | 'Z';
+// Lowercase: delete placements only. Uppercase: delete placements AND data.
+```
+
+### KittyQuiet
+
+```typescript
+type KittyQuiet = 0 | 1 | 2;
+// 0=all responses, 1=suppress OK, 2=suppress all
+```
+
+### KittyControlData
+
+Control key-value pairs for a Kitty graphics command.
+
+```typescript
+interface KittyControlData {
+  readonly a?: KittyAction;
+  readonly f?: KittyFormat;
+  readonly t?: KittyTransmission;
+  readonly o?: 'z';             // Compression
+  readonly m?: 0 | 1;           // More data flag
+  readonly s?: number;           // Source width
+  readonly v?: number;           // Source height
+  readonly i?: number;           // Image ID
+  readonly p?: number;           // Placement ID
+  readonly q?: KittyQuiet;
+  readonly x?: number;           // Source X offset
+  readonly y?: number;           // Source Y offset
+  readonly w?: number;           // Source rect width
+  readonly h?: number;           // Source rect height
+  readonly X?: number;           // Cell X offset
+  readonly Y?: number;           // Cell Y offset
+  readonly c?: number;           // Display columns
+  readonly r?: number;           // Display rows
+  readonly z?: number;           // Z-index
+  readonly C?: 0 | 1;           // Cursor movement policy
+  readonly d?: KittyDeleteMode;
+}
+```
+
+### KittyImageConfig
+
+```typescript
+interface KittyImageConfig {
+  readonly imageId?: number;
+  readonly placementId?: number;
+  readonly quiet?: KittyQuiet;
+  readonly zIndex?: number;
+  readonly holdCursor?: boolean;
+}
+```
+
+### KittyFrameConfig
+
+```typescript
+interface KittyFrameConfig {
+  readonly imageId: number;
+  readonly frameNumber?: number;
+  readonly backgroundFrame?: number;
+  readonly duration?: number;    // ms
+  readonly x?: number;
+  readonly y?: number;
+  readonly width?: number;
+  readonly height?: number;
+}
+```
+
+## Functions
+
+### Encoding
+
+#### kittyEncodeBase64
+
+Encodes binary data to base64.
+
+```typescript
+function kittyEncodeBase64(data: Uint8Array): string
+```
+
+#### serializeControlData
+
+Serializes control data key-value pairs into a comma-separated string.
+
+```typescript
+function serializeControlData(ctrl: KittyControlData): string
+```
+
+```typescript
+import { serializeControlData } from 'blecsd';
+
+serializeControlData({ a: 'T', f: 100, i: 1 }); // 'a=T,f=100,i=1'
+```
+
+#### imageFormatToKitty
+
+Maps an ImageData format string to the Kitty format code.
+
+```typescript
+function imageFormatToKitty(format: 'rgba' | 'rgb' | 'png'): KittyFormat
+```
+
+### Sequence Building
+
+#### buildKittySequence
+
+Builds a single Kitty graphics APC escape sequence.
+
+```typescript
+function buildKittySequence(ctrl: KittyControlData, payload?: string): string
+```
+
+#### chunkBase64
+
+Splits base64 data into chunks of at most `MAX_CHUNK_SIZE` bytes.
+
+```typescript
+function chunkBase64(base64Data: string): string[]
+```
+
+#### buildChunkedSequences
+
+Builds chunked sequences for transmitting large image data.
+
+```typescript
+function buildChunkedSequences(ctrl: KittyControlData, base64Data: string): string[]
+```
+
+#### kittyCursorPosition
+
+Builds a CUP (Cursor Position) escape sequence (0-based input, 1-based output).
+
+```typescript
+function kittyCursorPosition(x: number, y: number): string
+```
+
+### Transmit and Display
+
+#### buildTransmitAndDisplay
+
+Builds escape sequences to transmit and display an image. Handles chunking automatically.
+
+```typescript
+function buildTransmitAndDisplay(
+  image: ImageData,
+  options: RenderOptions,
+  config?: KittyImageConfig,
+): string
+```
+
+```typescript
+import { buildTransmitAndDisplay } from 'blecsd';
+
+const output = buildTransmitAndDisplay(
+  { width: 100, height: 50, data: pngBytes, format: 'png' },
+  { x: 0, y: 0, width: 40, height: 20 },
+);
+process.stdout.write(output);
+```
+
+#### buildTransmitOnly
+
+Transmits image data without displaying it. The image is stored in terminal memory for later placement.
+
+```typescript
+function buildTransmitOnly(image: ImageData, imageId: number, quiet?: KittyQuiet): string
+```
+
+#### buildPlacement
+
+Places a previously transmitted image.
+
+```typescript
+function buildPlacement(imageId: number, options: RenderOptions, config?: KittyImageConfig): string
+```
+
+### Deletion
+
+#### buildDeleteAll
+
+Deletes all image placements and data.
+
+```typescript
+function buildDeleteAll(): string
+```
+
+#### buildDeleteById
+
+Deletes a specific image by ID.
+
+```typescript
+function buildDeleteById(imageId: number, freeData?: boolean): string
+```
+
+#### buildDeleteAtCursor
+
+Deletes all images at the cursor position.
+
+```typescript
+function buildDeleteAtCursor(freeData?: boolean): string
+```
+
+### Animation
+
+#### buildAnimationFrame
+
+Transmits an animation frame.
+
+```typescript
+function buildAnimationFrame(frameData: Uint8Array, config: KittyFrameConfig): string
+```
+
+#### buildAnimationControl
+
+Controls animation playback.
+
+```typescript
+function buildAnimationControl(imageId: number, action: 'start' | 'stop', loops?: number): string
+```
+
+```typescript
+import { buildAnimationControl } from 'blecsd';
+
+process.stdout.write(buildAnimationControl(1, 'start'));  // Infinite loop
+process.stdout.write(buildAnimationControl(1, 'stop'));
+```
+
+### Query and Detection
+
+#### buildQuery
+
+Builds an escape sequence to query Kitty graphics protocol support.
+
+```typescript
+function buildQuery(): string
+```
+
+#### isKittySupported
+
+Checks if the current terminal supports the Kitty graphics protocol.
+
+```typescript
+function isKittySupported(env?: KittyEnvChecker): boolean
+```
+
+### Convenience
+
+#### renderKittyImage / clearKittyImage
+
+```typescript
+function renderKittyImage(image: ImageData, options: RenderOptions): string
+function clearKittyImage(id?: number): string
+```
+
+### Backend Factory
+
+#### createKittyBackend
+
+Creates a Kitty graphics backend for use with the graphics manager.
+
+```typescript
+function createKittyBackend(envChecker?: KittyEnvChecker): GraphicsBackend
+```
+
+```typescript
+import { createKittyBackend, createGraphicsManager, registerBackend } from 'blecsd';
+
+const manager = createGraphicsManager();
+registerBackend(manager, createKittyBackend());
+```
+
+## Zod Schemas
+
+```typescript
+import { KittyImageConfigSchema, KittyFrameConfigSchema } from 'blecsd';
+
+KittyImageConfigSchema.safeParse({ imageId: 1 });
+KittyFrameConfigSchema.safeParse({ imageId: 1, duration: 100 });
+```
+
+## See Also
+
+- [Graphics Backend](./graphics-backend.md) - Pluggable graphics backend system
+- [Graphics Sixel](./graphics-sixel.md) - Sixel graphics protocol
+- [Graphics iTerm2](./graphics-iterm2.md) - iTerm2 inline images

--- a/docs/api/terminal/graphics-sixel.md
+++ b/docs/api/terminal/graphics-sixel.md
@@ -1,0 +1,254 @@
+# Graphics Sixel
+
+Implements the DEC sixel protocol (DCS q ... ST) for displaying images in terminals that support sixel graphics. Encodes raw pixel data as sixel escape sequences with palette quantization and RLE compression.
+
+Sixel images are encoded in 6-pixel-tall horizontal bands using a color-indexed palette (up to 256 colors). Each band column is a single character whose 6 low bits indicate which of the 6 rows contain a given color.
+
+## Quick Start
+
+```typescript
+import {
+  createSixelGraphicsBackend,
+  encodeSixelImage,
+  isSixelSupported,
+  createGraphicsManager,
+  registerBackend,
+} from 'blecsd';
+
+// Register the sixel backend
+const manager = createGraphicsManager();
+registerBackend(manager, createSixelGraphicsBackend({ maxColors: 256 }));
+
+// Encode and display an image directly
+const seq = encodeSixelImage(imageData, 256, true);
+process.stdout.write(seq);
+```
+
+## Constants
+
+```typescript
+import { DCS_START, SIXEL_ST, SIXEL_BACKEND_NAME, DEFAULT_MAX_COLORS } from 'blecsd';
+
+DCS_START;         // '\x1bPq' - DCS introducer
+SIXEL_ST;          // '\x1b\\' - String terminator
+SIXEL_BACKEND_NAME; // 'sixel'
+DEFAULT_MAX_COLORS; // 256
+```
+
+## Types
+
+### SixelBackendConfig
+
+```typescript
+interface SixelBackendConfig {
+  readonly maxColors?: number;    // Max palette colors, 2-256 (default: 256)
+  readonly rleEnabled?: boolean;  // Enable RLE compression (default: true)
+}
+```
+
+### SixelEnvChecker
+
+```typescript
+interface SixelEnvChecker {
+  readonly getEnv: (name: string) => string | undefined;
+}
+```
+
+## Functions
+
+### Pixel Helpers
+
+#### bytesPerPixel
+
+```typescript
+function bytesPerPixel(format: 'rgba' | 'rgb' | 'png'): number
+```
+
+#### getPixelRGBA
+
+Extracts RGBA values from image data at a pixel index.
+
+```typescript
+function getPixelRGBA(data: Uint8Array, index: number, bpp: number): [number, number, number, number]
+```
+
+### Color Quantization
+
+#### packRGB
+
+Packs RGB into a single 24-bit integer.
+
+```typescript
+function packRGB(r: number, g: number, b: number): number
+```
+
+#### countImageColors
+
+Counts color occurrences in image data, skipping transparent pixels.
+
+```typescript
+function countImageColors(data: Uint8Array, pixelCount: number, bpp: number): Map<number, number>
+```
+
+#### buildPalette
+
+Builds a palette from color counts sorted by popularity.
+
+```typescript
+function buildPalette(
+  colorCounts: Map<number, number>,
+  maxColors: number,
+): { paletteFlat: Uint8Array; paletteCount: number }
+```
+
+#### findNearestColor
+
+Finds the nearest palette index for an RGB color using squared distance.
+
+```typescript
+function findNearestColor(
+  r: number, g: number, b: number,
+  paletteFlat: Uint8Array, paletteCount: number,
+): number
+```
+
+#### mapPixelsToPalette
+
+Maps all pixels to their nearest palette index.
+
+```typescript
+function mapPixelsToPalette(
+  data: Uint8Array, pixelCount: number, bpp: number,
+  paletteFlat: Uint8Array, paletteCount: number,
+): Uint8Array
+```
+
+### Sixel Encoding
+
+#### buildPaletteHeader
+
+Builds the sixel palette header string.
+
+```typescript
+function buildPaletteHeader(paletteFlat: Uint8Array, paletteCount: number): string
+```
+
+#### buildSixelColumn
+
+Builds a sixel bit pattern for one column across all rows in a band.
+
+```typescript
+function buildSixelColumn(
+  indexMap: Uint8Array, colorIdx: number, bandY: number,
+  maxRow: number, width: number, x: number,
+): number
+```
+
+#### rleEncodeBand
+
+Run-length encodes a band of sixel values. Uses `!<count><char>` for runs of 3 or more identical values.
+
+```typescript
+function rleEncodeBand(sixelValues: Uint8Array, width: number): { encoded: string; hasPixels: boolean }
+```
+
+#### rawEncodeBand
+
+Raw-encodes a band of sixel values (no RLE compression).
+
+```typescript
+function rawEncodeBand(sixelValues: Uint8Array, width: number): { encoded: string; hasPixels: boolean }
+```
+
+#### encodeSixelData
+
+Encodes a complete sixel image from pixel index map data. Processes in 6-pixel-tall bands.
+
+```typescript
+function encodeSixelData(
+  indexMap: Uint8Array, paletteCount: number,
+  width: number, height: number, rleEnabled: boolean,
+): string
+```
+
+#### encodeSixelImage
+
+Encodes image data as a complete sixel escape sequence (palette quantization + encoding + DCS framing).
+
+```typescript
+function encodeSixelImage(image: ImageData, maxColors: number, rleEnabled: boolean): string
+```
+
+```typescript
+import { encodeSixelImage } from 'blecsd';
+
+const seq = encodeSixelImage(imageData, 256, true);
+process.stdout.write(seq);
+```
+
+### Rendering
+
+#### renderSixelImage
+
+Renders image data as a positioned sixel escape sequence.
+
+```typescript
+function renderSixelImage(
+  image: ImageData, options: RenderOptions,
+  maxColors: number, rleEnabled: boolean,
+): string
+```
+
+#### clearSixelImage
+
+Clears a sixel image area by overwriting with spaces (sixel has no dedicated clear command).
+
+```typescript
+function clearSixelImage(options?: { x: number; y: number; width: number; height: number }): string
+```
+
+### Detection
+
+#### isSixelSupported
+
+Checks if the current terminal likely supports sixel graphics.
+
+```typescript
+function isSixelSupported(env?: SixelEnvChecker): boolean
+```
+
+Detected terminals: xterm (with XTERM_VERSION), mlterm, foot, contour, WezTerm, and any TERM containing "sixel".
+
+### Backend Factory
+
+#### createSixelGraphicsBackend
+
+Creates a sixel graphics backend for use with the graphics manager.
+
+```typescript
+function createSixelGraphicsBackend(
+  config?: SixelBackendConfig,
+  envChecker?: SixelEnvChecker,
+): GraphicsBackend
+```
+
+```typescript
+import { createSixelGraphicsBackend, createGraphicsManager, registerBackend } from 'blecsd';
+
+const manager = createGraphicsManager();
+registerBackend(manager, createSixelGraphicsBackend({ maxColors: 64 }));
+```
+
+## Zod Schema
+
+```typescript
+import { SixelBackendConfigSchema } from 'blecsd';
+
+SixelBackendConfigSchema.safeParse({ maxColors: 64 }); // Validated config
+```
+
+## See Also
+
+- [Graphics Backend](./graphics-backend.md) - Pluggable graphics backend system
+- [Graphics Kitty](./graphics-kitty.md) - Kitty graphics protocol
+- [Graphics iTerm2](./graphics-iterm2.md) - iTerm2 inline images

--- a/docs/api/terminal/input-sanitize.md
+++ b/docs/api/terminal/input-sanitize.md
@@ -1,0 +1,224 @@
+# Input Sanitize
+
+Sanitizes user-provided or network-received text by stripping C0/C1 control characters, null bytes, invalid UTF-8 sequences, and enforcing length limits. Designed for networked games and applications with user-generated content.
+
+## Quick Start
+
+```typescript
+import {
+  sanitizeTextInput,
+  sanitizeTextInputDetailed,
+  stripNullBytes,
+  stripControlChars,
+  isValidUtf8String,
+  hasControlChars,
+} from 'blecsd';
+
+// Basic sanitization
+const safe = sanitizeTextInput(userInput);
+
+// With length limit and no Unicode
+const limited = sanitizeTextInput(userInput, {
+  maxLength: 100,
+  allowUnicode: false,
+});
+
+// Detailed result with metadata
+const result = sanitizeTextInputDetailed(networkMessage, { maxLength: 256 });
+if (result.modified) {
+  console.warn(`Input sanitized: ${result.strippedCount} chars removed`);
+}
+```
+
+## Types
+
+### InputSanitizeOptions
+
+```typescript
+interface InputSanitizeOptions {
+  readonly allowUnicode: boolean;       // Allow non-ASCII Unicode (default: true)
+  readonly maxLength: number;           // Max string length (default: 0 = no limit)
+  readonly stripControl: boolean;       // Remove C0/C1 control chars (default: true)
+  readonly stripNull: boolean;          // Remove null bytes (default: true)
+  readonly allowTab: boolean;           // Allow tab even when stripping controls (default: true)
+  readonly allowNewline: boolean;       // Allow LF/CR even when stripping controls (default: true)
+  readonly replacementChar: string;     // Replacement for invalid sequences (default: '\uFFFD')
+}
+```
+
+### SanitizeResult
+
+```typescript
+interface SanitizeResult {
+  readonly text: string;
+  readonly modified: boolean;
+  readonly strippedCount: number;
+  readonly truncated: boolean;
+  readonly originalLength: number;
+}
+```
+
+### DEFAULT_INPUT_SANITIZE_OPTIONS
+
+```typescript
+const DEFAULT_INPUT_SANITIZE_OPTIONS: InputSanitizeOptions = {
+  allowUnicode: true,
+  maxLength: 0,
+  stripControl: true,
+  stripNull: true,
+  allowTab: true,
+  allowNewline: true,
+  replacementChar: '\uFFFD',
+};
+```
+
+## Functions
+
+### sanitizeTextInput
+
+Sanitizes untrusted text input by removing control characters, null bytes, and invalid sequences.
+
+```typescript
+function sanitizeTextInput(input: string, options?: Partial<InputSanitizeOptions>): string
+```
+
+```typescript
+import { sanitizeTextInput } from 'blecsd';
+
+const safe = sanitizeTextInput(userInput);
+
+const limited = sanitizeTextInput(userInput, {
+  maxLength: 100,
+  allowUnicode: false,
+});
+```
+
+### sanitizeTextInputDetailed
+
+Sanitizes text input and returns detailed metadata about changes.
+
+```typescript
+function sanitizeTextInputDetailed(
+  input: string,
+  options?: Partial<InputSanitizeOptions>,
+): SanitizeResult
+```
+
+```typescript
+import { sanitizeTextInputDetailed } from 'blecsd';
+
+const result = sanitizeTextInputDetailed(networkMessage, { maxLength: 256 });
+if (result.modified) {
+  console.warn(`Input sanitized: ${result.strippedCount} chars removed`);
+}
+```
+
+### stripNullBytes
+
+Strips all null bytes (0x00) from a string.
+
+```typescript
+function stripNullBytes(input: string): string
+```
+
+```typescript
+import { stripNullBytes } from 'blecsd';
+
+stripNullBytes('hello\x00world'); // 'helloworld'
+```
+
+### stripControlChars
+
+Strips C0 control characters (0x01-0x1F), optionally preserving tab and newline.
+
+```typescript
+function stripControlChars(input: string, allowTab?: boolean, allowNewline?: boolean): string
+```
+
+```typescript
+import { stripControlChars } from 'blecsd';
+
+stripControlChars('hello\x07world', true, true); // 'helloworld'
+```
+
+### stripC1Controls
+
+Strips C1 control characters (0x80-0x9F) from a string.
+
+```typescript
+function stripC1Controls(input: string): string
+```
+
+```typescript
+import { stripC1Controls } from 'blecsd';
+
+stripC1Controls('hello\x85world'); // 'helloworld'
+```
+
+### replaceInvalidUtf16
+
+Replaces lone surrogates (invalid UTF-16) with the replacement character.
+
+```typescript
+function replaceInvalidUtf16(input: string, replacement?: string): string
+```
+
+### restrictToAscii
+
+Restricts a string to printable ASCII characters (0x20-0x7E) plus tab, newline, and carriage return.
+
+```typescript
+function restrictToAscii(input: string, replacement?: string): string
+```
+
+```typescript
+import { restrictToAscii } from 'blecsd';
+
+restrictToAscii('cafe\u0301'); // 'caf\uFFFD'
+```
+
+### isValidUtf8String
+
+Validates that a string contains only valid UTF-8 compatible content.
+
+```typescript
+function isValidUtf8String(input: string): boolean
+```
+
+```typescript
+import { isValidUtf8String } from 'blecsd';
+
+isValidUtf8String('hello');       // true
+isValidUtf8String('hello\uD800'); // false (lone surrogate)
+```
+
+### hasControlChars
+
+Checks if a string contains any control characters (C0 or C1).
+
+```typescript
+function hasControlChars(input: string): boolean
+```
+
+### hasNullBytes
+
+Checks if a string contains null bytes.
+
+```typescript
+function hasNullBytes(input: string): boolean
+```
+
+## Zod Schema
+
+```typescript
+import { InputSanitizeOptionsSchema } from 'blecsd';
+
+const result = InputSanitizeOptionsSchema.safeParse({
+  maxLength: 256,
+  allowUnicode: true,
+});
+```
+
+## See Also
+
+- [Bracketed Paste](./bracketed-paste.md) - Paste event sanitization

--- a/docs/api/terminal/key-parser.md
+++ b/docs/api/terminal/key-parser.md
@@ -1,0 +1,153 @@
+# Key Parser
+
+Parses ANSI escape sequences into structured key events with strict typing. Handles regular characters, control characters, function keys, navigation keys, and modifier combinations.
+
+## Quick Start
+
+```typescript
+import {
+  parseKeySequence,
+  parseKeyBuffer,
+  isMouseSequence,
+} from 'blecsd';
+
+// Parse a single key sequence
+const event = parseKeySequence(Buffer.from([0x1b, 0x5b, 0x41]));
+if (event) {
+  console.log(event.name); // 'up'
+  console.log(event.ctrl); // false
+}
+
+// Parse Ctrl+C
+const ctrlC = parseKeySequence(Buffer.from([0x03]));
+console.log(ctrlC?.name); // 'c'
+console.log(ctrlC?.ctrl); // true
+
+// Parse multiple key sequences from one buffer
+const events = parseKeyBuffer(Buffer.from('abc'));
+console.log(events.length); // 3
+```
+
+## Types
+
+### KeyName
+
+All recognized key names, including letters (a-z), digits (0-9), function keys (f1-f12), navigation keys (up, down, left, right, home, end, pageup, pagedown, insert, delete, clear), special keys (return, enter, tab, backspace, escape, space), and punctuation/symbols.
+
+```typescript
+type KeyName =
+  | 'a' | 'b' | 'c' | /* ... */ | 'z'
+  | '0' | '1' | /* ... */ | '9'
+  | 'f1' | 'f2' | /* ... */ | 'f12'
+  | 'up' | 'down' | 'left' | 'right'
+  | 'home' | 'end' | 'pageup' | 'pagedown'
+  | 'insert' | 'delete' | 'clear'
+  | 'return' | 'enter' | 'tab' | 'backspace' | 'escape' | 'space'
+  | '!' | '@' | '#' | /* ... punctuation ... */
+  | 'undefined';
+```
+
+### KeyEvent
+
+Parsed keyboard event with modifiers.
+
+```typescript
+interface KeyEvent {
+  readonly sequence: string;     // Raw sequence string
+  readonly name: KeyName;        // Normalized key name
+  readonly ctrl: boolean;        // Ctrl modifier
+  readonly meta: boolean;        // Alt/Meta modifier
+  readonly shift: boolean;       // Shift modifier
+  readonly code?: string;        // Terminal-specific escape code
+  readonly raw: Uint8Array;      // Raw buffer data
+}
+```
+
+## Functions
+
+### parseKeySequence
+
+Parses a key sequence from a buffer. Handles regular characters, control characters (Ctrl+A through Ctrl+Z), function keys (F1-F12), navigation keys, modifier combinations, and special keys.
+
+```typescript
+function parseKeySequence(buffer: Uint8Array): KeyEvent | null
+```
+
+```typescript
+import { parseKeySequence } from 'blecsd';
+
+// Parse Ctrl+C
+const ctrlC = parseKeySequence(Buffer.from([0x03]));
+console.log(ctrlC?.name); // 'c'
+console.log(ctrlC?.ctrl); // true
+
+// Parse Up arrow
+const up = parseKeySequence(Buffer.from([0x1b, 0x5b, 0x41]));
+console.log(up?.name); // 'up'
+
+// Parse F1
+const f1 = parseKeySequence(Buffer.from([0x1b, 0x4f, 0x50]));
+console.log(f1?.name); // 'f1'
+```
+
+### parseKeyBuffer
+
+Parses multiple key sequences from a buffer. Handles cases where multiple keypresses arrive in a single read.
+
+```typescript
+function parseKeyBuffer(buffer: Uint8Array): readonly KeyEvent[]
+```
+
+```typescript
+import { parseKeyBuffer } from 'blecsd';
+
+const events = parseKeyBuffer(Buffer.from('abc'));
+console.log(events.length); // 3
+console.log(events[0].name); // 'a'
+console.log(events[1].name); // 'b'
+console.log(events[2].name); // 'c'
+```
+
+### isMouseSequence
+
+Checks if a buffer starts with a mouse sequence. Mouse sequences are handled separately by the mouse parser.
+
+```typescript
+function isMouseSequence(buffer: Uint8Array): boolean
+```
+
+## Supported Escape Sequences
+
+The parser recognizes sequences from multiple terminal types:
+
+| Sequence Type | Example | Key Name |
+|--------------|---------|----------|
+| xterm ESC O | ESC O P | f1 |
+| xterm ESC [ | ESC [ A | up |
+| xterm ESC [ ~ | ESC [ 15~ | f5 |
+| Cygwin ESC [[ | ESC [[ A | f1 |
+| rxvt shift | ESC [ a | up (shift) |
+| rxvt ctrl | ESC O a | up (ctrl) |
+| Meta+key | ESC a | a (meta) |
+| Control | 0x01-0x1a | Ctrl+a through Ctrl+z |
+
+### Modifier Encoding
+
+Modifier values follow the standard encoding: `1 + (shift * 1) + (alt * 2) + (ctrl * 4)`. For example, Ctrl+Shift+Up sends `ESC[1;6A`.
+
+## Zod Schema
+
+```typescript
+import { KeyEventSchema } from 'blecsd';
+
+const result = KeyEventSchema.safeParse(event);
+if (result.success) {
+  console.log('Valid key event');
+}
+```
+
+## See Also
+
+- [Mouse Parser](./mouse-parser.md) - Mouse event parsing
+- [Kitty Protocol](./kitty-protocol.md) - Modern keyboard protocol with key release events
+- [Bracketed Paste](./bracketed-paste.md) - Distinguishing pasted text from typed input

--- a/docs/api/terminal/kitty-protocol.md
+++ b/docs/api/terminal/kitty-protocol.md
@@ -1,0 +1,282 @@
+# Kitty Keyboard Protocol
+
+Implements the Kitty keyboard protocol for modern keyboard disambiguation with key release events. Provides progressive enhancement with legacy fallback, ESC vs Alt-key disambiguation, and rich modifier support (including Super, Hyper, CapsLock, NumLock).
+
+See the [Kitty keyboard protocol specification](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) for the full protocol reference.
+
+## Quick Start
+
+```typescript
+import {
+  KittyFlags,
+  generatePushSequence,
+  generatePopSequence,
+  generateQuerySequence,
+  parseKittyKeyEvent,
+  parseKittyQueryResponse,
+  kittyKeyToName,
+  createKittyConfig,
+  createKittyProtocolState,
+  activateProtocol,
+  deactivateProtocol,
+} from 'blecsd';
+
+// Enable Kitty keyboard protocol
+const flags = KittyFlags.DISAMBIGUATE | KittyFlags.REPORT_EVENTS;
+process.stdout.write(generatePushSequence(flags));
+
+// Parse incoming key events
+const event = parseKittyKeyEvent(buffer);
+if (event) {
+  const name = kittyKeyToName(event);
+  console.log(`${event.eventType}: ${name}`);
+  if (event.isRelease) {
+    console.log('Key released');
+  }
+}
+
+// Disable when done
+process.stdout.write(generatePopSequence());
+```
+
+## Types
+
+### KittyProtocolLevel
+
+Protocol enhancement level flags (can be combined with bitwise OR).
+
+```typescript
+type KittyProtocolLevel = 0 | 1 | 2 | 4 | 8 | 16;
+```
+
+### KittyFlags
+
+```typescript
+const KittyFlags = {
+  NONE: 0,             // Disabled (legacy mode)
+  DISAMBIGUATE: 1,     // Disambiguate escape codes
+  REPORT_EVENTS: 2,    // Report press/repeat/release
+  REPORT_ALTERNATE: 4, // Report alternate keys
+  REPORT_ALL: 8,       // Report all keys as escape codes
+  REPORT_TEXT: 16,     // Report associated text
+} as const;
+```
+
+### KittyEventType
+
+```typescript
+type KittyEventType = 'press' | 'repeat' | 'release';
+```
+
+### KittyModifiers
+
+Extended modifier information with left/right distinction.
+
+```typescript
+interface KittyModifiers {
+  readonly shift: boolean;
+  readonly alt: boolean;
+  readonly ctrl: boolean;
+  readonly super: boolean;
+  readonly hyper: boolean;
+  readonly meta: boolean;
+  readonly capsLock: boolean;
+  readonly numLock: boolean;
+}
+```
+
+### KittyKeyEvent
+
+Extended key event from the Kitty keyboard protocol.
+
+```typescript
+interface KittyKeyEvent {
+  readonly keyCode: number;                   // Unicode codepoint
+  readonly shiftedKey: number | undefined;    // Shifted key codepoint
+  readonly baseKey: number | undefined;       // Base layout key codepoint
+  readonly eventType: KittyEventType;
+  readonly isRepeat: boolean;
+  readonly isRelease: boolean;
+  readonly text: string;                      // Text produced by this key
+  readonly modifiers: KittyModifiers;
+  readonly rawParams: string;                 // Raw CSI parameters
+}
+```
+
+### KittyConfig
+
+```typescript
+interface KittyConfig {
+  readonly flags: number;       // Protocol flags (default: DISAMBIGUATE | REPORT_EVENTS)
+  readonly escTimeout: number;  // ESC disambiguation timeout in ms (default: 50)
+}
+```
+
+### KittyProtocolState
+
+```typescript
+interface KittyProtocolState {
+  readonly active: boolean;
+  readonly pushedFlags: number;
+  readonly detectedLevel: number | undefined;
+}
+```
+
+## Functions
+
+### Escape Sequence Generation
+
+#### generatePushSequence
+
+Generates the CSI sequence to enable (push) Kitty keyboard mode.
+
+```typescript
+function generatePushSequence(flags: number): string
+```
+
+```typescript
+import { generatePushSequence, KittyFlags } from 'blecsd';
+
+const seq = generatePushSequence(KittyFlags.DISAMBIGUATE | KittyFlags.REPORT_EVENTS);
+process.stdout.write(seq);
+```
+
+#### generatePopSequence
+
+Generates the CSI sequence to disable (pop) Kitty keyboard mode.
+
+```typescript
+function generatePopSequence(): string
+```
+
+#### generateQuerySequence
+
+Generates the CSI sequence to query the current keyboard mode.
+
+```typescript
+function generateQuerySequence(): string
+```
+
+### Parsing
+
+#### isKittyResponse
+
+Checks if a buffer contains a Kitty protocol query response.
+
+```typescript
+function isKittyResponse(buffer: Uint8Array): boolean
+```
+
+#### parseKittyQueryResponse
+
+Parses a query response to extract supported flags.
+
+```typescript
+function parseKittyQueryResponse(buffer: Uint8Array): number | undefined
+```
+
+```typescript
+import { parseKittyQueryResponse, KittyFlags } from 'blecsd';
+
+const flags = parseKittyQueryResponse(responseBuffer);
+if (flags !== undefined && (flags & KittyFlags.REPORT_EVENTS)) {
+  console.log('Key release events supported');
+}
+```
+
+#### isKittyKeyEvent
+
+Checks if a buffer contains a Kitty keyboard event (CSI ... u or CSI ... ~).
+
+```typescript
+function isKittyKeyEvent(buffer: Uint8Array): boolean
+```
+
+#### parseKittyKeyEvent
+
+Parses a Kitty keyboard event from a buffer.
+
+```typescript
+function parseKittyKeyEvent(buffer: Uint8Array): KittyKeyEvent | undefined
+```
+
+```typescript
+import { parseKittyKeyEvent } from 'blecsd';
+
+const event = parseKittyKeyEvent(buffer);
+if (event?.isRelease) {
+  console.log('Key released:', String.fromCodePoint(event.keyCode));
+}
+```
+
+#### kittyKeyToName
+
+Converts a Kitty key event to a human-readable key name. Handles special keys, function keys, keypad keys, modifier keys, and printable characters.
+
+```typescript
+function kittyKeyToName(event: KittyKeyEvent): string
+```
+
+```typescript
+import { parseKittyKeyEvent, kittyKeyToName } from 'blecsd';
+
+const event = parseKittyKeyEvent(buffer);
+if (event) console.log(kittyKeyToName(event)); // e.g., 'a', 'escape', 'f1'
+```
+
+### State Management
+
+#### createKittyConfig
+
+Creates a Kitty protocol configuration with defaults.
+
+```typescript
+function createKittyConfig(config?: Partial<KittyConfig>): KittyConfig
+```
+
+#### createKittyProtocolState
+
+Creates initial protocol state.
+
+```typescript
+function createKittyProtocolState(): KittyProtocolState
+```
+
+#### updateProtocolState
+
+Updates protocol state after a query response.
+
+```typescript
+function updateProtocolState(state: KittyProtocolState, detectedFlags: number): KittyProtocolState
+```
+
+#### activateProtocol
+
+Activates the protocol (after push sequence sent).
+
+```typescript
+function activateProtocol(state: KittyProtocolState, flags: number): KittyProtocolState
+```
+
+#### deactivateProtocol
+
+Deactivates the protocol (after pop sequence sent).
+
+```typescript
+function deactivateProtocol(state: KittyProtocolState): KittyProtocolState
+```
+
+### Detection
+
+#### isKittySupported
+
+Checks if Kitty keyboard protocol is supported based on capabilities.
+
+```typescript
+function isKittySupported(capabilities: { kittyKeyboard: number | false }): boolean
+```
+
+## See Also
+
+- [Key Parser](./key-parser.md) - Legacy ANSI key event parsing
+- [Capability Negotiation](./capability-negotiation.md) - Detecting terminal capabilities

--- a/docs/api/terminal/mouse-parser.md
+++ b/docs/api/terminal/mouse-parser.md
@@ -1,0 +1,194 @@
+# Mouse Parser
+
+Parses terminal mouse protocol escape sequences into structured events. Supports X10, SGR, URXVT, DEC, and VT300 protocols, plus terminal focus events.
+
+## Quick Start
+
+```typescript
+import {
+  parseMouseSequence,
+  isMouseBuffer,
+} from 'blecsd';
+
+// Parse an SGR mouse event
+const result = parseMouseSequence(Buffer.from('\x1b[<0;10;20M'));
+if (result?.type === 'mouse') {
+  console.log(result.event.x);      // 9 (0-indexed)
+  console.log(result.event.y);      // 19 (0-indexed)
+  console.log(result.event.button); // 'left'
+  console.log(result.event.action); // 'press'
+}
+
+// Parse a focus event
+const focus = parseMouseSequence(Buffer.from('\x1b[I'));
+if (focus?.type === 'focus') {
+  console.log(focus.event.focused); // true
+}
+```
+
+## Types
+
+### MouseButton
+
+```typescript
+type MouseButton = 'left' | 'middle' | 'right' | 'wheelUp' | 'wheelDown' | 'unknown';
+```
+
+### MouseAction
+
+```typescript
+type MouseAction = 'press' | 'release' | 'move' | 'wheel';
+```
+
+### MouseProtocol
+
+```typescript
+type MouseProtocol = 'x10' | 'sgr' | 'urxvt' | 'dec' | 'vt300';
+```
+
+### MouseEvent
+
+Parsed mouse event with position and modifiers.
+
+```typescript
+interface MouseEvent {
+  readonly x: number;              // 0-indexed column
+  readonly y: number;              // 0-indexed row
+  readonly button: MouseButton;
+  readonly action: MouseAction;
+  readonly ctrl: boolean;
+  readonly meta: boolean;
+  readonly shift: boolean;
+  readonly protocol: MouseProtocol;
+  readonly raw: Uint8Array;
+}
+```
+
+### FocusEvent
+
+Terminal focus gained/lost event.
+
+```typescript
+interface FocusEvent {
+  readonly focused: boolean;
+  readonly raw: Uint8Array;
+}
+```
+
+### ParseMouseResult
+
+Discriminated union returned by `parseMouseSequence`.
+
+```typescript
+type ParseMouseResult =
+  | { type: 'mouse'; event: MouseEvent }
+  | { type: 'focus'; event: FocusEvent }
+  | null;
+```
+
+## Functions
+
+### parseMouseSequence
+
+Parses a mouse or focus sequence from a buffer. Tries protocols in order: focus, SGR, X10, URXVT, DEC, VT300.
+
+```typescript
+function parseMouseSequence(buffer: Uint8Array): ParseMouseResult
+```
+
+```typescript
+import { parseMouseSequence } from 'blecsd';
+
+// SGR mouse press
+const result = parseMouseSequence(Buffer.from('\x1b[<0;10;20M'));
+if (result?.type === 'mouse') {
+  console.log(result.event.button); // 'left'
+  console.log(result.event.action); // 'press'
+}
+
+// Focus event
+const focus = parseMouseSequence(Buffer.from('\x1b[I'));
+if (focus?.type === 'focus') {
+  console.log(focus.event.focused); // true
+}
+```
+
+### isMouseBuffer
+
+Checks if a buffer contains a mouse sequence.
+
+```typescript
+function isMouseBuffer(buffer: Uint8Array): boolean
+```
+
+```typescript
+import { isMouseBuffer } from 'blecsd';
+
+const buffer = Buffer.from('\x1b[<0;10;20M');
+console.log(isMouseBuffer(buffer)); // true
+```
+
+## Protocol Details
+
+### X10/X11
+
+Format: `ESC [ M Cb Cx Cy`
+
+- Coordinates are encoded with +32 offset
+- Button 3 signals release (no button info on release)
+- Movement codes: 35, 39, 51, 43
+
+### SGR (most common modern protocol)
+
+Format: `ESC [ < Cb ; Cx ; Cy M/m`
+
+- `M` = press, `m` = release
+- Coordinates are 1-based (converted to 0-based)
+- Full button info on release
+
+### URXVT
+
+Format: `ESC [ Cb ; Cx ; Cy M`
+
+- Similar to X10 but with decimal encoding
+- Known bug: codes 128/129 on mousemove after wheel events
+
+### DEC Locator
+
+Format: `ESC [ < Cb ; Cx ; Cy ; page & w`
+
+- Different button encoding (2=left, 4=middle, 6=right, 3=release)
+- No modifier reporting
+
+### VT300 Locator
+
+Format: `ESC [ 24X ~ [ Cx , Cy ] CR`
+
+- Button X: 1=left, 2/3=middle, 5=right
+- No modifier reporting
+
+## Modifier Encoding
+
+Mouse modifier bits follow the X10 convention:
+
+| Bit | Modifier |
+|-----|----------|
+| 2 | Shift |
+| 3 | Meta/Alt |
+| 4 | Ctrl |
+
+## Zod Schemas
+
+```typescript
+import { MouseEventSchema, FocusEventSchema } from 'blecsd';
+
+const result = MouseEventSchema.safeParse(event);
+if (result.success) {
+  console.log('Valid mouse event');
+}
+```
+
+## See Also
+
+- [Key Parser](./key-parser.md) - Keyboard event parsing
+- [GPM Client](./gpm-client.md) - Linux console mouse support

--- a/docs/api/terminal/optimized-output.md
+++ b/docs/api/terminal/optimized-output.md
@@ -1,0 +1,307 @@
+# Optimized Output
+
+High-performance output buffering with escape sequence optimization. Batches terminal output and removes redundant escape sequences for efficient rendering.
+
+Key optimizations:
+- Single `write()` call per frame
+- Cursor position tracking to skip unnecessary moves
+- Color state deduplication
+- Escape sequence coalescing
+- Synchronized output support
+
+## Quick Start
+
+```typescript
+import {
+  createOutputBuffer,
+  writeCellAt,
+  writeStringAt,
+  flushToStream,
+  getOutputStats,
+  beginFrame,
+  endFrame,
+  DEFAULT_COLOR,
+} from 'blecsd';
+
+const buffer = createOutputBuffer({ syncMode: true, trackStats: true });
+
+// Begin synchronized frame
+beginFrame(buffer);
+
+// Write cells with automatic optimization
+writeCellAt(buffer, 0, 0, 'H', 0xff0000, 0x000000);
+writeCellAt(buffer, 1, 0, 'i', 0xff0000, 0x000000); // Same colors: no color reset emitted
+
+// Write a string
+writeStringAt(buffer, 0, 1, 'Hello World', 0x00ff00, DEFAULT_COLOR);
+
+// End frame and flush
+endFrame(buffer);
+flushToStream(buffer, process.stdout);
+
+// Check optimization stats
+const stats = getOutputStats(buffer);
+console.log(`Saved ${stats.bytesSaved} bytes via optimization`);
+```
+
+## Types
+
+### OutputBufferOptions
+
+```typescript
+interface OutputBufferOptions {
+  readonly initialCapacity?: number;  // Initial buffer capacity (default: 8192)
+  readonly syncMode?: boolean;        // Enable synchronized output (default: true)
+  readonly trackStats?: boolean;      // Track statistics (default: false)
+}
+```
+
+### ColorState
+
+```typescript
+interface ColorState {
+  fg: number;     // Current foreground (24-bit RGB or -1 for default)
+  bg: number;     // Current background (24-bit RGB or -1 for default)
+  attrs: number;  // Current text attributes
+}
+```
+
+### OutputStats
+
+```typescript
+interface OutputStats {
+  cellsWritten: number;
+  cursorMoves: number;
+  cursorMovesSkipped: number;
+  colorChanges: number;
+  colorChangesSkipped: number;
+  bytesWritten: number;
+  bytesSaved: number;
+}
+```
+
+### OutputBufferData
+
+The output buffer state object. Created by `createOutputBuffer`.
+
+### Text Attribute Flags
+
+```typescript
+import {
+  ATTR_BOLD,
+  ATTR_DIM,
+  ATTR_ITALIC,
+  ATTR_UNDERLINE,
+  ATTR_BLINK,
+  ATTR_INVERSE,
+  ATTR_HIDDEN,
+  ATTR_STRIKETHROUGH,
+  DEFAULT_COLOR,
+} from 'blecsd';
+
+// Combine attributes with bitwise OR
+const attrs = ATTR_BOLD | ATTR_UNDERLINE;
+```
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `ATTR_BOLD` | `1` | Bold text |
+| `ATTR_DIM` | `2` | Dim text |
+| `ATTR_ITALIC` | `4` | Italic text |
+| `ATTR_UNDERLINE` | `8` | Underlined text |
+| `ATTR_BLINK` | `16` | Blinking text |
+| `ATTR_INVERSE` | `32` | Inverse colors |
+| `ATTR_HIDDEN` | `64` | Hidden text |
+| `ATTR_STRIKETHROUGH` | `128` | Strikethrough text |
+| `DEFAULT_COLOR` | `-1` | Reset to default color |
+
+## Functions
+
+### Buffer Creation
+
+#### createOutputBuffer
+
+Creates a new optimized output buffer.
+
+```typescript
+function createOutputBuffer(options?: OutputBufferOptions): OutputBufferData
+```
+
+#### setScreenSize
+
+Sets the screen dimensions for line wrap calculations.
+
+```typescript
+function setScreenSize(buffer: OutputBufferData, width: number, height: number): void
+```
+
+### Writing
+
+#### writeCellAt
+
+Writes a character at a specific position with colors and attributes. Combines cursor movement and character output with optimization.
+
+```typescript
+function writeCellAt(
+  buffer: OutputBufferData,
+  x: number, y: number,
+  char: string,
+  fg?: number, bg?: number, attrs?: number,
+): void
+```
+
+#### writeStringAt
+
+Writes a string at a specific position.
+
+```typescript
+function writeStringAt(
+  buffer: OutputBufferData,
+  x: number, y: number,
+  text: string,
+  fg?: number, bg?: number, attrs?: number,
+): void
+```
+
+#### writeChar
+
+Writes a character at the current cursor position.
+
+```typescript
+function writeChar(buffer: OutputBufferData, char: string): void
+```
+
+#### writeRaw
+
+Writes raw content to the buffer without optimization. Use sparingly for special escape sequences.
+
+```typescript
+function writeRaw(buffer: OutputBufferData, content: string): void
+```
+
+### Cursor
+
+#### moveCursor
+
+Moves cursor to position, skipping if already there. Uses optimized single-axis moves when possible.
+
+```typescript
+function moveCursor(buffer: OutputBufferData, x: number, y: number): void
+```
+
+#### hideCursor / showCursor
+
+```typescript
+function hideCursor(buffer: OutputBufferData): void
+function showCursor(buffer: OutputBufferData): void
+```
+
+### Color and Attributes
+
+#### setForeground / setBackground
+
+Sets foreground or background color, skipping if already set.
+
+```typescript
+function setForeground(buffer: OutputBufferData, color: number): void
+function setBackground(buffer: OutputBufferData, color: number): void
+```
+
+#### setAttributes
+
+Sets text attributes, only changing what differs.
+
+```typescript
+function setAttributes(buffer: OutputBufferData, attrs: number): void
+```
+
+#### resetColorState
+
+Resets the color state to defaults.
+
+```typescript
+function resetColorState(buffer: OutputBufferData): void
+```
+
+### Frame Management
+
+#### beginFrame / endFrame
+
+Begins or ends a synchronized output frame.
+
+```typescript
+function beginFrame(buffer: OutputBufferData): void
+function endFrame(buffer: OutputBufferData): void
+```
+
+### Clearing
+
+```typescript
+function clearScreen(buffer: OutputBufferData): void
+function clearToEnd(buffer: OutputBufferData): void
+function clearLine(buffer: OutputBufferData): void
+```
+
+### Flushing and Reset
+
+#### flushToStream
+
+Flushes the buffer to a writable stream as a single `write()` call.
+
+```typescript
+function flushToStream(buffer: OutputBufferData, stream: Writable): void
+```
+
+#### clearBuffer
+
+Clears the buffer without flushing.
+
+```typescript
+function clearBuffer(buffer: OutputBufferData): void
+```
+
+#### resetBuffer
+
+Resets the buffer state completely (chunks, cursor position, color state).
+
+```typescript
+function resetBuffer(buffer: OutputBufferData): void
+```
+
+### Statistics
+
+#### getOutputStats
+
+Gets current buffer statistics.
+
+```typescript
+function getOutputStats(buffer: OutputBufferData): Readonly<OutputStats>
+```
+
+#### resetStats
+
+Resets buffer statistics.
+
+```typescript
+function resetStats(buffer: OutputBufferData): void
+```
+
+#### estimateBytesSaved
+
+Estimates bytes saved by optimization.
+
+```typescript
+function estimateBytesSaved(buffer: OutputBufferData): number
+```
+
+#### getContents / getBufferLength
+
+```typescript
+function getContents(buffer: OutputBufferData): string
+function getBufferLength(buffer: OutputBufferData): number
+```
+
+## See Also
+
+- [GPU Probe](./gpu-probe.md) - Detecting GPU-accelerated terminals
+- [Colors](./colors.md) - Color system for terminal rendering

--- a/docs/api/terminal/throttled-resize.md
+++ b/docs/api/terminal/throttled-resize.md
@@ -1,0 +1,136 @@
+# Throttled Resize
+
+Wraps the base resize handler with throttling and debouncing to prevent overwhelming the system during rapid terminal resize events (e.g., dragging the terminal edge).
+
+Strategy:
+- Throttle resize events to a maximum rate (default 30/sec)
+- During rapid resize: update dimensions only (skip full relayout)
+- On resize end (debounce): perform full relayout
+
+## Quick Start
+
+```typescript
+import {
+  createThrottledResize,
+  throttleResize,
+  debounceResize,
+} from 'blecsd';
+
+// Full throttled resize handler with ECS world integration
+const handler = createThrottledResize(world, (width, height, isFinal) => {
+  if (isFinal) {
+    performFullLayout(world);
+  } else {
+    updateDimensions(width, height);
+  }
+}, { maxRate: 30, debounceMs: 150 });
+
+// Clean up
+handler.dispose();
+```
+
+## Types
+
+### ThrottledResizeConfig
+
+```typescript
+interface ThrottledResizeConfig {
+  readonly maxRate: number;            // Max events per second (default: 30)
+  readonly debounceMs: number;         // Debounce delay before full relayout (default: 150)
+  readonly showIntermediate: boolean;  // Show intermediate state during resize (default: true)
+}
+```
+
+### ThrottledResizeState
+
+```typescript
+interface ThrottledResizeState {
+  readonly world: World;
+  readonly config: ThrottledResizeConfig;
+  readonly isResizing: boolean;
+  readonly lastWidth: number;
+  readonly lastHeight: number;
+  dispose(): void;
+}
+```
+
+### ResizeCallback
+
+```typescript
+type ResizeCallback = (width: number, height: number, isFinal: boolean) => void;
+```
+
+## Functions
+
+### createThrottledResize
+
+Creates a throttled resize handler that listens to SIGWINCH. During rapid resize, emits intermediate callbacks at a throttled rate. After resize stops (debounce), emits a final callback for full relayout.
+
+```typescript
+function createThrottledResize(
+  world: World,
+  onResize: ResizeCallback,
+  config?: Partial<ThrottledResizeConfig>,
+): ThrottledResizeState
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `world` | `World` | The ECS world |
+| `onResize` | `ResizeCallback` | Callback for resize events (intermediate and final) |
+| `config` | `Partial<ThrottledResizeConfig>` | Optional configuration |
+
+```typescript
+import { createThrottledResize } from 'blecsd';
+
+const handler = createThrottledResize(world, (width, height, isFinal) => {
+  if (isFinal) {
+    performFullLayout(world);
+  } else {
+    updateDimensions(width, height);
+  }
+}, { maxRate: 30, debounceMs: 150 });
+
+// Clean up when done
+handler.dispose();
+```
+
+### throttleResize
+
+Creates a simple throttle function for resize events. Useful when you need just the throttling without the full handler.
+
+```typescript
+function throttleResize<T extends (...args: unknown[]) => void>(fn: T, maxRate: number): T
+```
+
+```typescript
+import { throttleResize } from 'blecsd';
+
+const throttledRender = throttleResize(render, 30);
+process.stdout.on('resize', throttledRender);
+```
+
+### debounceResize
+
+Creates a debounced resize handler that waits for resize to stop.
+
+```typescript
+function debounceResize<T extends (...args: unknown[]) => void>(
+  fn: T,
+  delayMs: number,
+): { fn: T; cancel: () => void }
+```
+
+```typescript
+import { debounceResize } from 'blecsd';
+
+const { fn: debouncedLayout, cancel } = debounceResize(fullRelayout, 150);
+process.stdout.on('resize', debouncedLayout);
+
+// Clean up
+cancel();
+```
+
+## See Also
+
+- [Resize](./resize.md) - Base resize event handling

--- a/docs/api/utils/change-coalescing.md
+++ b/docs/api/utils/change-coalescing.md
@@ -1,0 +1,211 @@
+# Change Coalescing
+
+Batches multiple text changes within a single frame into a single re-layout/re-render, eliminating per-keystroke rendering during fast typing or streaming input.
+
+## Import
+
+```typescript
+import {
+  createCoalescer,
+  queueChange,
+  flushChanges,
+  getCoalescingState,
+  insertChange,
+  deleteChange,
+  replaceChange,
+  destroyCoalescer,
+} from 'blecsd';
+```
+
+## Types
+
+### TextChange
+
+A single text change operation.
+
+```typescript
+interface TextChange {
+  readonly startLine: number;
+  readonly startColumn: number;
+  readonly endLine: number;
+  readonly endColumn: number;
+  readonly text: string;
+  readonly timestamp: number;
+}
+```
+
+### DirtyRegion
+
+A coalesced dirty region representing the union of changes.
+
+```typescript
+interface DirtyRegion {
+  readonly startLine: number;
+  readonly endLine: number;
+  readonly lineCountChanged: boolean;
+  readonly lineDelta: number;
+}
+```
+
+### CoalescingConfig
+
+Configuration for change coalescing.
+
+```typescript
+interface CoalescingConfig {
+  readonly maxDelayMs: number;       // Default: 16 (~1 frame at 60fps)
+  readonly maxBatchSize: number;     // Default: 100
+  readonly immediateCursor: boolean; // Default: true
+}
+```
+
+### FlushResult
+
+Result of flushing coalesced changes.
+
+```typescript
+interface FlushResult {
+  readonly dirtyRegion: DirtyRegion;
+  readonly changeCount: number;
+  readonly timeSpanMs: number;
+  readonly changes: readonly TextChange[];
+}
+```
+
+### CoalescingState
+
+Read-only snapshot of the coalescer state.
+
+```typescript
+interface CoalescingState {
+  readonly config: CoalescingConfig;
+  readonly pendingCount: number;
+  readonly flushScheduled: boolean;
+  readonly totalProcessed: number;
+  readonly totalFlushes: number;
+  readonly avgChangesPerFlush: number;
+}
+```
+
+## Functions
+
+### createCoalescer
+
+Creates a change coalescer that batches text changes.
+
+```typescript
+function createCoalescer(
+  onFlush: (result: FlushResult) => void,
+  config?: Partial<CoalescingConfig>,
+): MutableCoalescingState
+```
+
+**Parameters:**
+- `onFlush` - Callback invoked when changes are flushed
+- `config` - Optional configuration overrides
+
+**Returns:** Opaque coalescer state handle
+
+### queueChange
+
+Queues a text change for coalescing. Flushes immediately if the batch size limit is reached, otherwise schedules a flush after `maxDelayMs`.
+
+```typescript
+function queueChange(state: MutableCoalescingState, change: TextChange): void
+```
+
+**Parameters:**
+- `state` - The coalescer state
+- `change` - The text change to queue
+
+### flushChanges
+
+Forces an immediate flush of all pending changes.
+
+```typescript
+function flushChanges(state: MutableCoalescingState): FlushResult | undefined
+```
+
+**Parameters:**
+- `state` - The coalescer state
+
+**Returns:** The flush result, or `undefined` if no changes were pending
+
+### getCoalescingState
+
+Gets a read-only snapshot of the coalescer state.
+
+```typescript
+function getCoalescingState(state: MutableCoalescingState): CoalescingState
+```
+
+**Parameters:**
+- `state` - The coalescer state
+
+**Returns:** State snapshot
+
+### insertChange
+
+Creates a `TextChange` for an insertion at the given position.
+
+```typescript
+function insertChange(line: number, column: number, text: string): TextChange
+```
+
+### deleteChange
+
+Creates a `TextChange` for a deletion spanning the given range.
+
+```typescript
+function deleteChange(
+  startLine: number, startColumn: number,
+  endLine: number, endColumn: number,
+): TextChange
+```
+
+### replaceChange
+
+Creates a `TextChange` for a replacement spanning the given range.
+
+```typescript
+function replaceChange(
+  startLine: number, startColumn: number,
+  endLine: number, endColumn: number,
+  text: string,
+): TextChange
+```
+
+### destroyCoalescer
+
+Destroys the coalescer, flushing any remaining changes and removing the callback.
+
+```typescript
+function destroyCoalescer(state: MutableCoalescingState): FlushResult | undefined
+```
+
+**Returns:** Final flush result if there were pending changes
+
+## Usage
+
+```typescript
+import { createCoalescer, queueChange, insertChange } from 'blecsd';
+
+const coalescer = createCoalescer((result) => {
+  console.log(`Flushing ${result.changeCount} changes`);
+  console.log(`Dirty region: lines ${result.dirtyRegion.startLine}-${result.dirtyRegion.endLine}`);
+  rerender(result.dirtyRegion);
+});
+
+// Fast typing: multiple changes coalesced into one flush
+queueChange(coalescer, insertChange(0, 5, 'a'));
+queueChange(coalescer, insertChange(0, 6, 'b'));
+queueChange(coalescer, insertChange(0, 7, 'c'));
+// All three changes are batched into a single flush callback
+```
+
+---
+
+## Related
+
+- [Virtualized Line Store](./virtualized-line-store.md) - Large text content storage
+- [Cursor Navigation](./cursor-navigation.md) - Cursor/viewport management

--- a/docs/api/utils/component-storage.md
+++ b/docs/api/utils/component-storage.md
@@ -1,0 +1,183 @@
+# Component Storage
+
+Memory-efficient component storage utilities for measuring, optimizing, and managing memory for large entity counts in the ECS.
+
+## Import
+
+```typescript
+import {
+  createSparseStore,
+  createTypedArrayPool,
+  estimateMemoryUsage,
+  getComponentMemoryReport,
+  isWithinMemoryBounds,
+} from 'blecsd';
+```
+
+## Types
+
+### ComponentMemoryReport
+
+Memory usage report for component storage.
+
+```typescript
+interface ComponentMemoryReport {
+  readonly totalBytes: number;
+  readonly componentBytes: ReadonlyMap<string, number>;
+  readonly entityCount: number;
+  readonly avgBytesPerEntity: number;
+  readonly efficiency: number;
+}
+```
+
+### SparseStorageConfig
+
+Configuration for sparse component storage.
+
+```typescript
+interface SparseStorageConfig {
+  readonly initialCapacity: number;  // Default: 64
+  readonly growthFactor: number;     // Default: 2
+  readonly maxCapacity: number;      // Default: 100000
+}
+```
+
+### SparseStore\<T\>
+
+A sparse component store backed by a Map, suitable for components used by a small fraction of entities.
+
+```typescript
+interface SparseStore<T> {
+  get(eid: Entity): T | undefined;
+  set(eid: Entity, value: T): void;
+  has(eid: Entity): boolean;
+  delete(eid: Entity): boolean;
+  readonly size: number;
+  entries(): IterableIterator<[Entity, T]>;
+  clear(): void;
+  memoryUsage(): number;
+}
+```
+
+### TypedArrayPool
+
+Pre-allocated typed array pool for Structure-of-Arrays components. Reduces GC pressure from repeated allocation.
+
+```typescript
+interface TypedArrayPool {
+  allocateF32(size: number): Float32Array;
+  allocateU32(size: number): Uint32Array;
+  allocateU8(size: number): Uint8Array;
+  release(arr: ArrayBufferView): void;
+  readonly totalAllocated: number;
+  readonly totalFree: number;
+  reset(): void;
+}
+```
+
+## Functions
+
+### createSparseStore
+
+Creates a sparse component store backed by a Map. Ideal for components present on less than 10% of entities.
+
+```typescript
+function createSparseStore<T>(config?: Partial<SparseStorageConfig>): SparseStore<T>
+```
+
+**Parameters:**
+- `config` - Optional configuration
+
+**Returns:** A new sparse store
+
+### createTypedArrayPool
+
+Creates a typed array pool for pre-allocation. Arrays are bucketed by power-of-2 sizes and recycled on release.
+
+```typescript
+function createTypedArrayPool(): TypedArrayPool
+```
+
+**Returns:** A new typed array pool
+
+### estimateMemoryUsage
+
+Estimates memory usage for a given entity count with standard components.
+
+```typescript
+function estimateMemoryUsage(
+  entityCount: number,
+  componentCount: number,
+  bytesPerComponent?: number,   // Default: 4 (f32)
+  fieldsPerComponent?: number,  // Default: 4
+): number
+```
+
+**Parameters:**
+- `entityCount` - Number of entities to estimate for
+- `componentCount` - Average number of components per entity
+- `bytesPerComponent` - Average bytes per component field
+- `fieldsPerComponent` - Average fields per component
+
+**Returns:** Estimated memory in bytes
+
+### getComponentMemoryReport
+
+Generates a component memory report from actual typed arrays.
+
+```typescript
+function getComponentMemoryReport(
+  world: World,
+  components: Record<string, Record<string, ArrayLike<number>>>,
+): ComponentMemoryReport
+```
+
+**Parameters:**
+- `world` - The ECS world
+- `components` - Named components to measure
+
+**Returns:** Memory report
+
+### isWithinMemoryBounds
+
+Checks if entity count is within safe memory bounds.
+
+```typescript
+function isWithinMemoryBounds(
+  entityCount: number,
+  maxMemoryMB?: number,              // Default: 100
+  avgComponentsPerEntity?: number,   // Default: 5
+): boolean
+```
+
+**Returns:** Whether the entity count is within bounds
+
+## Usage
+
+```typescript
+import { createSparseStore, createTypedArrayPool, estimateMemoryUsage } from 'blecsd';
+
+// Sparse store for debug labels (only some entities have them)
+const debugInfo = createSparseStore<{ label: string }>();
+debugInfo.set(playerEid, { label: 'Player' });
+debugInfo.set(bossEid, { label: 'Boss' });
+console.log(debugInfo.size);           // 2
+console.log(debugInfo.memoryUsage());  // estimated bytes
+
+// Typed array pool for reducing allocations
+const pool = createTypedArrayPool();
+const positions = pool.allocateF32(10000);
+// ... use positions ...
+pool.release(positions);
+console.log(pool.totalFree);  // bytes available for reuse
+
+// Memory estimation
+const bytes = estimateMemoryUsage(100000, 5);
+console.log(`~${(bytes / 1024 / 1024).toFixed(1)}MB for 100K entities`);
+```
+
+---
+
+## Related
+
+- [Unicode](./unicode.md) - Unicode character width utilities

--- a/docs/api/utils/cursor-navigation.md
+++ b/docs/api/utils/cursor-navigation.md
@@ -1,0 +1,275 @@
+# Cursor Navigation
+
+Cursor/caret navigation for large documents with O(log n) line lookup via binary search indexing, cursor-first viewport management, and instant page/document navigation.
+
+## Import
+
+```typescript
+import {
+  buildLineIndex,
+  buildLineIndexFromLengths,
+  lineForOffset,
+  offsetForLine,
+  createCursor,
+  createViewport,
+  createNavConfig,
+  ensureCursorVisible,
+  clampCursor,
+  moveCursorUp,
+  moveCursorDown,
+  moveCursorLeft,
+  moveCursorRight,
+  goToLine,
+  pageUp,
+  pageDown,
+  goToStart,
+  goToEnd,
+} from 'blecsd';
+```
+
+## Types
+
+### CursorPosition
+
+```typescript
+interface CursorPosition {
+  readonly line: number;    // 0-based
+  readonly column: number;  // 0-based
+}
+```
+
+### ViewportState
+
+```typescript
+interface ViewportState {
+  readonly topLine: number;     // First visible line (0-based)
+  readonly height: number;      // Visible line count
+  readonly leftColumn: number;  // First visible column
+  readonly width: number;       // Visible width in columns
+}
+```
+
+### CursorNavConfig
+
+```typescript
+interface CursorNavConfig {
+  readonly scrollPadding: number;      // Default: 5
+  readonly horizontalPadding: number;  // Default: 5
+  readonly lineWrap: boolean;          // Default: true
+  readonly tabWidth: number;           // Default: 4
+}
+```
+
+### LineIndex
+
+A line index for O(log n) line lookups by byte offset.
+
+```typescript
+interface LineIndex {
+  readonly offsets: readonly number[];
+  readonly lineCount: number;
+}
+```
+
+### NavigationResult
+
+```typescript
+interface NavigationResult {
+  readonly cursor: CursorPosition;
+  readonly viewport: ViewportState;
+  readonly scrolled: boolean;
+}
+```
+
+## Functions
+
+### buildLineIndex
+
+Builds a line index from text content for O(log n) lookups.
+
+```typescript
+function buildLineIndex(text: string): LineIndex
+```
+
+**Parameters:**
+- `text` - The full document text
+
+**Returns:** A line index structure
+
+### buildLineIndexFromLengths
+
+Builds a line index from an array of line lengths. More efficient when line lengths are already known.
+
+```typescript
+function buildLineIndexFromLengths(lineLengths: readonly number[]): LineIndex
+```
+
+### lineForOffset
+
+Finds the line number for a given byte offset using binary search. O(log n).
+
+```typescript
+function lineForOffset(index: LineIndex, offset: number): number
+```
+
+### offsetForLine
+
+Gets the byte offset for the start of a line.
+
+```typescript
+function offsetForLine(index: LineIndex, line: number): number
+```
+
+**Returns:** Byte offset, or -1 if out of range
+
+### createCursor
+
+Creates a cursor position, clamped to non-negative values.
+
+```typescript
+function createCursor(line?: number, column?: number): CursorPosition
+```
+
+### createViewport
+
+Creates a viewport state with sensible defaults.
+
+```typescript
+function createViewport(
+  topLine?: number,     // Default: 0
+  height?: number,      // Default: 24
+  leftColumn?: number,  // Default: 0
+  width?: number,       // Default: 80
+): ViewportState
+```
+
+### createNavConfig
+
+Creates a navigation config with defaults.
+
+```typescript
+function createNavConfig(config?: Partial<CursorNavConfig>): CursorNavConfig
+```
+
+### ensureCursorVisible
+
+Adjusts the viewport to ensure the cursor is visible, applying scroll padding.
+
+```typescript
+function ensureCursorVisible(
+  cursor: CursorPosition,
+  viewport: ViewportState,
+  totalLines: number,
+  config?: Partial<CursorNavConfig>,
+): { viewport: ViewportState; scrolled: boolean }
+```
+
+### clampCursor
+
+Clamps a cursor position within document bounds.
+
+```typescript
+function clampCursor(
+  cursor: CursorPosition,
+  totalLines: number,
+  getLineLength: (line: number) => number,
+): CursorPosition
+```
+
+### moveCursorUp / moveCursorDown
+
+Moves cursor vertically by a given number of lines.
+
+```typescript
+function moveCursorUp(
+  cursor: CursorPosition, lines: number,
+  viewport: ViewportState, totalLines: number,
+  config?: Partial<CursorNavConfig>,
+): NavigationResult
+
+function moveCursorDown(
+  cursor: CursorPosition, lines: number,
+  viewport: ViewportState, totalLines: number,
+  config?: Partial<CursorNavConfig>,
+): NavigationResult
+```
+
+### moveCursorLeft / moveCursorRight
+
+Moves cursor horizontally. Wraps to adjacent lines when `lineWrap` is enabled.
+
+```typescript
+function moveCursorLeft(
+  cursor: CursorPosition, columns: number,
+  viewport: ViewportState, totalLines: number,
+  getLineLength: (line: number) => number,
+  config?: Partial<CursorNavConfig>,
+): NavigationResult
+
+function moveCursorRight(
+  cursor: CursorPosition, columns: number,
+  viewport: ViewportState, totalLines: number,
+  getLineLength: (line: number) => number,
+  config?: Partial<CursorNavConfig>,
+): NavigationResult
+```
+
+### goToLine
+
+Jumps to a specific line using O(1) direct jump.
+
+```typescript
+function goToLine(
+  targetLine: number,
+  viewport: ViewportState,
+  totalLines: number,
+  config?: Partial<CursorNavConfig>,
+): NavigationResult
+```
+
+### pageUp / pageDown
+
+Moves cursor by one viewport height.
+
+```typescript
+function pageUp(cursor: CursorPosition, viewport: ViewportState, totalLines: number, config?: Partial<CursorNavConfig>): NavigationResult
+function pageDown(cursor: CursorPosition, viewport: ViewportState, totalLines: number, config?: Partial<CursorNavConfig>): NavigationResult
+```
+
+### goToStart / goToEnd
+
+Jumps to the beginning or end of the document.
+
+```typescript
+function goToStart(viewport: ViewportState, totalLines: number, config?: Partial<CursorNavConfig>): NavigationResult
+function goToEnd(viewport: ViewportState, totalLines: number, config?: Partial<CursorNavConfig>): NavigationResult
+```
+
+## Usage
+
+```typescript
+import {
+  buildLineIndex, lineForOffset, createCursor, createViewport,
+  ensureCursorVisible, goToLine,
+} from 'blecsd';
+
+// Build a line index for fast offset-to-line lookups
+const index = buildLineIndex('hello\nworld\nfoo');
+lineForOffset(index, 7); // 1 (within "world")
+
+// Cursor and viewport management
+const cursor = createCursor(100, 0);
+const viewport = createViewport(0, 40);
+const { viewport: newVp, scrolled } = ensureCursorVisible(cursor, viewport, 10000);
+
+// Instant jump to any line in a million-line document
+const result = goToLine(999999, viewport, 1000000);
+```
+
+---
+
+## Related
+
+- [Change Coalescing](./change-coalescing.md) - Batching text changes
+- [Fold Regions](./fold-regions.md) - Collapsible document regions
+- [Virtualized Line Store](./virtualized-line-store.md) - Large text content storage

--- a/docs/api/utils/diff-render.md
+++ b/docs/api/utils/diff-render.md
@@ -1,0 +1,326 @@
+# Diff Render
+
+Fast diff computation and rendering for large changesets, with unified and side-by-side views, collapsible unchanged regions, and virtualized output.
+
+## Import
+
+```typescript
+import {
+  computeDiff,
+  computeDiffLazy,
+  computeDiffCached,
+  createDiffCache,
+  clearDiffCache,
+  expandChunk,
+  collapseChunk,
+  toggleChunk,
+  expandAll,
+  collapseUnchanged,
+  getVisibleDiffLines,
+  getTotalLineCount,
+  getSideBySideView,
+  toUnifiedDiff,
+  parseUnifiedDiff,
+  getDiffStats,
+  DEFAULT_CONTEXT,
+  DEFAULT_COLLAPSE_THRESHOLD,
+} from 'blecsd';
+```
+
+## Types
+
+### DiffType
+
+```typescript
+type DiffType = 'add' | 'remove' | 'context' | 'header';
+```
+
+### DiffLine
+
+A single line in a diff.
+
+```typescript
+interface DiffLine {
+  readonly type: DiffType;
+  readonly content: string;
+  readonly oldLineNo?: number;
+  readonly newLineNo?: number;
+}
+```
+
+### DiffChunk
+
+A chunk/hunk in a diff.
+
+```typescript
+interface DiffChunk {
+  readonly id: number;
+  readonly oldStart: number;
+  readonly oldCount: number;
+  readonly newStart: number;
+  readonly newCount: number;
+  readonly lines: readonly DiffLine[];
+  collapsed: boolean;
+  readonly contextBefore: number;
+  readonly contextAfter: number;
+}
+```
+
+### DiffResult
+
+Full diff result.
+
+```typescript
+interface DiffResult {
+  readonly chunks: readonly DiffChunk[];
+  readonly additions: number;
+  readonly deletions: number;
+  readonly contextLines: number;
+  readonly computeTimeMs: number;
+}
+```
+
+### DiffConfig
+
+```typescript
+interface DiffConfig {
+  readonly contextLines: number;        // Context lines around changes (default: 3)
+  readonly collapseThreshold: number;   // Collapse unchanged regions above this (default: 10)
+  readonly initiallyCollapsed: boolean; // Start with unchanged regions collapsed
+}
+```
+
+### DiffCache
+
+```typescript
+interface DiffCache {
+  oldHash: number;
+  newHash: number;
+  result: DiffResult | null;
+  readonly expandedChunks: Set<number>;
+}
+```
+
+### SideBySideLine
+
+```typescript
+interface SideBySideLine {
+  readonly left?: SideBySideEntry<'remove' | 'context'>;
+  readonly right?: SideBySideEntry<'add' | 'context'>;
+}
+
+interface SideBySideEntry<T extends SideBySideEntryType = SideBySideEntryType> {
+  readonly lineNo: number;
+  readonly content: string;
+  readonly type: T;
+}
+```
+
+### VisibleDiff
+
+```typescript
+interface VisibleDiff {
+  readonly lines: readonly DiffLine[];
+  readonly startIndex: number;
+  readonly totalLines: number;
+  readonly chunkInfo: readonly { chunkId: number; collapsed: boolean }[];
+}
+```
+
+## Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DEFAULT_CONTEXT` | 3 | Default context lines around changes |
+| `DEFAULT_COLLAPSE_THRESHOLD` | 10 | Collapse unchanged regions larger than this |
+
+## Functions
+
+### computeDiff
+
+Computes the diff between two texts. Uses Myers' algorithm for large inputs (O((N+M)D)) and LCS for small inputs.
+
+```typescript
+function computeDiff(
+  oldText: string,
+  newText: string,
+  config?: Partial<DiffConfig>,
+): DiffResult
+```
+
+**Parameters:**
+- `oldText` - Original text
+- `newText` - Modified text
+- `config` - Diff configuration
+
+**Returns:** Diff result with chunks and stats.
+
+**Example:**
+```typescript
+import { computeDiff } from 'blecsd';
+
+const result = computeDiff(
+  'line 1\nline 2\nline 3',
+  'line 1\nmodified\nline 3',
+);
+console.log(result.additions);  // 1
+console.log(result.deletions);  // 1
+```
+
+### computeDiffLazy
+
+Computes diff lazily (currently delegates to `computeDiff`). Intended for very large inputs.
+
+```typescript
+function computeDiffLazy(
+  oldText: string,
+  newText: string,
+  batchSize?: number,
+): DiffResult
+```
+
+### createDiffCache / clearDiffCache
+
+Creates and clears the diff cache.
+
+```typescript
+function createDiffCache(): DiffCache
+function clearDiffCache(cache: DiffCache): void
+```
+
+### computeDiffCached
+
+Computes diff with caching. Returns cached result when inputs have not changed.
+
+```typescript
+function computeDiffCached(
+  cache: DiffCache,
+  oldText: string,
+  newText: string,
+  config?: Partial<DiffConfig>,
+): DiffResult
+```
+
+### Chunk Operations
+
+#### expandChunk / collapseChunk / toggleChunk
+
+```typescript
+function expandChunk(cache: DiffCache, result: DiffResult, chunkId: number): void
+function collapseChunk(cache: DiffCache, result: DiffResult, chunkId: number): void
+function toggleChunk(cache: DiffCache, result: DiffResult, chunkId: number): boolean
+```
+
+`toggleChunk` returns `true` if the chunk is now collapsed, `false` if expanded.
+
+#### expandAll / collapseUnchanged
+
+```typescript
+function expandAll(cache: DiffCache, result: DiffResult): void
+function collapseUnchanged(cache: DiffCache, result: DiffResult): void
+```
+
+### Rendering
+
+#### getVisibleDiffLines
+
+Gets visible lines for virtualized rendering. Collapsed chunks appear as single placeholder lines.
+
+```typescript
+function getVisibleDiffLines(
+  result: DiffResult,
+  startLine: number,
+  viewportSize: number,
+): VisibleDiff
+```
+
+#### getTotalLineCount
+
+Gets total line count accounting for collapsed chunks.
+
+```typescript
+function getTotalLineCount(result: DiffResult): number
+```
+
+#### getSideBySideView
+
+Converts diff to side-by-side view with left/right line pairs.
+
+```typescript
+function getSideBySideView(
+  result: DiffResult,
+  startLine: number,
+  viewportSize: number,
+): readonly SideBySideLine[]
+```
+
+### Unified Format
+
+#### toUnifiedDiff
+
+Formats a diff result as unified diff text.
+
+```typescript
+function toUnifiedDiff(
+  result: DiffResult,
+  oldName?: string,
+  newName?: string,
+): string
+```
+
+#### parseUnifiedDiff
+
+Parses unified diff text back into a DiffResult.
+
+```typescript
+function parseUnifiedDiff(diffText: string): DiffResult
+```
+
+### getDiffStats
+
+Gets summary statistics.
+
+```typescript
+function getDiffStats(result: DiffResult): {
+  additions: number;
+  deletions: number;
+  totalChanges: number;
+  chunks: number;
+  collapsedChunks: number;
+}
+```
+
+## Usage Example
+
+```typescript
+import {
+  computeDiffCached,
+  createDiffCache,
+  getVisibleDiffLines,
+  toUnifiedDiff,
+} from 'blecsd';
+
+const cache = createDiffCache();
+
+const oldText = 'function hello() {\n  return "world";\n}';
+const newText = 'function hello() {\n  return "universe";\n}';
+
+const result = computeDiffCached(cache, oldText, newText);
+
+// Virtualized rendering
+const visible = getVisibleDiffLines(result, 0, 20);
+for (const line of visible.lines) {
+  const prefix = line.type === 'add' ? '+' : line.type === 'remove' ? '-' : ' ';
+  console.log(prefix + line.content);
+}
+
+// Export as unified diff
+console.log(toUnifiedDiff(result, 'old.ts', 'new.ts'));
+```
+
+---
+
+## Related
+
+- [Markdown Render](./markdown-render.md) - Markdown parsing and rendering
+- [Virtual Scrollback](./virtual-scrollback.md) - Scrollback buffer for large output

--- a/docs/api/utils/fast-wrap.md
+++ b/docs/api/utils/fast-wrap.md
@@ -1,0 +1,354 @@
+# Fast Wrap
+
+Efficient word wrapping with per-paragraph caching, dirty tracking, and progressive rewrapping that prioritizes the visible region for responsive UI.
+
+## Import
+
+```typescript
+import {
+  createWrapCache,
+  clearWrapCache,
+  resizeWrapCache,
+  wrapWithCache,
+  wrapVisibleFirst,
+  continueWrap,
+  invalidateRange,
+  invalidateParagraph,
+  invalidateAll,
+  lineToPosition,
+  positionToLine,
+  getWrapCacheStats,
+  getWidth,
+  MAX_PARAGRAPH_CHUNK,
+  DEFAULT_BATCH_SIZE,
+} from 'blecsd';
+```
+
+## Types
+
+### WrapEntry
+
+Cached wrap result for a single paragraph.
+
+```typescript
+interface WrapEntry {
+  readonly text: string;
+  readonly hash: number;
+  readonly width: number;
+  readonly lines: readonly string[];
+  readonly breakPoints: readonly number[];
+}
+```
+
+### WrapCache
+
+The wrap cache data structure.
+
+```typescript
+interface WrapCache {
+  width: number;
+  readonly entries: Map<number, WrapEntry>;
+  readonly dirty: Set<number>;
+  totalLines: number;
+  readonly lineOffsets: number[];
+  fullInvalidate: boolean;
+}
+```
+
+### FastWrapOptions
+
+Options for wrap operations.
+
+```typescript
+interface FastWrapOptions {
+  readonly width: number;           // Max width in characters
+  readonly breakWord?: boolean;     // Break mid-word (default: false)
+  readonly unicodeWidth?: boolean;  // Unicode-aware width (default: true)
+}
+```
+
+### ProgressiveWrapResult
+
+Result of progressive wrapping.
+
+```typescript
+interface ProgressiveWrapResult {
+  readonly lines: readonly string[];
+  readonly hasMore: boolean;
+  readonly nextParagraph: number;
+  readonly timeMs: number;
+}
+```
+
+### LinePosition
+
+Maps a display line back to its paragraph and character offset.
+
+```typescript
+interface LinePosition {
+  readonly paragraph: number;
+  readonly lineInParagraph: number;
+  readonly charOffset: number;
+}
+```
+
+### WrapCacheStats
+
+```typescript
+interface WrapCacheStats {
+  readonly cachedParagraphs: number;
+  readonly dirtyParagraphs: number;
+  readonly totalLines: number;
+  readonly width: number;
+  readonly fullInvalidate: boolean;
+}
+```
+
+## Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `MAX_PARAGRAPH_CHUNK` | 1000 | Max paragraph length before splitting |
+| `DEFAULT_BATCH_SIZE` | 100 | Default paragraphs per progressive batch |
+
+## Functions
+
+### Cache Management
+
+#### createWrapCache
+
+Creates a new wrap cache.
+
+```typescript
+function createWrapCache(width: number): WrapCache
+```
+
+**Example:**
+```typescript
+import { createWrapCache } from 'blecsd';
+
+const cache = createWrapCache(80);
+```
+
+#### clearWrapCache
+
+Clears all cached entries.
+
+```typescript
+function clearWrapCache(cache: WrapCache): void
+```
+
+#### resizeWrapCache
+
+Resizes the cache to a new width, invalidating all entries.
+
+```typescript
+function resizeWrapCache(cache: WrapCache, newWidth: number): void
+```
+
+### Wrapping
+
+#### wrapWithCache
+
+Wraps text using the cache. Paragraphs are cached individually: unchanged paragraphs reuse their previous result.
+
+```typescript
+function wrapWithCache(
+  cache: WrapCache,
+  text: string,
+  options?: Partial<FastWrapOptions>,
+): readonly string[]
+```
+
+**Parameters:**
+- `cache` - The wrap cache
+- `text` - Text to wrap (newlines split paragraphs)
+- `options` - Wrap options
+
+**Returns:** Array of wrapped lines.
+
+**Example:**
+```typescript
+import { createWrapCache, wrapWithCache } from 'blecsd';
+
+const cache = createWrapCache(40);
+const lines = wrapWithCache(cache, 'This is a long paragraph that will be wrapped at 40 characters.');
+// ['This is a long paragraph that will be', 'wrapped at 40 characters.']
+```
+
+#### wrapVisibleFirst
+
+Wraps only the visible region first for responsive UI. Returns a `ProgressiveWrapResult` so you can continue wrapping the rest in the background.
+
+```typescript
+function wrapVisibleFirst(
+  cache: WrapCache,
+  text: string,
+  startLine: number,
+  endLine: number,
+  options?: Partial<FastWrapOptions>,
+): ProgressiveWrapResult
+```
+
+**Parameters:**
+- `cache` - The wrap cache
+- `text` - Text to wrap
+- `startLine` - First visible line
+- `endLine` - Last visible line (exclusive)
+- `options` - Wrap options
+
+**Returns:** Progressive wrap result.
+
+**Example:**
+```typescript
+import { createWrapCache, wrapVisibleFirst, continueWrap } from 'blecsd';
+
+const cache = createWrapCache(80);
+
+// Wrap visible region first (fast)
+const result = wrapVisibleFirst(cache, longText, 0, 50);
+
+// Continue wrapping the rest in the background
+if (result.hasMore) {
+  const more = continueWrap(cache, longText, result.nextParagraph);
+}
+```
+
+#### continueWrap
+
+Continues wrapping from a specific paragraph. Use this for background processing after the visible region is done.
+
+```typescript
+function continueWrap(
+  cache: WrapCache,
+  text: string,
+  startParagraph: number,
+  batchSize?: number,
+  options?: Partial<FastWrapOptions>,
+): ProgressiveWrapResult
+```
+
+### Invalidation
+
+#### invalidateRange
+
+Invalidates a range of paragraphs, forcing rewrap on next call.
+
+```typescript
+function invalidateRange(
+  cache: WrapCache,
+  startParagraph: number,
+  endParagraph: number,
+): void
+```
+
+#### invalidateParagraph
+
+Invalidates a single paragraph.
+
+```typescript
+function invalidateParagraph(cache: WrapCache, paragraph: number): void
+```
+
+#### invalidateAll
+
+Invalidates all paragraphs.
+
+```typescript
+function invalidateAll(cache: WrapCache): void
+```
+
+### Line Mapping
+
+#### lineToPosition
+
+Maps a display line number to paragraph position. Uses binary search.
+
+```typescript
+function lineToPosition(cache: WrapCache, lineNumber: number): LinePosition | undefined
+```
+
+**Example:**
+```typescript
+import { createWrapCache, wrapWithCache, lineToPosition } from 'blecsd';
+
+const cache = createWrapCache(40);
+wrapWithCache(cache, 'First paragraph\nSecond paragraph that wraps');
+
+const pos = lineToPosition(cache, 2);
+// { paragraph: 1, lineInParagraph: 1, charOffset: 20 }
+```
+
+#### positionToLine
+
+Maps a paragraph position to a display line number.
+
+```typescript
+function positionToLine(
+  cache: WrapCache,
+  paragraph: number,
+  lineInParagraph?: number,
+): number
+```
+
+**Returns:** Display line number, or -1 if invalid.
+
+### Utilities
+
+#### getWidth
+
+Gets the visible width of a string. Uses Unicode-aware width when enabled.
+
+```typescript
+function getWidth(text: string, unicodeWidth: boolean): number
+```
+
+#### getWrapCacheStats
+
+Gets cache statistics.
+
+```typescript
+function getWrapCacheStats(cache: WrapCache): WrapCacheStats
+```
+
+## Usage Example
+
+```typescript
+import {
+  createWrapCache,
+  wrapWithCache,
+  resizeWrapCache,
+  wrapVisibleFirst,
+  continueWrap,
+  lineToPosition,
+} from 'blecsd';
+
+const cache = createWrapCache(80);
+const text = 'Line one.\nA longer second paragraph that needs wrapping.\nThird line.';
+
+// Full wrap
+const lines = wrapWithCache(cache, text);
+console.log(lines);
+
+// On terminal resize
+resizeWrapCache(cache, 40);
+const visible = wrapVisibleFirst(cache, text, 0, 20);
+console.log(visible.lines);
+
+// Background wrap remaining
+if (visible.hasMore) {
+  continueWrap(cache, text, visible.nextParagraph);
+}
+
+// Map display line to source
+const pos = lineToPosition(cache, 1);
+console.log(`Paragraph ${pos?.paragraph}, offset ${pos?.charOffset}`);
+```
+
+---
+
+## Related
+
+- [Unicode](./unicode.md) - Unicode width calculation used by the wrapper
+- [Line Gutter](./line-gutter.md) - Line number gutter rendering
+- [Virtual Scrollback](./virtual-scrollback.md) - Scrollback buffer for wrapped content

--- a/docs/api/utils/fold-regions.md
+++ b/docs/api/utils/fold-regions.md
@@ -1,0 +1,251 @@
+# Fold Regions
+
+Folding/collapsing regions for efficient large document display. Manages fold state as metadata, dynamically adjusting visible line counts without re-rendering folded content. Supports nested regions with O(log n) fold/unfold operations.
+
+## Import
+
+```typescript
+import {
+  createFoldState,
+  addFoldRegion,
+  removeFoldRegion,
+  foldRegion,
+  unfoldRegion,
+  toggleFold,
+  foldAll,
+  unfoldAll,
+  foldAtDepth,
+  getFoldAtLine,
+  getAllFoldRegions,
+  getVisibleFoldLines,
+  visibleToOriginalLine,
+  originalToVisibleLine,
+  getFoldStats,
+  updateTotalLines,
+} from 'blecsd';
+```
+
+## Types
+
+### FoldRegion
+
+A fold region definition.
+
+```typescript
+interface FoldRegion {
+  readonly id: string;
+  readonly startLine: number;   // 0-based, inclusive
+  readonly endLine: number;     // 0-based, inclusive
+  readonly folded: boolean;
+  readonly label: string;
+  readonly depth: number;       // 0 = top-level
+}
+```
+
+### FoldConfig
+
+```typescript
+interface FoldConfig {
+  readonly minFoldableLines: number;  // Default: 2
+  readonly labelTemplate: string;     // Default: '... {count} lines'
+  readonly maxDepth: number;          // Default: 10
+}
+```
+
+### VisibleLine
+
+A visible line after applying fold state.
+
+```typescript
+interface VisibleLine {
+  readonly originalLine: number;
+  readonly isFoldPlaceholder: boolean;
+  readonly foldId: string | undefined;
+  readonly foldLabel: string | undefined;
+  readonly hiddenLines: number;
+}
+```
+
+### FoldStats
+
+```typescript
+interface FoldStats {
+  readonly totalRegions: number;
+  readonly foldedRegions: number;
+  readonly hiddenLines: number;
+  readonly visibleLines: number;
+  readonly maxDepth: number;
+}
+```
+
+## Functions
+
+### createFoldState
+
+Creates a fold manager for a document.
+
+```typescript
+function createFoldState(totalLines: number, config?: Partial<FoldConfig>): MutableFoldState
+```
+
+### addFoldRegion
+
+Adds a foldable region. Returns `undefined` if the region is too small, out of bounds, or exceeds max depth.
+
+```typescript
+function addFoldRegion(
+  state: MutableFoldState,
+  startLine: number,
+  endLine: number,
+  label?: string,
+): string | undefined
+```
+
+**Returns:** The fold region ID, or `undefined` if invalid
+
+### removeFoldRegion
+
+Removes a fold region by ID.
+
+```typescript
+function removeFoldRegion(state: MutableFoldState, foldId: string): boolean
+```
+
+### foldRegion / unfoldRegion
+
+Folds (collapses) or unfolds (expands) a region.
+
+```typescript
+function foldRegion(state: MutableFoldState, foldId: string): boolean
+function unfoldRegion(state: MutableFoldState, foldId: string): boolean
+```
+
+### toggleFold
+
+Toggles a region's fold state.
+
+```typescript
+function toggleFold(state: MutableFoldState, foldId: string): boolean | undefined
+```
+
+**Returns:** The new folded state, or `undefined` if region not found
+
+### foldAll / unfoldAll
+
+Folds or unfolds all regions.
+
+```typescript
+function foldAll(state: MutableFoldState): number
+function unfoldAll(state: MutableFoldState): number
+```
+
+**Returns:** Number of regions affected
+
+### foldAtDepth
+
+Folds all regions at or deeper than the specified depth.
+
+```typescript
+function foldAtDepth(state: MutableFoldState, depth: number): number
+```
+
+### getFoldAtLine
+
+Gets the innermost fold region at a given line.
+
+```typescript
+function getFoldAtLine(state: MutableFoldState, line: number): FoldRegion | undefined
+```
+
+### getAllFoldRegions
+
+Gets all fold regions sorted by start line.
+
+```typescript
+function getAllFoldRegions(state: MutableFoldState): readonly FoldRegion[]
+```
+
+### getVisibleFoldLines
+
+Computes visible lines for a viewport, respecting fold state. Only processes lines within the viewport range.
+
+```typescript
+function getVisibleFoldLines(
+  state: MutableFoldState,
+  viewportStart: number,
+  viewportHeight: number,
+): readonly VisibleLine[]
+```
+
+### visibleToOriginalLine
+
+Converts a visible line index (folded coordinates) to the original document line index.
+
+```typescript
+function visibleToOriginalLine(state: MutableFoldState, visibleLine: number): number
+```
+
+### originalToVisibleLine
+
+Converts an original document line to the visible line index.
+
+```typescript
+function originalToVisibleLine(state: MutableFoldState, originalLine: number): number
+```
+
+**Returns:** Visible line index, or -1 if the line is hidden by a fold
+
+### getFoldStats
+
+Gets fold statistics.
+
+```typescript
+function getFoldStats(state: MutableFoldState): FoldStats
+```
+
+### updateTotalLines
+
+Updates the total document line count. Removes regions that are now out of bounds.
+
+```typescript
+function updateTotalLines(state: MutableFoldState, totalLines: number): void
+```
+
+## Usage
+
+```typescript
+import {
+  createFoldState, addFoldRegion, foldRegion,
+  getVisibleFoldLines, getFoldStats,
+} from 'blecsd';
+
+const folds = createFoldState(10000);
+
+// Add foldable regions (e.g., function bodies)
+const id1 = addFoldRegion(folds, 10, 50);
+const id2 = addFoldRegion(folds, 100, 200);
+
+// Collapse a region
+if (id1) foldRegion(folds, id1);
+
+// Get visible lines for a viewport
+const visible = getVisibleFoldLines(folds, 0, 40);
+for (const line of visible) {
+  if (line.isFoldPlaceholder) {
+    console.log(`[${line.foldLabel}]`);  // "... 40 lines"
+  } else {
+    console.log(`Line ${line.originalLine}`);
+  }
+}
+
+// Check stats
+const stats = getFoldStats(folds);
+console.log(`${stats.visibleLines} visible of ${stats.visibleLines + stats.hiddenLines} total`);
+```
+
+---
+
+## Related
+
+- [Cursor Navigation](./cursor-navigation.md) - Cursor/viewport management
+- [Virtualized Line Store](./virtualized-line-store.md) - Large text content storage

--- a/docs/api/utils/fuzzy-search.md
+++ b/docs/api/utils/fuzzy-search.md
@@ -1,0 +1,275 @@
+# Fuzzy Search
+
+Fuzzy string matching with scoring, highlighting, and filtering support for building searchable lists and command palettes.
+
+## Import
+
+```typescript
+import {
+  fuzzyMatch,
+  fuzzySearch,
+  fuzzySearchBy,
+  fuzzyFilter,
+  fuzzyTest,
+  highlightMatch,
+  FuzzyOptionsSchema,
+} from 'blecsd';
+```
+
+## Types
+
+### FuzzyOptions
+
+Options for fuzzy matching behavior.
+
+```typescript
+interface FuzzyOptions {
+  readonly caseSensitive?: boolean;       // Default: false
+  readonly threshold?: number;            // Min score 0-1 (default: 0)
+  readonly limit?: number;               // Max results (default: unlimited)
+  readonly consecutiveBonus?: number;     // Bonus for consecutive matches (default: 0.3)
+  readonly wordBoundaryBonus?: number;    // Bonus for boundary matches (default: 0.2)
+  readonly prefixBonus?: number;          // Bonus for prefix match (default: 0.5)
+  readonly gapPenalty?: number;           // Penalty per gap character (default: 0.1)
+}
+```
+
+### FuzzyMatch\<T\>
+
+A single fuzzy match result.
+
+```typescript
+interface FuzzyMatch<T = string> {
+  readonly item: T;                    // The original item
+  readonly text: string;               // The string that was matched against
+  readonly score: number;              // Match score (0-1, higher is better)
+  readonly indices: readonly number[]; // Indices of matched characters
+}
+```
+
+### FuzzySearchOptions\<T\>
+
+Options with a text extractor for searching object arrays.
+
+```typescript
+interface FuzzySearchOptions<T> extends FuzzyOptions {
+  readonly getText?: (item: T) => string;
+}
+```
+
+## Schemas
+
+### FuzzyOptionsSchema
+
+Zod schema for validating fuzzy options at runtime.
+
+```typescript
+import { FuzzyOptionsSchema } from 'blecsd';
+
+const validated = FuzzyOptionsSchema.parse({ threshold: 0.5 });
+```
+
+## Functions
+
+### fuzzyMatch
+
+Calculates the fuzzy match score for a query against a single text string.
+
+```typescript
+function fuzzyMatch(
+  query: string,
+  text: string,
+  options?: FuzzyOptions,
+): FuzzyMatch<string> | null
+```
+
+**Parameters:**
+- `query` - The search query
+- `text` - The text to search in
+- `options` - Matching options
+
+**Returns:** Match result with score and indices, or `null` if no match.
+
+**Example:**
+```typescript
+import { fuzzyMatch } from 'blecsd';
+
+const result = fuzzyMatch('app', 'application');
+// { item: 'application', text: 'application', score: 0.9, indices: [0, 1, 2] }
+
+fuzzyMatch('xyz', 'application'); // null
+```
+
+### fuzzySearch
+
+Performs fuzzy search on an array of strings. Returns results sorted by score (highest first).
+
+```typescript
+function fuzzySearch(
+  query: string,
+  items: readonly string[],
+  options?: FuzzyOptions,
+): FuzzyMatch<string>[]
+```
+
+**Parameters:**
+- `query` - The search query
+- `items` - Array of strings to search
+- `options` - Search options
+
+**Returns:** Array of matches sorted by score (highest first).
+
+**Example:**
+```typescript
+import { fuzzySearch } from 'blecsd';
+
+const items = ['apple', 'application', 'banana', 'apply'];
+const results = fuzzySearch('app', items);
+// [
+//   { item: 'apple', score: 0.9, indices: [0, 1, 2], ... },
+//   { item: 'apply', score: 0.9, indices: [0, 1, 2], ... },
+//   { item: 'application', score: 0.7, indices: [0, 1, 2], ... },
+// ]
+```
+
+### fuzzySearchBy
+
+Performs fuzzy search on an array of objects, using a text extractor function.
+
+```typescript
+function fuzzySearchBy<T>(
+  query: string,
+  items: readonly T[],
+  options: FuzzySearchOptions<T>,
+): FuzzyMatch<T>[]
+```
+
+**Parameters:**
+- `query` - The search query
+- `items` - Array of objects to search
+- `options` - Search options with `getText` extractor
+
+**Returns:** Array of matches with original item objects, sorted by score.
+
+**Example:**
+```typescript
+import { fuzzySearchBy } from 'blecsd';
+
+interface Command { name: string; shortcut: string }
+const commands: Command[] = [
+  { name: 'Open File', shortcut: 'Ctrl+O' },
+  { name: 'Open Recent', shortcut: 'Ctrl+Shift+O' },
+  { name: 'Save', shortcut: 'Ctrl+S' },
+];
+
+const results = fuzzySearchBy('open', commands, {
+  getText: (cmd) => cmd.name,
+});
+// Returns matches with original Command objects
+```
+
+### fuzzyFilter
+
+Filters items by fuzzy match and returns only the matching strings (not full match objects).
+
+```typescript
+function fuzzyFilter(
+  query: string,
+  items: readonly string[],
+  options?: FuzzyOptions,
+): string[]
+```
+
+**Parameters:**
+- `query` - The search query
+- `items` - Array of strings to filter
+- `options` - Search options
+
+**Returns:** Array of matching strings.
+
+**Example:**
+```typescript
+import { fuzzyFilter } from 'blecsd';
+
+const items = ['apple', 'application', 'banana'];
+const filtered = fuzzyFilter('app', items);
+// ['apple', 'application']
+```
+
+### fuzzyTest
+
+Checks whether a string matches a fuzzy query.
+
+```typescript
+function fuzzyTest(
+  query: string,
+  text: string,
+  options?: FuzzyOptions,
+): boolean
+```
+
+**Parameters:**
+- `query` - The search query
+- `text` - The text to check
+- `options` - Match options
+
+**Returns:** `true` if the text matches the query.
+
+**Example:**
+```typescript
+import { fuzzyTest } from 'blecsd';
+
+fuzzyTest('app', 'application'); // true
+fuzzyTest('xyz', 'application'); // false
+```
+
+### highlightMatch
+
+Highlights matched characters in a string using a custom highlight function.
+
+```typescript
+function highlightMatch(
+  text: string,
+  indices: readonly number[],
+  highlight?: (char: string) => string,
+): string
+```
+
+**Parameters:**
+- `text` - The original text
+- `indices` - The matched character indices (from `FuzzyMatch.indices`)
+- `highlight` - Function to wrap matched characters (default: wraps in brackets)
+
+**Returns:** Text with highlighted matches.
+
+**Example:**
+```typescript
+import { fuzzyMatch, highlightMatch } from 'blecsd';
+
+const match = fuzzyMatch('app', 'application');
+if (match) {
+  const highlighted = highlightMatch(match.text, match.indices, (c) => `\x1b[1m${c}\x1b[0m`);
+  // Bold ANSI highlighting on matched characters
+}
+```
+
+## Usage Example
+
+```typescript
+import { fuzzySearch, highlightMatch } from 'blecsd';
+
+const files = ['README.md', 'package.json', 'src/index.ts', 'src/utils/rope.ts'];
+
+const results = fuzzySearch('rop', files, { threshold: 0.3 });
+for (const result of results) {
+  const display = highlightMatch(result.text, result.indices, (c) => `[${c}]`);
+  console.log(`${display} (score: ${result.score.toFixed(2)})`);
+}
+// src/utils/[r][o][p]e.ts (score: 0.65)
+```
+
+---
+
+## Related
+
+- [Virtual Scrollback](./virtual-scrollback.md) - Scrollback buffer for searchable history

--- a/docs/api/utils/lazy-content.md
+++ b/docs/api/utils/lazy-content.md
@@ -1,0 +1,188 @@
+# Lazy Content
+
+Lazy content loading and pagination for huge files. Loads only the visible viewport initially, then progressively loads surrounding content in the background with a bounded memory footprint.
+
+## Import
+
+```typescript
+import {
+  createLazyContent,
+  getLazyLines,
+  prefetchAround,
+  evictChunks,
+  clearLazyContent,
+  getLazyContentState,
+  isRangeLoaded,
+  createArraySource,
+} from 'blecsd';
+```
+
+## Types
+
+### LazyContentConfig
+
+```typescript
+interface LazyContentConfig {
+  readonly chunkSize: number;       // Default: 1000
+  readonly maxCachedChunks: number; // Default: 50
+  readonly readAheadLines: number;  // Default: 500
+  readonly readBehindLines: number; // Default: 200
+  readonly maxMemoryBytes: number;  // Default: 100MB
+}
+```
+
+### ContentChunk
+
+A loaded content chunk.
+
+```typescript
+interface ContentChunk {
+  readonly index: number;
+  readonly startLine: number;
+  readonly endLine: number;          // exclusive
+  readonly lines: readonly string[];
+  readonly byteSize: number;
+  readonly lastAccessedAt: number;
+}
+```
+
+### ContentSource
+
+Content source that provides lazy loading capability.
+
+```typescript
+interface ContentSource {
+  readonly totalLines: number;
+  readonly loadRange: (startLine: number, endLine: number) => readonly string[];
+  readonly isExactCount: boolean;
+}
+```
+
+### LazyContentState
+
+Read-only snapshot of the lazy content loader.
+
+```typescript
+interface LazyContentState {
+  readonly config: LazyContentConfig;
+  readonly totalLines: number;
+  readonly loadedChunks: number;
+  readonly memoryUsage: number;
+  readonly hitRate: number;  // 0-1
+}
+```
+
+## Functions
+
+### createLazyContent
+
+Creates a lazy content loader for a content source.
+
+```typescript
+function createLazyContent(
+  source: ContentSource,
+  config?: Partial<LazyContentConfig>,
+): MutableLazyState
+```
+
+### getLazyLines
+
+Gets lines from the lazy loader, loading chunks as needed. Chunks are loaded on demand and cached with LRU eviction.
+
+```typescript
+function getLazyLines(
+  state: MutableLazyState,
+  startLine: number,
+  endLine: number,
+): readonly string[]
+```
+
+### prefetchAround
+
+Pre-loads chunks around a viewport for smooth scrolling.
+
+```typescript
+function prefetchAround(
+  state: MutableLazyState,
+  viewportStart: number,
+  viewportEnd: number,
+): void
+```
+
+### evictChunks
+
+Evicts the least recently used chunks to free memory.
+
+```typescript
+function evictChunks(state: MutableLazyState, targetChunks?: number): number
+```
+
+**Returns:** Number of chunks evicted
+
+### clearLazyContent
+
+Clears all cached chunks and resets hit/miss counters.
+
+```typescript
+function clearLazyContent(state: MutableLazyState): void
+```
+
+### getLazyContentState
+
+Gets a read-only snapshot of the loader statistics.
+
+```typescript
+function getLazyContentState(state: MutableLazyState): LazyContentState
+```
+
+### isRangeLoaded
+
+Checks if a specific line range is already loaded.
+
+```typescript
+function isRangeLoaded(
+  state: MutableLazyState,
+  startLine: number,
+  endLine: number,
+): boolean
+```
+
+### createArraySource
+
+Creates a content source from an array of lines. Useful for testing or in-memory content.
+
+```typescript
+function createArraySource(lines: readonly string[]): ContentSource
+```
+
+## Usage
+
+```typescript
+import { createLazyContent, getLazyLines, prefetchAround, getLazyContentState } from 'blecsd';
+
+// Create a source from a large file (e.g., via readline)
+const source = {
+  totalLines: 1000000,
+  isExactCount: true,
+  loadRange: (start, end) => fileLines.slice(start, end),
+};
+
+const loader = createLazyContent(source, { chunkSize: 500 });
+
+// Get only the visible viewport lines
+const visible = getLazyLines(loader, 500, 540);
+
+// Pre-load surrounding chunks for smooth scrolling
+prefetchAround(loader, 500, 540);
+
+// Check loader stats
+const stats = getLazyContentState(loader);
+console.log(`${stats.loadedChunks} chunks, hit rate: ${(stats.hitRate * 100).toFixed(0)}%`);
+```
+
+---
+
+## Related
+
+- [Virtualized Line Store](./virtualized-line-store.md) - O(1) line access for in-memory content
+- [Cursor Navigation](./cursor-navigation.md) - Cursor/viewport management

--- a/docs/api/utils/line-gutter.md
+++ b/docs/api/utils/line-gutter.md
@@ -1,0 +1,253 @@
+# Line Gutter
+
+Efficient line number gutter rendering with dynamic width, relative/hybrid numbering modes (vim-style), and virtualized computation that only processes visible lines.
+
+## Import
+
+```typescript
+import {
+  createGutterConfig,
+  computeDigitWidth,
+  computeGutterWidth,
+  formatLineNumber,
+  computeVisibleGutter,
+  gutterWidthChanged,
+  renderGutterBlock,
+} from 'blecsd';
+```
+
+## Types
+
+### LineNumberMode
+
+```typescript
+type LineNumberMode = 'absolute' | 'relative' | 'hybrid';
+```
+
+- **absolute** - Standard line numbers (1, 2, 3, ...)
+- **relative** - Distance from cursor line (vim `relativenumber`)
+- **hybrid** - Current line shows absolute, others show relative (vim `number` + `relativenumber`)
+
+### GutterConfig
+
+Configuration for gutter rendering.
+
+```typescript
+interface GutterConfig {
+  readonly mode: LineNumberMode;       // Default: 'absolute'
+  readonly minWidth: number;           // Min digit columns (default: 3)
+  readonly rightPadding: number;       // Padding after number (default: 1)
+  readonly padChar: string;            // Padding character (default: ' ')
+  readonly separator: string;          // Separator char (default: '\u2502')
+  readonly highlightCurrent: boolean;  // Highlight current line (default: true)
+}
+```
+
+### GutterLine
+
+A single rendered gutter cell.
+
+```typescript
+interface GutterLine {
+  readonly text: string;
+  readonly isCurrent: boolean;
+  readonly lineNumber: number;
+  readonly width: number;
+}
+```
+
+### GutterResult
+
+Result of computing visible gutter lines.
+
+```typescript
+interface GutterResult {
+  readonly lines: readonly GutterLine[];
+  readonly gutterWidth: number;
+  readonly digitWidth: number;
+  readonly totalLines: number;
+}
+```
+
+## Functions
+
+### createGutterConfig
+
+Creates a full gutter config with defaults for any omitted fields.
+
+```typescript
+function createGutterConfig(config?: Partial<GutterConfig>): GutterConfig
+```
+
+**Example:**
+```typescript
+import { createGutterConfig } from 'blecsd';
+
+const config = createGutterConfig({ mode: 'relative' });
+```
+
+### computeDigitWidth
+
+Computes the number of digit columns needed for a given line count.
+
+```typescript
+function computeDigitWidth(totalLines: number, minWidth: number): number
+```
+
+**Example:**
+```typescript
+import { computeDigitWidth } from 'blecsd';
+
+computeDigitWidth(99, 3);    // 3 (minWidth applies)
+computeDigitWidth(1000, 3);  // 4
+computeDigitWidth(99999, 3); // 5
+```
+
+### computeGutterWidth
+
+Computes total gutter width including padding and separator.
+
+```typescript
+function computeGutterWidth(digitWidth: number, config?: Partial<GutterConfig>): number
+```
+
+### formatLineNumber
+
+Formats a single line number for display.
+
+```typescript
+function formatLineNumber(
+  lineNumber: number,
+  cursorLine: number,
+  digitWidth: number,
+  mode: LineNumberMode,
+): string
+```
+
+**Parameters:**
+- `lineNumber` - Absolute line number (1-based)
+- `cursorLine` - Current cursor line (1-based)
+- `digitWidth` - Width to pad the number to
+- `mode` - Line numbering mode
+
+**Example:**
+```typescript
+import { formatLineNumber } from 'blecsd';
+
+formatLineNumber(42, 42, 4, 'absolute');  // '  42'
+formatLineNumber(40, 42, 4, 'relative');  // '   2'
+formatLineNumber(42, 42, 4, 'hybrid');    // '  42'
+formatLineNumber(40, 42, 4, 'hybrid');    // '   2'
+```
+
+### computeVisibleGutter
+
+Computes gutter lines for a viewport. Runs in O(viewportHeight) regardless of total document size.
+
+```typescript
+function computeVisibleGutter(
+  totalLines: number,
+  viewportStart: number,
+  viewportHeight: number,
+  cursorLine: number,
+  config?: Partial<GutterConfig>,
+): GutterResult
+```
+
+**Parameters:**
+- `totalLines` - Total lines in the document
+- `viewportStart` - First visible line index (0-based)
+- `viewportHeight` - Number of visible lines
+- `cursorLine` - Current cursor line (1-based)
+- `config` - Optional gutter config overrides
+
+**Example:**
+```typescript
+import { computeVisibleGutter } from 'blecsd';
+
+const result = computeVisibleGutter(100000, 500, 40, 520);
+for (const line of result.lines) {
+  process.stdout.write(line.text + '\n');
+}
+console.log(`Gutter width: ${result.gutterWidth}`);
+```
+
+### gutterWidthChanged
+
+Checks if the gutter width would change at a new line count. Useful for detecting when a layout reflow is needed (e.g., going from 999 to 1000 lines).
+
+```typescript
+function gutterWidthChanged(oldTotal: number, newTotal: number, minWidth?: number): boolean
+```
+
+**Example:**
+```typescript
+import { gutterWidthChanged } from 'blecsd';
+
+gutterWidthChanged(999, 1000, 3);  // true (3 digits -> 4 digits)
+gutterWidthChanged(100, 200, 3);   // false (both 3 digits)
+```
+
+### renderGutterBlock
+
+Renders gutter lines with ANSI styling. Returns an array of styled strings.
+
+```typescript
+function renderGutterBlock(
+  result: GutterResult,
+  currentHighlight: string,
+  normalStyle: string,
+  reset?: string,
+): readonly string[]
+```
+
+**Parameters:**
+- `result` - Computed gutter result
+- `currentHighlight` - ANSI prefix for the current line
+- `normalStyle` - ANSI prefix for normal lines
+- `reset` - ANSI reset sequence (default: `'\x1b[0m'`)
+
+**Example:**
+```typescript
+import { computeVisibleGutter, renderGutterBlock } from 'blecsd';
+
+const gutter = computeVisibleGutter(1000, 0, 40, 1);
+const styled = renderGutterBlock(gutter, '\x1b[1;33m', '\x1b[90m');
+for (const line of styled) {
+  process.stdout.write(line + '\n');
+}
+```
+
+## Usage Example
+
+```typescript
+import { computeVisibleGutter, renderGutterBlock, gutterWidthChanged } from 'blecsd';
+
+let totalLines = 500;
+let viewportStart = 0;
+const viewportHeight = 40;
+let cursorLine = 1;
+
+function render(): void {
+  const gutter = computeVisibleGutter(totalLines, viewportStart, viewportHeight, cursorLine, {
+    mode: 'hybrid',
+  });
+  const styled = renderGutterBlock(gutter, '\x1b[1;33m', '\x1b[90m');
+  // Combine with content lines for display
+}
+
+// Detect gutter resize
+function onLinesChanged(newTotal: number): void {
+  if (gutterWidthChanged(totalLines, newTotal, 3)) {
+    // Relayout needed
+  }
+  totalLines = newTotal;
+}
+```
+
+---
+
+## Related
+
+- [Virtual Scrollback](./virtual-scrollback.md) - Scrollback buffer for scrolled views
+- [Fast Wrap](./fast-wrap.md) - Word wrapping for content beside the gutter

--- a/docs/api/utils/markdown-render.md
+++ b/docs/api/utils/markdown-render.md
@@ -1,0 +1,386 @@
+# Markdown Render
+
+Streaming markdown parser with block-level caching, syntax highlighting for code blocks, and virtualized rendered output.
+
+## Import
+
+```typescript
+import {
+  parseMarkdown,
+  parseMarkdownCached,
+  parseInline,
+  createMarkdownCache,
+  clearMarkdownCache,
+  invalidateLines,
+  renderBlock,
+  renderMarkdown,
+  getVisibleMarkdown,
+  getTotalLineCount,
+  getMarkdownStats,
+  DEFAULT_PARSE_BATCH,
+} from 'blecsd';
+```
+
+## Types
+
+### BlockType
+
+Block-level element types.
+
+```typescript
+type BlockType = 'paragraph' | 'heading' | 'code' | 'list' | 'blockquote' | 'table' | 'hr' | 'html';
+```
+
+### InlineType
+
+Inline element types.
+
+```typescript
+type InlineType = 'text' | 'bold' | 'italic' | 'code' | 'link' | 'image' | 'strikethrough';
+```
+
+### InlineElement
+
+An inline element within a block.
+
+```typescript
+interface InlineElement {
+  readonly type: InlineType;
+  readonly content: string;
+  readonly href?: string;
+  readonly title?: string;
+  readonly children?: readonly InlineElement[];
+}
+```
+
+### MarkdownBlock
+
+A parsed markdown block.
+
+```typescript
+interface MarkdownBlock {
+  readonly type: BlockType;
+  readonly source: string;
+  readonly lineStart: number;
+  readonly lineEnd: number;
+  readonly data: BlockData;
+  readonly hash: number;
+}
+```
+
+### BlockData
+
+Union of block-specific data types:
+
+```typescript
+type BlockData =
+  | HeadingData
+  | CodeData
+  | ListData
+  | TableData
+  | ParagraphData
+  | BlockquoteData
+  | HrData
+  | HtmlData;
+```
+
+#### HeadingData
+
+```typescript
+interface HeadingData {
+  readonly kind: 'heading';
+  readonly level: 1 | 2 | 3 | 4 | 5 | 6;
+  readonly text: string;
+  readonly inline: readonly InlineElement[];
+}
+```
+
+#### CodeData
+
+```typescript
+interface CodeData {
+  readonly kind: 'code';
+  readonly language: string;
+  readonly code: string;
+  readonly highlighted?: readonly (readonly Token[])[];
+}
+```
+
+#### ListData
+
+```typescript
+interface ListData {
+  readonly kind: 'list';
+  readonly ordered: boolean;
+  readonly start?: number;
+  readonly items: readonly ListItem[];
+}
+
+interface ListItem {
+  readonly content: string;
+  readonly inline: readonly InlineElement[];
+  readonly indent: number;
+  readonly checked?: boolean;
+}
+```
+
+#### TableData
+
+```typescript
+interface TableData {
+  readonly kind: 'table';
+  readonly headers: readonly TableCell[];
+  readonly alignments: readonly ('left' | 'center' | 'right' | null)[];
+  readonly rows: readonly (readonly TableCell[])[];
+}
+
+interface TableCell {
+  readonly content: string;
+  readonly inline: readonly InlineElement[];
+}
+```
+
+#### ParagraphData / BlockquoteData / HrData / HtmlData
+
+```typescript
+interface ParagraphData {
+  readonly kind: 'paragraph';
+  readonly text: string;
+  readonly inline: readonly InlineElement[];
+}
+
+interface BlockquoteData {
+  readonly kind: 'blockquote';
+  readonly content: string;
+  readonly blocks: readonly MarkdownBlock[];
+}
+
+interface HrData { readonly kind: 'hr'; }
+interface HtmlData { readonly kind: 'html'; readonly html: string; }
+```
+
+### RenderedLine
+
+A single rendered output line.
+
+```typescript
+interface RenderedLine {
+  readonly content: string;
+  readonly style: LineStyle;
+  readonly blockIndex: number;
+  readonly lineInBlock: number;
+}
+```
+
+### LineStyle
+
+Style information for a rendered line.
+
+```typescript
+interface LineStyle {
+  readonly fg?: number;
+  readonly bg?: number;
+  readonly bold?: boolean;
+  readonly italic?: boolean;
+  readonly underline?: boolean;
+  readonly dim?: boolean;
+}
+```
+
+### MarkdownParseResult
+
+```typescript
+interface MarkdownParseResult {
+  readonly blocks: readonly MarkdownBlock[];
+  readonly parseTimeMs: number;
+}
+```
+
+### MarkdownCache
+
+Cache for incremental parsing.
+
+```typescript
+interface MarkdownCache {
+  blocks: Map<string, MarkdownBlock>;
+  sourceHash: number;
+  highlightCaches: Map<string, HighlightCache>;
+  renderedLines: RenderedLine[] | null;
+}
+```
+
+### VisibleMarkdown
+
+Result of a virtualized visible-lines query.
+
+```typescript
+interface VisibleMarkdown {
+  readonly lines: readonly RenderedLine[];
+  readonly totalLines: number;
+  readonly startIndex: number;
+  readonly endIndex: number;
+}
+```
+
+### MarkdownStats
+
+```typescript
+interface MarkdownStats {
+  readonly blockCount: number;
+  readonly lineCount: number;
+  readonly headingCount: number;
+  readonly codeBlockCount: number;
+  readonly listCount: number;
+  readonly tableCount: number;
+  readonly linkCount: number;
+}
+```
+
+## Functions
+
+### parseMarkdown
+
+Parses a markdown string into blocks.
+
+```typescript
+function parseMarkdown(source: string): MarkdownParseResult
+```
+
+**Parameters:**
+- `source` - Raw markdown text
+
+**Returns:** Parse result with blocks and timing.
+
+**Example:**
+```typescript
+import { parseMarkdown } from 'blecsd';
+
+const result = parseMarkdown('# Hello\n\nSome **bold** text.');
+console.log(result.blocks.length); // 2 (heading + paragraph)
+console.log(result.parseTimeMs);   // e.g. 0.5
+```
+
+### parseInline
+
+Parses inline markdown elements (bold, italic, code, links, images, strikethrough).
+
+```typescript
+function parseInline(text: string): readonly InlineElement[]
+```
+
+**Example:**
+```typescript
+import { parseInline } from 'blecsd';
+
+const elements = parseInline('Hello **world** and `code`');
+// [{ type: 'text', content: 'Hello ' },
+//  { type: 'bold', content: 'world', ... },
+//  { type: 'text', content: ' and ' },
+//  { type: 'code', content: 'code' }]
+```
+
+### createMarkdownCache / clearMarkdownCache
+
+Creates and clears the incremental parsing cache.
+
+```typescript
+function createMarkdownCache(): MarkdownCache
+function clearMarkdownCache(cache: MarkdownCache): void
+```
+
+### parseMarkdownCached
+
+Parses markdown with caching. On unchanged source, returns cached result instantly.
+
+```typescript
+function parseMarkdownCached(cache: MarkdownCache, source: string): MarkdownParseResult
+```
+
+### invalidateLines
+
+Invalidates cached blocks that overlap a line range, forcing reparse on next call.
+
+```typescript
+function invalidateLines(cache: MarkdownCache, startLine: number, endLine: number): void
+```
+
+### renderBlock
+
+Renders a single block to output lines.
+
+```typescript
+function renderBlock(block: MarkdownBlock, cache: MarkdownCache): readonly RenderedLine[]
+```
+
+### renderMarkdown
+
+Renders all blocks to output lines, caching the result.
+
+```typescript
+function renderMarkdown(result: MarkdownParseResult, cache: MarkdownCache): readonly RenderedLine[]
+```
+
+### getVisibleMarkdown
+
+Gets visible lines for virtualized rendering.
+
+```typescript
+function getVisibleMarkdown(
+  result: MarkdownParseResult,
+  cache: MarkdownCache,
+  startLine: number,
+  count: number,
+): VisibleMarkdown
+```
+
+**Parameters:**
+- `result` - Parse result
+- `cache` - Markdown cache
+- `startLine` - First visible line index
+- `count` - Number of lines to return
+
+**Returns:** Visible lines with total count and range info.
+
+### getTotalLineCount
+
+Gets the total rendered line count.
+
+```typescript
+function getTotalLineCount(result: MarkdownParseResult, cache: MarkdownCache): number
+```
+
+### getMarkdownStats
+
+Gets statistics about parsed markdown.
+
+```typescript
+function getMarkdownStats(result: MarkdownParseResult): MarkdownStats
+```
+
+## Usage Example
+
+```typescript
+import {
+  parseMarkdownCached,
+  createMarkdownCache,
+  getVisibleMarkdown,
+} from 'blecsd';
+
+const cache = createMarkdownCache();
+const source = '# Title\n\nParagraph text.\n\n```ts\nconst x = 1;\n```';
+
+const result = parseMarkdownCached(cache, source);
+
+// Render only visible lines (virtualized)
+const visible = getVisibleMarkdown(result, cache, 0, 10);
+for (const line of visible.lines) {
+  console.log(line.content);
+}
+```
+
+---
+
+## Related
+
+- [Diff Render](./diff-render.md) - Diff computation and rendering
+- [Fast Wrap](./fast-wrap.md) - Word wrapping with caching

--- a/docs/api/utils/rope.md
+++ b/docs/api/utils/rope.md
@@ -1,0 +1,407 @@
+# Rope
+
+Immutable rope data structure for efficient large text buffer operations. Provides O(log n) insert, delete, and index operations using a balanced binary tree of string chunks.
+
+## Import
+
+```typescript
+import {
+  createRope,
+  createEmptyRope,
+  getLength,
+  getNewlineCount,
+  getLineCount,
+  isEmpty,
+  charAt,
+  substring,
+  getText,
+  getLineForIndex,
+  getLineStart,
+  getLineEnd,
+  getLine,
+  getLines,
+  insert,
+  append,
+  prepend,
+  deleteRange,
+  replaceRange,
+  getStats,
+  verify,
+} from 'blecsd';
+```
+
+## Types
+
+### Rope
+
+A rope is either a leaf node or an internal node.
+
+```typescript
+type Rope = RopeLeaf | RopeNode;
+```
+
+### RopeLeaf
+
+A leaf node containing actual text content.
+
+```typescript
+interface RopeLeaf {
+  readonly type: 'leaf';
+  readonly text: string;
+  readonly length: number;
+  readonly newlines: number;
+  readonly lineBreaks: readonly number[];
+}
+```
+
+### RopeNode
+
+An internal node containing two subtrees.
+
+```typescript
+interface RopeNode {
+  readonly type: 'node';
+  readonly left: Rope;
+  readonly right: Rope;
+  readonly leftLength: number;
+  readonly length: number;
+  readonly newlines: number;
+  readonly depth: number;
+}
+```
+
+### LineInfo
+
+Line information returned by `getLine`.
+
+```typescript
+interface LineInfo {
+  readonly text: string;
+  readonly start: number;
+  readonly end: number;
+  readonly lineNumber: number;
+}
+```
+
+### RopeStats
+
+Statistics about a rope's internal structure.
+
+```typescript
+interface RopeStats {
+  readonly length: number;
+  readonly newlines: number;
+  readonly leafCount: number;
+  readonly depth: number;
+  readonly avgLeafSize: number;
+}
+```
+
+## Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `LEAF_MAX_SIZE` | 512 | Maximum characters in a leaf node |
+| `LEAF_MIN_SIZE` | 256 | Minimum characters before merging |
+| `MAX_DEPTH` | 48 | Maximum tree depth before rebalance |
+
+## Functions
+
+### Creation
+
+#### createRope
+
+Creates a rope from a string. Large strings are automatically split into balanced chunks.
+
+```typescript
+function createRope(text?: string): Rope
+```
+
+**Parameters:**
+- `text` - Initial text content (default: empty string)
+
+**Returns:** A new Rope.
+
+**Example:**
+```typescript
+import { createRope } from 'blecsd';
+
+const rope = createRope('Hello, World!');
+```
+
+#### createEmptyRope
+
+Creates an empty rope.
+
+```typescript
+function createEmptyRope(): Rope
+```
+
+### Queries
+
+#### getLength
+
+Gets the total character count.
+
+```typescript
+function getLength(rope: Rope): number
+```
+
+#### getNewlineCount
+
+Gets the total number of newline characters.
+
+```typescript
+function getNewlineCount(rope: Rope): number
+```
+
+#### getLineCount
+
+Gets the total number of lines (newlines + 1).
+
+```typescript
+function getLineCount(rope: Rope): number
+```
+
+#### isEmpty
+
+Checks if the rope is empty.
+
+```typescript
+function isEmpty(rope: Rope): boolean
+```
+
+#### charAt
+
+Gets the character at a specific index.
+
+```typescript
+function charAt(rope: Rope, index: number): string | undefined
+```
+
+**Parameters:**
+- `rope` - The rope to query
+- `index` - Character index (0-based)
+
+**Returns:** Character at index, or `undefined` if out of bounds.
+
+#### substring
+
+Gets a substring from the rope.
+
+```typescript
+function substring(rope: Rope, start: number, end?: number): string
+```
+
+**Parameters:**
+- `rope` - The rope to query
+- `start` - Start index (inclusive)
+- `end` - End index (exclusive, defaults to end of rope)
+
+**Returns:** Substring.
+
+#### getText
+
+Converts the entire rope to a string.
+
+```typescript
+function getText(rope: Rope): string
+```
+
+### Line Operations
+
+#### getLineForIndex
+
+Gets the line number for a character position.
+
+```typescript
+function getLineForIndex(rope: Rope, index: number): number
+```
+
+**Parameters:**
+- `rope` - The rope to query
+- `index` - Character index
+
+**Returns:** Line number (0-based).
+
+#### getLineStart
+
+Gets the start index of a line.
+
+```typescript
+function getLineStart(rope: Rope, lineNumber: number): number
+```
+
+**Returns:** Start index, or -1 if out of bounds.
+
+#### getLineEnd
+
+Gets the end index of a line (position of newline or end of rope).
+
+```typescript
+function getLineEnd(rope: Rope, lineNumber: number): number
+```
+
+**Returns:** End index, or -1 if out of bounds.
+
+#### getLine
+
+Gets a specific line's content.
+
+```typescript
+function getLine(rope: Rope, lineNumber: number): LineInfo | undefined
+```
+
+**Parameters:**
+- `rope` - The rope to query
+- `lineNumber` - Line number (0-based)
+
+**Returns:** Line info or `undefined` if out of bounds.
+
+**Example:**
+```typescript
+import { createRope, getLine } from 'blecsd';
+
+const rope = createRope('Line 1\nLine 2\nLine 3');
+const line = getLine(rope, 1);
+console.log(line?.text); // 'Line 2'
+```
+
+#### getLines
+
+Gets a range of lines.
+
+```typescript
+function getLines(rope: Rope, startLine: number, endLine: number): LineInfo[]
+```
+
+**Parameters:**
+- `rope` - The rope to query
+- `startLine` - Start line (inclusive)
+- `endLine` - End line (exclusive)
+
+**Returns:** Array of line info objects.
+
+### Mutations
+
+All mutation functions return a new rope (immutable).
+
+#### insert
+
+Inserts text at a position.
+
+```typescript
+function insert(rope: Rope, index: number, text: string): Rope
+```
+
+**Example:**
+```typescript
+import { createRope, insert, getText } from 'blecsd';
+
+let rope = createRope('Hello World');
+rope = insert(rope, 6, 'Beautiful ');
+console.log(getText(rope)); // 'Hello Beautiful World'
+```
+
+#### append
+
+Appends text to the end.
+
+```typescript
+function append(rope: Rope, text: string): Rope
+```
+
+#### prepend
+
+Prepends text to the start.
+
+```typescript
+function prepend(rope: Rope, text: string): Rope
+```
+
+#### deleteRange
+
+Deletes a range of text.
+
+```typescript
+function deleteRange(rope: Rope, start: number, end: number): Rope
+```
+
+**Parameters:**
+- `rope` - The rope to modify
+- `start` - Start index (inclusive)
+- `end` - End index (exclusive)
+
+**Example:**
+```typescript
+import { createRope, deleteRange, getText } from 'blecsd';
+
+let rope = createRope('Hello Beautiful World');
+rope = deleteRange(rope, 6, 16);
+console.log(getText(rope)); // 'Hello World'
+```
+
+#### replaceRange
+
+Replaces a range of text.
+
+```typescript
+function replaceRange(rope: Rope, start: number, end: number, text: string): Rope
+```
+
+**Example:**
+```typescript
+import { createRope, replaceRange, getText } from 'blecsd';
+
+let rope = createRope('Hello World');
+rope = replaceRange(rope, 6, 11, 'Universe');
+console.log(getText(rope)); // 'Hello Universe'
+```
+
+### Statistics and Debugging
+
+#### getStats
+
+Gets statistics about the rope's internal structure.
+
+```typescript
+function getStats(rope: Rope): RopeStats
+```
+
+#### verify
+
+Verifies rope integrity (useful for testing and debugging).
+
+```typescript
+function verify(rope: Rope): boolean
+```
+
+## Usage Example
+
+```typescript
+import { createRope, insert, deleteRange, getLine, getText, getStats } from 'blecsd';
+
+// Build a document
+let doc = createRope('');
+doc = insert(doc, 0, 'function hello() {\n');
+doc = insert(doc, doc.length, '  return "world";\n');
+doc = insert(doc, doc.length, '}\n');
+
+// Query lines
+const line = getLine(doc, 1);
+console.log(line?.text); // '  return "world";'
+
+// Edit in the middle
+doc = replaceRange(doc, 19, 36, '  console.log("hi");');
+
+// Check stats
+const stats = getStats(doc);
+console.log(`${stats.length} chars, ${stats.leafCount} leaves, depth ${stats.depth}`);
+```
+
+---
+
+## Related
+
+- [Fast Wrap](./fast-wrap.md) - Word wrapping with caching
+- [Line Gutter](./line-gutter.md) - Line number rendering

--- a/docs/api/utils/syntax-highlight.md
+++ b/docs/api/utils/syntax-highlight.md
@@ -1,0 +1,329 @@
+# Syntax Highlight
+
+Line-based incremental syntax highlighting with state tracking. Only changed lines and affected multi-line constructs are re-processed, with visible-first highlighting for responsive display.
+
+## Import
+
+```typescript
+import {
+  // Cache management
+  createHighlightCache,
+  clearHighlightCache,
+  setGrammar,
+  getHighlightStats,
+  // Invalidation
+  invalidateLines,
+  invalidateLine,
+  invalidateAllLines,
+  // Tokenization
+  tokenizeLine,
+  // Highlighting
+  highlightWithCache,
+  highlightVisibleFirst,
+  continueHighlight,
+  // Language detection
+  detectLanguage,
+  detectLanguageFromContent,
+  getGrammarByName,
+  // Grammars
+  GRAMMAR_JAVASCRIPT,
+  GRAMMAR_PYTHON,
+  GRAMMAR_RUST,
+  GRAMMAR_GO,
+  GRAMMAR_SHELL,
+  GRAMMAR_JSON,
+  GRAMMAR_PLAINTEXT,
+  GRAMMARS,
+  // Constants
+  EMPTY_STATE,
+  DEFAULT_HIGHLIGHT_BATCH,
+} from 'blecsd';
+```
+
+## Types
+
+### TokenType
+
+```typescript
+type TokenType =
+  | 'keyword' | 'string' | 'number' | 'comment'
+  | 'operator' | 'punctuation' | 'identifier' | 'function'
+  | 'type' | 'constant' | 'variable' | 'property'
+  | 'builtin' | 'regexp' | 'escape' | 'tag'
+  | 'attribute' | 'text';
+```
+
+### Token
+
+A token represents a highlighted span of text.
+
+```typescript
+interface Token {
+  readonly type: TokenType;
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+}
+```
+
+### LineState
+
+State for tracking multi-line constructs across lines.
+
+```typescript
+interface LineState {
+  readonly inString: string | null;
+  readonly inComment: boolean;
+  readonly templateDepth: number;
+  readonly commentDepth: number;
+}
+```
+
+### LineEntry
+
+A cached line entry with tokens and state.
+
+```typescript
+interface LineEntry {
+  readonly text: string;
+  readonly tokens: readonly Token[];
+  readonly startState: LineState;
+  readonly endState: LineState;
+}
+```
+
+### Grammar
+
+Language grammar definition.
+
+```typescript
+interface Grammar {
+  readonly name: string;
+  readonly extensions: readonly string[];
+  readonly keywords: ReadonlySet<string>;
+  readonly builtins: ReadonlySet<string>;
+  readonly types: ReadonlySet<string>;
+  readonly constants: ReadonlySet<string>;
+  readonly operators: RegExp;
+  readonly lineComment: string | null;
+  readonly blockCommentStart: string | null;
+  readonly blockCommentEnd: string | null;
+  readonly stringDelimiters: readonly string[];
+  readonly templateLiteralStart: string | null;
+  readonly templateLiteralEnd: string | null;
+  readonly numberPattern: RegExp;
+  readonly identifierPattern: RegExp;
+  readonly nestedComments: boolean;
+}
+```
+
+### HighlightCache
+
+Highlight cache for a document.
+
+```typescript
+interface HighlightCache {
+  grammar: Grammar;
+  readonly entries: Map<number, LineEntry>;
+  readonly dirty: Set<number>;
+  lineCount: number;
+  fullInvalidate: boolean;
+}
+```
+
+### HighlightResult
+
+Result of visible-first highlighting.
+
+```typescript
+interface HighlightResult {
+  readonly lines: readonly LineEntry[];
+  readonly hasMore: boolean;
+  readonly nextLine: number;
+  readonly timeMs: number;
+}
+```
+
+### HighlightStats
+
+```typescript
+interface HighlightStats {
+  readonly cachedLines: number;
+  readonly dirtyLines: number;
+  readonly grammar: string;
+  readonly lineCount: number;
+  readonly fullInvalidate: boolean;
+}
+```
+
+## Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DEFAULT_HIGHLIGHT_BATCH` | `100` | Default batch size for background highlighting |
+| `EMPTY_STATE` | `{ inString: null, inComment: false, templateDepth: 0, commentDepth: 0 }` | Initial empty line state |
+
+## Built-in Grammars
+
+| Grammar | Languages |
+|---------|-----------|
+| `GRAMMAR_JAVASCRIPT` | .js, .jsx, .ts, .tsx, .mjs, .cjs |
+| `GRAMMAR_PYTHON` | .py, .pyw, .pyi |
+| `GRAMMAR_RUST` | .rs (with nested comments) |
+| `GRAMMAR_GO` | .go |
+| `GRAMMAR_SHELL` | .sh, .bash, .zsh, .fish |
+| `GRAMMAR_JSON` | .json, .jsonc, .json5 |
+| `GRAMMAR_PLAINTEXT` | .txt, .text (no highlighting) |
+
+## Functions
+
+### createHighlightCache
+
+Creates a new highlight cache for a grammar.
+
+```typescript
+function createHighlightCache(grammar: Grammar): HighlightCache
+```
+
+### clearHighlightCache
+
+Clears all entries from the cache.
+
+```typescript
+function clearHighlightCache(cache: HighlightCache): void
+```
+
+### setGrammar
+
+Changes the grammar used for highlighting. Invalidates all lines if the grammar changed.
+
+```typescript
+function setGrammar(cache: HighlightCache, grammar: Grammar): void
+```
+
+### getHighlightStats
+
+Gets statistics about the highlight cache.
+
+```typescript
+function getHighlightStats(cache: HighlightCache): HighlightStats
+```
+
+### invalidateLines / invalidateLine / invalidateAllLines
+
+Marks lines as dirty so they are re-tokenized on the next highlight pass.
+
+```typescript
+function invalidateLines(cache: HighlightCache, start: number, end: number): void
+function invalidateLine(cache: HighlightCache, line: number): void
+function invalidateAllLines(cache: HighlightCache): void
+```
+
+### tokenizeLine
+
+Tokenizes a single line given a grammar and starting state.
+
+```typescript
+function tokenizeLine(grammar: Grammar, line: string, startState: LineState): LineEntry
+```
+
+### highlightWithCache
+
+Highlights full text, caching results. Re-tokenizes only dirty or state-changed lines.
+
+```typescript
+function highlightWithCache(cache: HighlightCache, text: string): readonly LineEntry[]
+```
+
+### highlightVisibleFirst
+
+Highlights visible lines first for responsive display, returning continuation info for background processing.
+
+```typescript
+function highlightVisibleFirst(
+  cache: HighlightCache,
+  text: string,
+  startLine: number,
+  endLine: number,
+): HighlightResult
+```
+
+### continueHighlight
+
+Continues highlighting from a specific line in batches.
+
+```typescript
+function continueHighlight(
+  cache: HighlightCache,
+  text: string,
+  startLine: number,
+  batchSize?: number,
+): HighlightResult
+```
+
+### detectLanguage
+
+Detects the language from a file extension.
+
+```typescript
+function detectLanguage(filename: string): Grammar
+```
+
+### detectLanguageFromContent
+
+Detects the language from content heuristics (shebangs, common patterns).
+
+```typescript
+function detectLanguageFromContent(content: string): Grammar
+```
+
+### getGrammarByName
+
+Gets a grammar by name, supporting aliases (e.g., "ts", "py", "rs").
+
+```typescript
+function getGrammarByName(name: string): Grammar
+```
+
+## Usage
+
+```typescript
+import {
+  createHighlightCache, highlightVisibleFirst, continueHighlight,
+  detectLanguage, GRAMMAR_JAVASCRIPT, tokenizeLine, EMPTY_STATE,
+} from 'blecsd';
+
+// Detect language and create cache
+const grammar = detectLanguage('app.ts');
+const cache = createHighlightCache(grammar);
+
+// Highlight visible lines first (responsive)
+const result = highlightVisibleFirst(cache, sourceCode, 0, 40);
+for (const line of result.lines) {
+  for (const token of line.tokens) {
+    // Apply color based on token.type
+    renderToken(token.text, token.type);
+  }
+}
+
+// Continue in the background
+if (result.hasMore) {
+  let next = result.nextLine;
+  while (true) {
+    const batch = continueHighlight(cache, sourceCode, next, 100);
+    next = batch.nextLine;
+    if (!batch.hasMore) break;
+  }
+}
+
+// Tokenize a single line
+const entry = tokenizeLine(GRAMMAR_JAVASCRIPT, 'const x = 42;', EMPTY_STATE);
+// entry.tokens: [keyword "const", text " ", identifier "x", ...]
+```
+
+---
+
+## Related
+
+- [Virtualized Line Store](./virtualized-line-store.md) - Large text content storage
+- [Fold Regions](./fold-regions.md) - Collapsible document regions

--- a/docs/api/utils/text-search.md
+++ b/docs/api/utils/text-search.md
@@ -1,0 +1,314 @@
+# Text Search
+
+Fast search across massive text buffers with Boyer-Moore-Horspool for literal string matching, regex support with timeout protection, incremental search with result caching, and match navigation.
+
+## Import
+
+```typescript
+import {
+  // Search functions
+  search,
+  searchLiteral,
+  searchRegex,
+  searchReverse,
+  searchBatch,
+  boyerMooreHorspool,
+  // Cache
+  createSearchCache,
+  clearSearchCache,
+  updateSearchQuery,
+  searchWithCache,
+  // Navigation
+  getNextMatch,
+  getPreviousMatch,
+  getMatchAt,
+  findNearestMatch,
+  getVisibleMatches,
+  getMatchStatus,
+  // Utilities
+  positionToLineColumn,
+  // Constants
+  DEFAULT_TIMEOUT,
+  DEFAULT_SEARCH_BATCH,
+} from 'blecsd';
+```
+
+## Types
+
+### SearchMatch
+
+A single match result.
+
+```typescript
+interface SearchMatch {
+  readonly start: number;   // Character index
+  readonly end: number;     // Character index
+  readonly line: number;    // 0-indexed
+  readonly column: number;  // 0-indexed
+  readonly text: string;    // Matched text
+}
+```
+
+### SearchOptions
+
+```typescript
+interface SearchOptions {
+  readonly caseSensitive?: boolean;  // Default: false
+  readonly wholeWord?: boolean;      // Default: false
+  readonly regex?: boolean;          // Default: false
+  readonly maxMatches?: number;      // Default: unlimited
+  readonly timeout?: number;         // Default: 5000ms (regex only)
+  readonly startPosition?: number;
+  readonly reverse?: boolean;
+}
+```
+
+### SearchResult
+
+```typescript
+interface SearchResult {
+  readonly matches: readonly SearchMatch[];
+  readonly totalCount: number;
+  readonly truncated: boolean;
+  readonly timedOut: boolean;
+  readonly timeMs: number;
+  readonly query: string;
+}
+```
+
+### SearchCache
+
+Search cache for incremental updates and match navigation.
+
+```typescript
+interface SearchCache {
+  query: string;
+  options: SearchOptions;
+  matches: SearchMatch[];
+  textHash: number;
+  currentIndex: number;
+  complete: boolean;
+  lastPosition: number;
+}
+```
+
+### ProgressiveSearchResult
+
+```typescript
+interface ProgressiveSearchResult {
+  readonly matches: readonly SearchMatch[];
+  readonly hasMore: boolean;
+  readonly nextPosition: number;
+  readonly timeMs: number;
+}
+```
+
+## Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DEFAULT_TIMEOUT` | `5000` | Default regex timeout in milliseconds |
+| `DEFAULT_SEARCH_BATCH` | `100000` | Default batch size for progressive search |
+
+## Functions
+
+### search
+
+Unified search function handling both literal and regex patterns.
+
+```typescript
+function search(text: string, query: string, options?: SearchOptions): SearchResult
+```
+
+### searchLiteral
+
+Searches for literal text using Boyer-Moore-Horspool.
+
+```typescript
+function searchLiteral(text: string, query: string, options?: SearchOptions): SearchResult
+```
+
+### searchRegex
+
+Searches for regex pattern with timeout protection.
+
+```typescript
+function searchRegex(text: string, pattern: string, options?: SearchOptions): SearchResult
+```
+
+### searchReverse
+
+Searches in reverse (from end to start), returning matches in reverse order.
+
+```typescript
+function searchReverse(text: string, query: string, options?: SearchOptions): SearchResult
+```
+
+### boyerMooreHorspool
+
+Low-level Boyer-Moore-Horspool literal string search returning match start positions.
+
+```typescript
+function boyerMooreHorspool(
+  text: string,
+  pattern: string,
+  caseSensitive?: boolean,
+  startPosition?: number,
+): number[]
+```
+
+### searchBatch
+
+Performs incremental search in batches for progressive results.
+
+```typescript
+function searchBatch(
+  text: string,
+  query: string,
+  startPosition: number,
+  batchSize?: number,
+  options?: SearchOptions,
+): ProgressiveSearchResult
+```
+
+### positionToLineColumn
+
+Converts a character position to line and column numbers.
+
+```typescript
+function positionToLineColumn(text: string, position: number): { line: number; column: number }
+```
+
+## Cache Functions
+
+### createSearchCache / clearSearchCache
+
+Creates or clears a search cache.
+
+```typescript
+function createSearchCache(): SearchCache
+function clearSearchCache(cache: SearchCache): void
+```
+
+### updateSearchQuery
+
+Updates the cache with a new query, invalidating if the query, options, or text changed.
+
+```typescript
+function updateSearchQuery(
+  cache: SearchCache,
+  text: string,
+  query: string,
+  options?: SearchOptions,
+): boolean
+```
+
+**Returns:** Whether the cache was invalidated
+
+### searchWithCache
+
+Performs cached search with incremental updates. Continues from where the last search left off.
+
+```typescript
+function searchWithCache(
+  cache: SearchCache,
+  text: string,
+  batchSize?: number,
+): SearchResult
+```
+
+## Navigation Functions
+
+### getNextMatch / getPreviousMatch
+
+Navigates through matches, wrapping around at boundaries.
+
+```typescript
+function getNextMatch(cache: SearchCache): SearchMatch | undefined
+function getPreviousMatch(cache: SearchCache): SearchMatch | undefined
+```
+
+### getMatchAt
+
+Gets a specific match by index.
+
+```typescript
+function getMatchAt(cache: SearchCache, index: number): SearchMatch | undefined
+```
+
+### findNearestMatch
+
+Finds the nearest match to a text position using binary search.
+
+```typescript
+function findNearestMatch(
+  cache: SearchCache,
+  position: number,
+  preferAfter?: boolean,
+): { match: SearchMatch; index: number } | undefined
+```
+
+### getVisibleMatches
+
+Gets matches visible in a line range.
+
+```typescript
+function getVisibleMatches(
+  cache: SearchCache,
+  startLine: number,
+  endLine: number,
+): readonly SearchMatch[]
+```
+
+### getMatchStatus
+
+Gets match count for display (e.g., "3 of 100").
+
+```typescript
+function getMatchStatus(cache: SearchCache): { current: number; total: number; complete: boolean }
+```
+
+## Usage
+
+```typescript
+import {
+  search, searchLiteral, createSearchCache,
+  updateSearchQuery, searchWithCache,
+  getNextMatch, getMatchStatus, getVisibleMatches,
+} from 'blecsd';
+
+// Simple literal search
+const result = searchLiteral(document, 'TODO', { caseSensitive: false });
+console.log(`Found ${result.totalCount} matches in ${result.timeMs.toFixed(1)}ms`);
+
+// Regex search with timeout
+const regexResult = search(document, 'function\\s+\\w+', { regex: true, timeout: 3000 });
+if (regexResult.timedOut) console.log('Search timed out');
+
+// Cached incremental search for interactive use
+const cache = createSearchCache();
+updateSearchQuery(cache, document, 'error');
+
+// Process in batches (non-blocking)
+let result2 = searchWithCache(cache, document, 50000);
+while (!cache.complete) {
+  result2 = searchWithCache(cache, document, 50000);
+}
+
+// Navigate matches
+const next = getNextMatch(cache);
+if (next) console.log(`Match at line ${next.line}, column ${next.column}`);
+
+const status = getMatchStatus(cache);
+console.log(`${status.current} of ${status.total}`);
+
+// Get matches for visible viewport
+const visible = getVisibleMatches(cache, 0, 40);
+```
+
+---
+
+## Related
+
+- [Virtualized Line Store](./virtualized-line-store.md) - Large text content storage
+- [Cursor Navigation](./cursor-navigation.md) - Cursor/viewport management

--- a/docs/api/utils/virtual-scrollback.md
+++ b/docs/api/utils/virtual-scrollback.md
@@ -1,0 +1,364 @@
+# Virtual Scrollback
+
+Efficient virtualized scrollback buffer with chunked storage, LRU caching, optional compression, and fast line range lookups for unlimited scrollback history.
+
+## Import
+
+```typescript
+import {
+  createScrollbackBuffer,
+  clearScrollback,
+  appendLine,
+  appendLines,
+  getLine,
+  getLineRange,
+  getVisibleLines,
+  jumpToLine,
+  scrollBy,
+  scrollToTop,
+  scrollToBottom,
+  getScrollbackStats,
+  getMemoryUsage,
+  loadFromText,
+  exportToText,
+  trimToLineCount,
+  compressOldChunks,
+  decompressAll,
+  DEFAULT_CHUNK_SIZE,
+  DEFAULT_MAX_CACHED,
+  DEFAULT_MAX_MEMORY,
+  COMPRESSION_RATIO,
+} from 'blecsd';
+```
+
+## Types
+
+### ScrollbackLine
+
+A single line of content with optional metadata.
+
+```typescript
+interface ScrollbackLine {
+  readonly text: string;
+  readonly ansi?: string;
+  readonly timestamp?: number;
+  readonly meta?: Record<string, unknown>;
+}
+```
+
+### Chunk
+
+A chunk of stored lines.
+
+```typescript
+interface Chunk {
+  readonly id: number;
+  readonly lines: ScrollbackLine[];
+  readonly startLine: number;
+  readonly lineCount: number;
+  compressed: boolean;
+  compressedData?: string;
+  memorySize: number;
+  lastAccess: number;
+}
+```
+
+### ScrollbackConfig
+
+Buffer configuration.
+
+```typescript
+interface ScrollbackConfig {
+  readonly chunkSize: number;           // Lines per chunk (default: 1000)
+  readonly maxCachedChunks: number;     // Max chunks in memory (default: 100)
+  readonly enableCompression: boolean;  // Compress old chunks (default: true)
+  readonly maxLines: number;            // Max total lines, 0 = unlimited
+  readonly maxMemory: number;           // Memory limit in bytes, 0 = unlimited
+}
+```
+
+### LineRange
+
+Result from a line range query.
+
+```typescript
+interface LineRange {
+  readonly lines: readonly ScrollbackLine[];
+  readonly startLine: number;
+  readonly endLine: number;
+  readonly complete: boolean;
+  readonly loadTimeMs: number;
+}
+```
+
+### ScrollbackStats
+
+```typescript
+interface ScrollbackStats {
+  readonly totalLines: number;
+  readonly totalChunks: number;
+  readonly cachedChunks: number;
+  readonly compressedChunks: number;
+  readonly memoryBytes: number;
+  readonly memoryMB: number;
+}
+```
+
+### ScrollbackBuffer
+
+The main buffer object.
+
+```typescript
+interface ScrollbackBuffer {
+  readonly config: ScrollbackConfig;
+  readonly chunks: Map<number, Chunk>;
+  readonly lruOrder: number[];
+  totalLines: number;
+  memoryBytes: number;
+  nextChunkId: number;
+}
+```
+
+## Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DEFAULT_CHUNK_SIZE` | 1000 | Default lines per chunk |
+| `DEFAULT_MAX_CACHED` | 100 | Default max cached chunks |
+| `DEFAULT_MAX_MEMORY` | 209715200 | Default memory limit (200 MB) |
+| `COMPRESSION_RATIO` | 0.5 | Estimated compression ratio |
+
+## Functions
+
+### Buffer Creation
+
+#### createScrollbackBuffer
+
+Creates a new scrollback buffer.
+
+```typescript
+function createScrollbackBuffer(config?: Partial<ScrollbackConfig>): ScrollbackBuffer
+```
+
+**Example:**
+```typescript
+import { createScrollbackBuffer } from 'blecsd';
+
+const buffer = createScrollbackBuffer({
+  chunkSize: 1000,
+  maxCachedChunks: 100,
+  enableCompression: true,
+});
+```
+
+#### clearScrollback
+
+Clears all content from the buffer.
+
+```typescript
+function clearScrollback(buffer: ScrollbackBuffer): void
+```
+
+### Line Operations
+
+#### appendLine
+
+Appends a single line. Automatically manages chunking, LRU eviction, and compression.
+
+```typescript
+function appendLine(
+  buffer: ScrollbackBuffer,
+  text: string,
+  ansi?: string,
+  meta?: Record<string, unknown>,
+): void
+```
+
+**Example:**
+```typescript
+import { createScrollbackBuffer, appendLine } from 'blecsd';
+
+const buffer = createScrollbackBuffer();
+appendLine(buffer, 'Hello, world!');
+appendLine(buffer, '\x1b[31mRed text\x1b[0m', undefined, { color: 'red' });
+```
+
+#### appendLines
+
+Appends multiple lines at once.
+
+```typescript
+function appendLines(buffer: ScrollbackBuffer, lines: readonly string[]): void
+```
+
+#### getLine
+
+Gets a single line by index.
+
+```typescript
+function getLine(buffer: ScrollbackBuffer, lineIndex: number): ScrollbackLine | undefined
+```
+
+#### getLineRange
+
+Gets a range of lines.
+
+```typescript
+function getLineRange(
+  buffer: ScrollbackBuffer,
+  startLine: number,
+  endLine: number,
+): LineRange
+```
+
+#### getVisibleLines
+
+Gets lines for a viewport.
+
+```typescript
+function getVisibleLines(
+  buffer: ScrollbackBuffer,
+  viewportStart: number,
+  viewportSize: number,
+): LineRange
+```
+
+### Scrolling
+
+#### jumpToLine
+
+Jumps to a line, preloading surrounding context.
+
+```typescript
+function jumpToLine(
+  buffer: ScrollbackBuffer,
+  lineIndex: number,
+  contextLines?: number,
+): LineRange
+```
+
+**Parameters:**
+- `buffer` - The buffer
+- `lineIndex` - Target line
+- `contextLines` - Lines to preload before and after (default: 100)
+
+#### scrollBy
+
+Scrolls by a delta.
+
+```typescript
+function scrollBy(
+  buffer: ScrollbackBuffer,
+  currentLine: number,
+  delta: number,
+  viewportSize: number,
+): LineRange
+```
+
+**Parameters:**
+- `delta` - Lines to scroll (positive = down, negative = up)
+
+#### scrollToTop / scrollToBottom
+
+```typescript
+function scrollToTop(buffer: ScrollbackBuffer, viewportSize: number): LineRange
+function scrollToBottom(buffer: ScrollbackBuffer, viewportSize: number): LineRange
+```
+
+### Statistics
+
+#### getScrollbackStats
+
+```typescript
+function getScrollbackStats(buffer: ScrollbackBuffer): ScrollbackStats
+```
+
+#### getMemoryUsage
+
+```typescript
+function getMemoryUsage(buffer: ScrollbackBuffer): number
+```
+
+### Bulk Operations
+
+#### loadFromText
+
+Loads content from a newline-separated text string.
+
+```typescript
+function loadFromText(buffer: ScrollbackBuffer, text: string): void
+```
+
+#### exportToText
+
+Exports buffer content as text.
+
+```typescript
+function exportToText(
+  buffer: ScrollbackBuffer,
+  startLine?: number,
+  endLine?: number,
+): string
+```
+
+#### trimToLineCount
+
+Trims old content to stay within a line limit.
+
+```typescript
+function trimToLineCount(buffer: ScrollbackBuffer, maxLines: number): void
+```
+
+### Compression Control
+
+#### compressOldChunks
+
+Forces compression of all chunks except the most recent N.
+
+```typescript
+function compressOldChunks(buffer: ScrollbackBuffer, keepUncompressed?: number): void
+```
+
+#### decompressAll
+
+Decompresses all chunks (for export or bulk processing).
+
+```typescript
+function decompressAll(buffer: ScrollbackBuffer): void
+```
+
+## Usage Example
+
+```typescript
+import {
+  createScrollbackBuffer,
+  appendLine,
+  getVisibleLines,
+  scrollToBottom,
+  getScrollbackStats,
+} from 'blecsd';
+
+const buffer = createScrollbackBuffer({ chunkSize: 500 });
+
+// Simulate terminal output
+for (let i = 0; i < 10000; i++) {
+  appendLine(buffer, `[${new Date().toISOString()}] Log line ${i}`);
+}
+
+// Get visible viewport
+const visible = scrollToBottom(buffer, 40);
+for (const line of visible.lines) {
+  console.log(line.text);
+}
+
+// Check stats
+const stats = getScrollbackStats(buffer);
+console.log(`${stats.totalLines} lines, ${stats.memoryMB} MB, ${stats.compressedChunks} compressed`);
+```
+
+---
+
+## Related
+
+- [Line Gutter](./line-gutter.md) - Line number rendering for scrolled views
+- [Fast Wrap](./fast-wrap.md) - Word wrapping with caching

--- a/docs/api/utils/virtualized-line-store.md
+++ b/docs/api/utils/virtualized-line-store.md
@@ -1,0 +1,271 @@
+# Virtualized Line Store
+
+High-performance data structure for storing and accessing millions of lines with O(1) random access. Optimized for read-only content with streaming append support.
+
+## Import
+
+```typescript
+import {
+  createLineStore,
+  createLineStoreFromLines,
+  createEmptyLineStore,
+  getLineAtIndex,
+  getLineInfo,
+  getLineRange,
+  getVisibleLines,
+  appendToStore,
+  appendLines,
+  getLineCount,
+  getByteSize,
+  isStoreEmpty,
+  getStoreStats,
+  getLineForOffset,
+  getOffsetForLine,
+  exportContent,
+  exportLineRange,
+  trimToLineCount,
+  CHUNKED_THRESHOLD,
+} from 'blecsd';
+```
+
+## Types
+
+### VirtualizedLineStore
+
+Immutable view of a virtualized line store.
+
+```typescript
+interface VirtualizedLineStore {
+  readonly buffer: string;
+  readonly offsets: Uint32Array;
+  readonly lineCount: number;
+  readonly byteSize: number;
+  readonly indexed: boolean;
+}
+```
+
+### LineStoreStats
+
+```typescript
+interface LineStoreStats {
+  readonly lineCount: number;
+  readonly byteSize: number;
+  readonly offsetArrayBytes: number;
+  readonly totalMemoryBytes: number;
+  readonly avgLineLength: number;
+  readonly indexed: boolean;
+}
+```
+
+### LineRange
+
+```typescript
+interface LineRange {
+  readonly lines: readonly string[];
+  readonly startLine: number;
+  readonly endLine: number;         // exclusive
+  readonly extractTimeMs: number;
+}
+```
+
+### LineInfo
+
+```typescript
+interface LineInfo {
+  readonly text: string;
+  readonly offset: number;
+  readonly length: number;
+  readonly lineNumber: number;
+}
+```
+
+## Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `CHUNKED_THRESHOLD` | `1_000_000` | Maximum lines before switching to chunked mode |
+
+## Zod Schemas
+
+Validation schemas are exported for runtime validation of parameters.
+
+```typescript
+import { LineIndexSchema, LineRangeParamsSchema, VisibleLinesParamsSchema, TrimParamsSchema } from 'blecsd';
+```
+
+## Functions
+
+### createLineStore
+
+Creates a virtualized line store from text content.
+
+```typescript
+function createLineStore(content?: string): VirtualizedLineStore
+```
+
+### createLineStoreFromLines
+
+Creates a line store from an array of lines.
+
+```typescript
+function createLineStoreFromLines(lines: readonly string[]): VirtualizedLineStore
+```
+
+### createEmptyLineStore
+
+Creates an empty line store.
+
+```typescript
+function createEmptyLineStore(): VirtualizedLineStore
+```
+
+### getLineAtIndex
+
+Gets a line at a specific index. O(1) operation.
+
+```typescript
+function getLineAtIndex(store: VirtualizedLineStore, index: number): string | undefined
+```
+
+### getLineInfo
+
+Gets detailed information about a line.
+
+```typescript
+function getLineInfo(store: VirtualizedLineStore, index: number): LineInfo | undefined
+```
+
+### getLineRange
+
+Gets a range of lines. Optimized for viewport extraction.
+
+```typescript
+function getLineRange(
+  store: VirtualizedLineStore,
+  startLine: number,
+  endLine: number,
+): LineRange
+```
+
+### getVisibleLines
+
+Gets visible lines for a viewport with configurable overscan.
+
+```typescript
+function getVisibleLines(
+  store: VirtualizedLineStore,
+  firstVisible: number,
+  visibleCount: number,
+  overscanBefore?: number,  // Default: 5
+  overscanAfter?: number,   // Default: 5
+): LineRange
+```
+
+### appendToStore
+
+Appends raw content to the store, returning a new store. Optimized for streaming append (log viewers).
+
+```typescript
+function appendToStore(store: VirtualizedLineStore, content: string): VirtualizedLineStore
+```
+
+### appendLines
+
+Appends an array of lines to the store.
+
+```typescript
+function appendLines(store: VirtualizedLineStore, lines: readonly string[]): VirtualizedLineStore
+```
+
+### getLineCount / getByteSize / isStoreEmpty
+
+Simple query functions.
+
+```typescript
+function getLineCount(store: VirtualizedLineStore): number
+function getByteSize(store: VirtualizedLineStore): number
+function isStoreEmpty(store: VirtualizedLineStore): boolean
+```
+
+### getStoreStats
+
+Gets statistics about the store.
+
+```typescript
+function getStoreStats(store: VirtualizedLineStore): LineStoreStats
+```
+
+### getLineForOffset
+
+Finds the line index for a byte offset using binary search. O(log n).
+
+```typescript
+function getLineForOffset(store: VirtualizedLineStore, byteOffset: number): number
+```
+
+### getOffsetForLine
+
+Gets the byte offset for a line.
+
+```typescript
+function getOffsetForLine(store: VirtualizedLineStore, lineIndex: number): number
+```
+
+**Returns:** Byte offset, or -1 if out of bounds
+
+### exportContent / exportLineRange
+
+Exports content as strings.
+
+```typescript
+function exportContent(store: VirtualizedLineStore): string
+function exportLineRange(store: VirtualizedLineStore, startLine: number, endLine: number): string
+```
+
+### trimToLineCount
+
+Creates a trimmed store with only the last N lines. Useful for keeping log buffers bounded.
+
+```typescript
+function trimToLineCount(store: VirtualizedLineStore, maxLines: number): VirtualizedLineStore
+```
+
+## Usage
+
+```typescript
+import {
+  createLineStore, getLineAtIndex, getLineRange,
+  appendToStore, getStoreStats, trimToLineCount,
+} from 'blecsd';
+
+// Create store from content
+const store = createLineStore('Line 1\nLine 2\nLine 3');
+
+// O(1) random access
+const line = getLineAtIndex(store, 1); // 'Line 2'
+
+// Extract viewport
+const viewport = getLineRange(store, 0, 25);
+console.log(viewport.lines.length);       // 3
+console.log(`${viewport.extractTimeMs}ms`);
+
+// Streaming append for log viewers
+let logStore = createLineStore('');
+logStore = appendToStore(logStore, 'Log entry 1\nLog entry 2');
+logStore = appendToStore(logStore, '\nLog entry 3');
+
+// Keep log bounded
+logStore = trimToLineCount(logStore, 10000);
+
+// Stats
+const stats = getStoreStats(store);
+console.log(`${stats.lineCount} lines, ${stats.totalMemoryBytes} bytes`);
+```
+
+---
+
+## Related
+
+- [Lazy Content](./lazy-content.md) - Lazy loading for huge files
+- [Cursor Navigation](./cursor-navigation.md) - Cursor/viewport management
+- [Text Search](./text-search.md) - Search across text buffers

--- a/docs/api/widgets/content-manipulation.md
+++ b/docs/api/widgets/content-manipulation.md
@@ -1,0 +1,408 @@
+# Content Manipulation
+
+A set of functions for line-level manipulation of entity text content. Provides array-like operations (push, pop, shift, splice) on content lines with automatic scroll adjustment.
+
+## Overview
+
+```typescript
+import {
+  getLines,
+  setLines,
+  insertLine,
+  deleteLine,
+  pushLine,
+  popLine,
+  spliceLines,
+} from 'blecsd';
+
+// Set content, then manipulate by line
+setContent(world, entity, 'Line 1\nLine 2\nLine 3');
+
+insertLine(world, entity, 1, 'Inserted');
+// Content: 'Line 1\nInserted\nLine 2\nLine 3'
+
+const removed = popLine(world, entity);
+// removed: 'Line 3'
+// Content: 'Line 1\nInserted\nLine 2'
+```
+
+---
+
+## Reading Functions
+
+### getLines
+
+Gets the content of an entity as an array of lines.
+
+```typescript
+import { getLines } from 'blecsd';
+
+setContent(world, entity, 'Line 1\nLine 2\nLine 3');
+const lines = getLines(world, entity);
+// ['Line 1', 'Line 2', 'Line 3']
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `eid: Entity` - The entity ID
+
+**Returns:** `string[]`
+
+### getLineCount
+
+Gets the number of lines in an entity's content.
+
+```typescript
+import { getLineCount } from 'blecsd';
+
+setContent(world, entity, 'Line 1\nLine 2\nLine 3');
+console.log(getLineCount(world, entity)); // 3
+```
+
+**Returns:** `number`
+
+### getLine
+
+Gets a specific line by index (0-based).
+
+```typescript
+import { getLine } from 'blecsd';
+
+setContent(world, entity, 'Line 1\nLine 2\nLine 3');
+console.log(getLine(world, entity, 1)); // 'Line 2'
+```
+
+**Returns:** `string` - The line content, or empty string if index is out of bounds.
+
+### getBaseLine
+
+Gets a line from the base content (before scroll adjustment). Equivalent to `getLine` since scroll offset is applied during rendering, not storage.
+
+```typescript
+import { getBaseLine } from 'blecsd';
+
+console.log(getBaseLine(world, entity, 0)); // Same as getLine
+```
+
+---
+
+## Writing Functions
+
+### setLine
+
+Sets a specific line by index. Marks the entity dirty.
+
+```typescript
+import { setLine } from 'blecsd';
+
+setContent(world, entity, 'Line 1\nLine 2\nLine 3');
+setLine(world, entity, 1, 'Modified Line');
+// Content: 'Line 1\nModified Line\nLine 3'
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `eid: Entity` - The entity ID
+- `index: number` - Line index (0-based)
+- `line: string` - New line content
+
+**Returns:** `Entity` - The entity ID for chaining
+
+### setBaseLine
+
+Sets a line in the base content. Equivalent to `setLine`.
+
+```typescript
+import { setBaseLine } from 'blecsd';
+
+setBaseLine(world, entity, 0, 'New first line');
+```
+
+### setLines
+
+Sets all content lines at once. Marks the entity dirty and adjusts scroll if content is now shorter.
+
+```typescript
+import { setLines } from 'blecsd';
+
+setLines(world, entity, ['Line 1', 'Line 2', 'Line 3']);
+// Content: 'Line 1\nLine 2\nLine 3'
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `eid: Entity` - The entity ID
+- `lines: string[]` - Array of lines
+
+**Returns:** `Entity`
+
+### clearLines
+
+Clears all lines and resets scroll position.
+
+```typescript
+import { clearLines } from 'blecsd';
+
+clearLines(world, entity);
+// Content: ''
+```
+
+---
+
+## Insertion Functions
+
+### insertLine
+
+Inserts a line at a specific position. Adjusts scroll if inserting above the current scroll position.
+
+```typescript
+import { insertLine } from 'blecsd';
+
+setContent(world, entity, 'Line 1\nLine 3');
+insertLine(world, entity, 1, 'Line 2');
+// Content: 'Line 1\nLine 2\nLine 3'
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `eid: Entity` - The entity ID
+- `index: number` - Position to insert (0-based, clamped to valid range)
+- `line: string` - The line to insert
+
+**Returns:** `Entity`
+
+### insertTop
+
+Inserts a line at the top of the content.
+
+```typescript
+import { insertTop } from 'blecsd';
+
+setContent(world, entity, 'Line 2\nLine 3');
+insertTop(world, entity, 'Line 1');
+// Content: 'Line 1\nLine 2\nLine 3'
+```
+
+### insertBottom
+
+Inserts a line at the bottom of the content.
+
+```typescript
+import { insertBottom } from 'blecsd';
+
+setContent(world, entity, 'Line 1\nLine 2');
+insertBottom(world, entity, 'Line 3');
+// Content: 'Line 1\nLine 2\nLine 3'
+```
+
+---
+
+## Deletion Functions
+
+### deleteLine
+
+Deletes one or more lines starting at a specific position. Adjusts scroll if deleting above the current scroll position.
+
+```typescript
+import { deleteLine } from 'blecsd';
+
+setContent(world, entity, 'Line 1\nLine 2\nLine 3\nLine 4');
+deleteLine(world, entity, 1, 2);
+// Content: 'Line 1\nLine 4'
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `eid: Entity` - The entity ID
+- `index: number` - Starting line index
+- `count?: number` - Number of lines to delete (default: 1)
+
+**Returns:** `Entity`
+
+### deleteTop
+
+Deletes lines from the top.
+
+```typescript
+import { deleteTop } from 'blecsd';
+
+setContent(world, entity, 'Line 1\nLine 2\nLine 3');
+deleteTop(world, entity, 1);
+// Content: 'Line 2\nLine 3'
+```
+
+### deleteBottom
+
+Deletes lines from the bottom.
+
+```typescript
+import { deleteBottom } from 'blecsd';
+
+setContent(world, entity, 'Line 1\nLine 2\nLine 3');
+deleteBottom(world, entity, 1);
+// Content: 'Line 1\nLine 2'
+```
+
+---
+
+## Stack-Like Operations
+
+### pushLine
+
+Pushes a line to the bottom (alias for `insertBottom`).
+
+```typescript
+import { pushLine } from 'blecsd';
+
+pushLine(world, entity, 'Log entry 1');
+pushLine(world, entity, 'Log entry 2');
+// Lines: ['Log entry 1', 'Log entry 2']
+```
+
+### popLine
+
+Removes and returns the last line.
+
+```typescript
+import { popLine } from 'blecsd';
+
+setContent(world, entity, 'Line 1\nLine 2\nLine 3');
+const removed = popLine(world, entity);
+// removed: 'Line 3'
+// Content: 'Line 1\nLine 2'
+```
+
+**Returns:** `string` - The removed line, or empty string if content is empty.
+
+### shiftLine
+
+Removes and returns the first line. Adjusts scroll position.
+
+```typescript
+import { shiftLine } from 'blecsd';
+
+setContent(world, entity, 'Line 1\nLine 2\nLine 3');
+const removed = shiftLine(world, entity);
+// removed: 'Line 1'
+// Content: 'Line 2\nLine 3'
+```
+
+**Returns:** `string` - The removed line, or empty string if content is empty.
+
+### unshiftLine
+
+Adds a line to the top (alias for `insertTop`).
+
+```typescript
+import { unshiftLine } from 'blecsd';
+
+unshiftLine(world, entity, 'New first line');
+```
+
+---
+
+## Batch Operations
+
+### replaceLines
+
+Replaces multiple lines starting at an index (in-place, does not change line count).
+
+```typescript
+import { replaceLines } from 'blecsd';
+
+setContent(world, entity, 'A\nB\nC\nD\nE');
+replaceLines(world, entity, 1, ['X', 'Y']);
+// Content: 'A\nX\nY\nD\nE'
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `eid: Entity` - The entity ID
+- `startIndex: number` - Starting line index
+- `newLines: string[]` - Replacement lines
+
+**Returns:** `Entity`
+
+### spliceLines
+
+Deletes and/or inserts lines at a position (like `Array.splice`).
+
+```typescript
+import { spliceLines } from 'blecsd';
+
+setContent(world, entity, 'A\nB\nC\nD');
+const deleted = spliceLines(world, entity, 1, 2, ['X', 'Y', 'Z']);
+// deleted: ['B', 'C']
+// Content: 'A\nX\nY\nZ\nD'
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `eid: Entity` - The entity ID
+- `start: number` - Starting index
+- `deleteCount: number` - Number of lines to delete
+- `insertLines?: string[]` - Optional lines to insert
+
+**Returns:** `string[]` - Array of deleted lines
+
+---
+
+## Scroll Behavior
+
+All modification functions automatically adjust the scroll position for entities that have the scrollable component:
+
+- **Inserting above scroll position** - Scroll shifts down to keep the same content visible
+- **Deleting above scroll position** - Scroll shifts up proportionally
+- **Content becomes shorter than scroll** - Scroll is clamped to the valid range
+- **Clearing content** - Scroll resets to 0
+
+---
+
+## Examples
+
+### Log Buffer with Maximum Lines
+
+```typescript
+import { pushLine, getLineCount, deleteTop } from 'blecsd';
+
+const MAX_LINES = 1000;
+
+function addLogEntry(world, entity, message) {
+  pushLine(world, entity, message);
+
+  // Evict old entries
+  const count = getLineCount(world, entity);
+  if (count > MAX_LINES) {
+    deleteTop(world, entity, count - MAX_LINES);
+  }
+}
+```
+
+### Editable Text Buffer
+
+```typescript
+import { getLine, setLine, insertLine, deleteLine } from 'blecsd';
+
+// Insert a line at the cursor
+function insertAtCursor(world, entity, cursorLine, text) {
+  insertLine(world, entity, cursorLine, text);
+}
+
+// Delete the current line
+function deleteCurrentLine(world, entity, cursorLine) {
+  deleteLine(world, entity, cursorLine);
+}
+
+// Replace the current line
+function replaceCurrentLine(world, entity, cursorLine, newText) {
+  setLine(world, entity, cursorLine, newText);
+}
+```
+
+---
+
+## See Also
+
+- [Log Widget](./log.md) - Append-only log display
+- [Streaming Text](./streaming-text.md) - Incremental text rendering
+- [ScrollableText Widget](./scrollableText.md) - Scrollable text display

--- a/docs/api/widgets/file-manager.md
+++ b/docs/api/widgets/file-manager.md
@@ -1,0 +1,360 @@
+# FileManager Widget
+
+A file browser widget for navigating directories and selecting files. Supports directory navigation, sorted entries (directories first), hidden file toggle, and glob-based file filtering.
+
+## Overview
+
+```typescript
+import { createFileManager } from 'blecsd';
+
+const world = createWorld();
+
+const fm = createFileManager(world, {
+  cwd: '/home/user',
+  showHidden: false,
+  width: 50,
+  height: 25,
+  border: { type: 'line' },
+});
+
+fm.onSelect((entry) => {
+  console.log('Selected file:', entry.name);
+});
+
+fm.onNavigate((path) => {
+  console.log('Navigated to:', path);
+});
+```
+
+---
+
+## Configuration
+
+### FileManagerConfig
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `cwd` | `string` | `process.cwd()` | Initial working directory |
+| `showHidden` | `boolean` | `false` | Whether to show hidden files |
+| `filePattern` | `string` | - | Glob pattern for filtering files (e.g., `'*.ts'`) |
+| `width` | `number` | `40` | Widget width |
+| `height` | `number` | `20` | Widget height |
+| `left` | `number` | `0` | Left position |
+| `top` | `number` | `0` | Top position |
+| `fg` | `string \| number` | - | Foreground color |
+| `bg` | `string \| number` | - | Background color |
+| `border` | `FileManagerBorderConfig` | - | Border configuration |
+| `padding` | `number \| PaddingConfig` | - | Padding |
+
+### FileEntry
+
+```typescript
+interface FileEntry {
+  readonly name: string;       // File or directory name
+  readonly path: string;       // Full absolute path
+  readonly isDirectory: boolean;
+  readonly size: number;       // File size in bytes (0 for directories)
+}
+```
+
+### Zod Schema
+
+```typescript
+import { FileManagerConfigSchema } from 'blecsd';
+
+const result = FileManagerConfigSchema.safeParse({
+  cwd: '/home/user',
+  showHidden: false,
+  width: 50,
+  height: 25,
+});
+```
+
+---
+
+## Factory Function
+
+### createFileManager
+
+Creates a FileManager widget.
+
+```typescript
+import { createFileManager } from 'blecsd';
+
+const fm = createFileManager(world, {
+  cwd: '/home/user/projects',
+  showHidden: false,
+  filePattern: '*.ts',
+  width: 50,
+  height: 25,
+  border: { type: 'line', ch: 'single' },
+});
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `config?: FileManagerConfig` - Widget configuration
+
+**Returns:** `FileManagerWidget`
+
+---
+
+## FileManagerWidget Interface
+
+### eid
+
+```typescript
+readonly eid: Entity
+```
+
+The underlying entity ID.
+
+### show / hide
+
+```typescript
+show(): FileManagerWidget
+hide(): FileManagerWidget
+```
+
+Controls visibility.
+
+### move
+
+```typescript
+move(dx: number, dy: number): FileManagerWidget
+```
+
+Moves the widget by a relative offset.
+
+### setPosition
+
+```typescript
+setPosition(x: number, y: number): FileManagerWidget
+```
+
+Sets the absolute position.
+
+### center
+
+```typescript
+center(termWidth: number, termHeight: number): FileManagerWidget
+```
+
+Centers the widget within the given terminal dimensions.
+
+### setCwd
+
+```typescript
+setCwd(path: string): FileManagerWidget
+```
+
+Sets the current working directory. Reloads directory entries and resets the selection index.
+
+```typescript
+fm.setCwd('/home/user/documents');
+```
+
+### getCwd
+
+```typescript
+getCwd(): string
+```
+
+Gets the current working directory.
+
+### getSelected
+
+```typescript
+getSelected(): FileEntry | undefined
+```
+
+Gets the currently selected entry (by cursor index).
+
+### refresh
+
+```typescript
+refresh(): FileManagerWidget
+```
+
+Reloads the directory listing from the filesystem.
+
+### getEntries
+
+```typescript
+getEntries(): readonly FileEntry[]
+```
+
+Gets all current directory entries.
+
+### onSelect
+
+```typescript
+onSelect(cb: (entry: FileEntry) => void): FileManagerWidget
+```
+
+Registers a callback for when a file is selected (Enter on a file entry).
+
+### onNavigate
+
+```typescript
+onNavigate(cb: (path: string) => void): FileManagerWidget
+```
+
+Registers a callback for when navigating into a directory.
+
+### destroy
+
+```typescript
+destroy(): void
+```
+
+Destroys the widget and removes the entity from the world.
+
+---
+
+## Key Handling
+
+### handleFileManagerKey
+
+Handles keyboard input for a file manager widget.
+
+```typescript
+import { handleFileManagerKey } from 'blecsd';
+
+handleFileManagerKey(world, fmEid, 'down');      // Move selection down
+handleFileManagerKey(world, fmEid, 'up');         // Move selection up
+handleFileManagerKey(world, fmEid, 'enter');      // Open file or enter directory
+handleFileManagerKey(world, fmEid, 'backspace');  // Go to parent directory
+```
+
+**Supported keys:**
+
+| Key | Action |
+|-----|--------|
+| `up` | Move selection up |
+| `down` | Move selection down |
+| `enter` | Open file (fires onSelect) or navigate into directory (fires onNavigate) |
+| `backspace` | Navigate to parent directory |
+
+**Parameters:**
+- `world: World` - The ECS world
+- `eid: Entity` - The file manager entity ID
+- `key: string` - The key name
+
+**Returns:** `boolean` - true if the key was handled
+
+---
+
+## Utility Functions
+
+### isFileManager
+
+```typescript
+import { isFileManager } from 'blecsd';
+
+if (isFileManager(world, entity)) {
+  // Entity is a file manager widget
+}
+```
+
+### setReadDirFn
+
+Injects a custom directory-reading function. Primarily used for testing to mock filesystem operations.
+
+```typescript
+import { setReadDirFn } from 'blecsd';
+
+setReadDirFn(fmEid, (dir) => [
+  { name: 'src', path: dir + '/src', isDirectory: true, size: 0 },
+  { name: 'file.ts', path: dir + '/file.ts', isDirectory: false, size: 1024 },
+]);
+```
+
+---
+
+## Examples
+
+### File Picker Dialog
+
+```typescript
+import { createFileManager } from 'blecsd';
+
+const picker = createFileManager(world, {
+  cwd: '/home/user',
+  filePattern: '*.json',
+  width: 50,
+  height: 20,
+  border: { type: 'line', ch: 'rounded' },
+  padding: 1,
+});
+
+picker.center(80, 24);
+
+picker.onSelect((entry) => {
+  console.log('Selected:', entry.path);
+  picker.destroy();
+});
+```
+
+### Directory Browser with Hidden Files
+
+```typescript
+import { createFileManager, handleFileManagerKey } from 'blecsd';
+
+const browser = createFileManager(world, {
+  cwd: '/etc',
+  showHidden: true,
+  width: 60,
+  height: 30,
+});
+
+// In your input handler:
+function onKeyPress(key) {
+  handleFileManagerKey(world, browser.eid, key);
+}
+```
+
+### Filtered File Listing
+
+```typescript
+import { createFileManager } from 'blecsd';
+
+const fm = createFileManager(world, {
+  cwd: '/home/user/project',
+  filePattern: '*.ts',  // Only show TypeScript files
+  showHidden: false,
+});
+
+const entries = fm.getEntries();
+for (const entry of entries) {
+  console.log(entry.isDirectory ? `[DIR] ${entry.name}` : entry.name);
+}
+```
+
+---
+
+## Display Format
+
+The file manager displays entries in this format:
+
+```
+[dirname]
+..
+> src/
+  lib/
+  package.json
+  tsconfig.json
+```
+
+- The current directory name is shown in brackets at the top
+- `..` provides parent directory navigation
+- Directories are shown with a trailing `/`
+- The selected entry is prefixed with `>`
+- Entries are sorted: directories first (alphabetically), then files (alphabetically)
+
+---
+
+## See Also
+
+- [Tree Widget](./tree.md) - Hierarchical tree view
+- [List Widget](./list.md) - Selectable list items

--- a/docs/api/widgets/image.md
+++ b/docs/api/widgets/image.md
@@ -1,0 +1,333 @@
+# Image Widget
+
+Renders bitmap images in the terminal using ANSI escape sequences (256-color, ASCII art, braille) or stores bitmaps for external image protocols (w3m, iTerm2, Kitty, Sixel).
+
+## Overview
+
+```typescript
+import { createImage } from 'blecsd';
+
+const world = createWorld();
+
+const bitmap = {
+  width: 2,
+  height: 2,
+  data: new Uint8Array([
+    255, 0, 0, 255,  255, 0, 0, 255,
+    255, 0, 0, 255,  255, 0, 0, 255,
+  ]),
+};
+
+const image = createImage(world, {
+  x: 5,
+  y: 2,
+  type: 'ansi',
+  renderMode: 'color',
+  bitmap,
+});
+```
+
+---
+
+## Configuration
+
+### ImageConfig
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `x` | `number` | `0` | X position |
+| `y` | `number` | `0` | Y position |
+| `width` | `number` | bitmap width | Width in terminal columns |
+| `height` | `number` | bitmap height | Height in terminal rows |
+| `type` | `'ansi' \| 'overlay'` | `'ansi'` | Rendering type |
+| `bitmap` | `Bitmap` | - | Initial bitmap data |
+| `renderMode` | `'color' \| 'ascii' \| 'braille'` | `'color'` | ANSI render mode |
+| `dither` | `boolean` | `false` | Enable dithering in color mode |
+| `visible` | `boolean` | `true` | Whether to show initially |
+
+### ImageType
+
+- `'ansi'` - Renders bitmap as ANSI escape sequences using 256-color palette
+- `'overlay'` - Stores bitmap for external overlay protocols (w3m, iTerm2, Kitty, Sixel)
+
+### RenderMode
+
+- `'color'` - 256-color half-block characters
+- `'ascii'` - ASCII art using brightness mapping
+- `'braille'` - Braille character rendering
+
+### Bitmap
+
+```typescript
+interface Bitmap {
+  readonly width: number;
+  readonly height: number;
+  readonly data: Uint8Array;  // RGBA pixels, 4 bytes per pixel
+}
+```
+
+### Zod Schema
+
+```typescript
+import { ImageConfigSchema } from 'blecsd';
+
+const result = ImageConfigSchema.safeParse({
+  type: 'ansi',
+  width: 40,
+  renderMode: 'color',
+});
+```
+
+---
+
+## Factory Function
+
+### createImage
+
+Creates an Image widget.
+
+```typescript
+import { createImage } from 'blecsd';
+
+const image = createImage(world, {
+  x: 10,
+  y: 5,
+  width: 40,
+  height: 20,
+  type: 'ansi',
+  renderMode: 'color',
+  bitmap: myBitmap,
+});
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `config?: ImageConfig` - Widget configuration
+
+**Returns:** `ImageWidget`
+
+---
+
+## ImageWidget Interface
+
+### eid
+
+```typescript
+readonly eid: Entity
+```
+
+The underlying entity ID.
+
+### show / hide / isVisible
+
+```typescript
+show(): ImageWidget
+hide(): ImageWidget
+isVisible(): boolean
+```
+
+Controls visibility.
+
+### move
+
+```typescript
+move(dx: number, dy: number): ImageWidget
+```
+
+Moves the image by a relative offset.
+
+### setPosition
+
+```typescript
+setPosition(x: number, y: number): ImageWidget
+```
+
+Sets the absolute position.
+
+### getPosition
+
+```typescript
+getPosition(): { x: number; y: number }
+```
+
+Gets the current position.
+
+### setImage
+
+```typescript
+setImage(bitmap: Bitmap): ImageWidget
+```
+
+Sets the bitmap to render. Automatically re-renders the ANSI content.
+
+```typescript
+image.setImage({
+  width: 4,
+  height: 4,
+  data: new Uint8Array(4 * 4 * 4), // 4x4 RGBA
+});
+```
+
+### getImage
+
+```typescript
+getImage(): Bitmap | undefined
+```
+
+Gets the current bitmap data.
+
+### getType
+
+```typescript
+getType(): ImageType
+```
+
+Returns `'ansi'` or `'overlay'`.
+
+### getCellMap
+
+```typescript
+getCellMap(): CellMap | undefined
+```
+
+Gets the last rendered CellMap (ANSI mode only). Useful for advanced rendering integration.
+
+### setRenderMode
+
+```typescript
+setRenderMode(mode: RenderMode): ImageWidget
+```
+
+Changes the ANSI render mode and re-renders.
+
+```typescript
+image.setRenderMode('braille');
+```
+
+### getRenderMode
+
+```typescript
+getRenderMode(): RenderMode
+```
+
+Gets the current render mode.
+
+### render
+
+```typescript
+render(): string
+```
+
+Renders the current bitmap to an ANSI string. Returns an empty string if no bitmap is set.
+
+```typescript
+const ansiOutput = image.render();
+process.stdout.write(ansiOutput);
+```
+
+### destroy
+
+```typescript
+destroy(): void
+```
+
+Destroys the image widget and removes the entity from the world.
+
+---
+
+## Utility Functions
+
+### isImage
+
+```typescript
+import { isImage } from 'blecsd';
+
+if (isImage(world, entity)) {
+  // Entity is an image widget
+}
+```
+
+### getImageBitmap
+
+```typescript
+import { getImageBitmap } from 'blecsd';
+
+const bitmap = getImageBitmap(entity);
+if (bitmap) {
+  console.log(`Image: ${bitmap.width}x${bitmap.height}`);
+}
+```
+
+### getImageCellMap
+
+```typescript
+import { getImageCellMap } from 'blecsd';
+
+const cellMap = getImageCellMap(entity);
+if (cellMap) {
+  console.log(`Cells: ${cellMap.width}x${cellMap.height}`);
+}
+```
+
+---
+
+## Examples
+
+### Render Modes
+
+```typescript
+import { createImage } from 'blecsd';
+
+const image = createImage(world, {
+  bitmap: myBitmap,
+  type: 'ansi',
+});
+
+// Switch between render modes
+image.setRenderMode('color');    // 256-color half-blocks
+image.setRenderMode('ascii');    // ASCII art
+image.setRenderMode('braille');  // Braille characters
+```
+
+### Overlay Mode for External Protocols
+
+```typescript
+import { createImage, getImageBitmap } from 'blecsd';
+
+const image = createImage(world, {
+  x: 0,
+  y: 0,
+  type: 'overlay',
+  bitmap: myBitmap,
+});
+
+// Bitmap is stored but not rendered to ANSI.
+// Your rendering system can retrieve it for Kitty/iTerm2/Sixel output.
+const bitmap = getImageBitmap(image.eid);
+```
+
+### Dynamic Image Updates
+
+```typescript
+import { createImage } from 'blecsd';
+
+const image = createImage(world, {
+  x: 0,
+  y: 0,
+  width: 40,
+  height: 20,
+  type: 'ansi',
+});
+
+// Update the image dynamically
+function updateFrame(bitmap) {
+  image.setImage(bitmap).show();
+}
+```
+
+---
+
+## See Also
+
+- [Video Widget](./video.md) - Video playback in the terminal
+- [Viewport3D](./viewport3d.md) - 3D rendering viewport

--- a/docs/api/widgets/log.md
+++ b/docs/api/widgets/log.md
@@ -1,0 +1,333 @@
+# Log Widget
+
+An append-only scrollable log display optimized for log messages, console output, and other streaming text content.
+
+## Overview
+
+```typescript
+import { createLog, addEntity } from 'blecsd';
+
+const world = createWorld();
+const eid = addEntity(world);
+
+const log = createLog(world, eid, {
+  width: 80,
+  height: 20,
+  scrollback: 500,
+  timestamps: true,
+  border: { type: 'line' },
+});
+
+log.log('Server started on port %d', 3000);
+log.log('Connection from %s', '192.168.1.1');
+```
+
+---
+
+## Configuration
+
+### LogConfig
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `left` | `number \| string \| keyword` | - | Left position |
+| `top` | `number \| string \| keyword` | - | Top position |
+| `right` | `number \| string \| keyword` | - | Right position |
+| `bottom` | `number \| string \| keyword` | - | Bottom position |
+| `width` | `number \| string \| 'auto'` | `'auto'` | Width |
+| `height` | `number \| string \| 'auto'` | `'auto'` | Height |
+| `fg` | `string \| number` | - | Foreground color |
+| `bg` | `string \| number` | - | Background color |
+| `border` | `BorderConfig` | - | Border configuration |
+| `padding` | `number \| PaddingConfig` | - | Padding |
+| `scrollbar` | `boolean \| ScrollbarConfig` | - | Scrollbar configuration |
+| `mouse` | `boolean` | `true` | Enable mouse wheel scrolling |
+| `keys` | `boolean` | `true` | Enable keyboard scrolling |
+| `scrollback` | `number` | `1000` | Maximum lines to keep |
+| `scrollOnInput` | `boolean` | `true` | Auto-scroll to bottom on new content |
+| `timestamps` | `boolean` | `false` | Add timestamps to log entries |
+| `timestampFormat` | `string` | `'HH:mm:ss'` | Timestamp format string |
+
+### ScrollbarConfig
+
+```typescript
+interface ScrollbarConfig {
+  readonly mode?: 'auto' | 'visible' | 'hidden';
+  readonly fg?: string | number;
+  readonly bg?: string | number;
+  readonly trackChar?: string;
+  readonly thumbChar?: string;
+}
+```
+
+### Zod Schema
+
+```typescript
+import { LogConfigSchema } from 'blecsd';
+
+const validated = LogConfigSchema.parse({
+  width: 80,
+  height: 20,
+  scrollback: 500,
+  timestamps: true,
+});
+```
+
+---
+
+## Factory Function
+
+### createLog
+
+Creates a Log widget attached to an existing entity.
+
+```typescript
+import { createLog, addEntity } from 'blecsd';
+
+const eid = addEntity(world);
+const log = createLog(world, eid, {
+  width: 80,
+  height: 20,
+  scrollback: 500,
+  timestamps: true,
+  timestampFormat: 'HH:mm:ss.SSS',
+});
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `entity: Entity` - The entity to attach to
+- `config?: LogConfig` - Widget configuration
+
+**Returns:** `LogWidget`
+
+---
+
+## LogWidget Interface
+
+### eid
+
+```typescript
+readonly eid: Entity
+```
+
+The underlying entity ID.
+
+### log
+
+```typescript
+log(...args: unknown[]): LogWidget
+```
+
+Logs a message with optional printf-style interpolation. Supports `%s` (string), `%d`/`%i` (integer), `%f` (float), and `%j`/`%o`/`%O` (JSON).
+
+```typescript
+log.log('Hello %s, you have %d messages', 'Alice', 5);
+log.log({ user: 'bob', action: 'login' });
+```
+
+### clear
+
+```typescript
+clear(): LogWidget
+```
+
+Clears all log entries and scrolls to top.
+
+### getLines
+
+```typescript
+getLines(): readonly string[]
+```
+
+Returns a copy of all lines in the log.
+
+### getLineCount
+
+```typescript
+getLineCount(): number
+```
+
+Returns the number of lines currently in the log.
+
+### show / hide
+
+```typescript
+show(): LogWidget
+hide(): LogWidget
+```
+
+Controls visibility.
+
+### move
+
+```typescript
+move(dx: number, dy: number): LogWidget
+```
+
+Moves the widget by a relative offset.
+
+### setPosition
+
+```typescript
+setPosition(x: number, y: number): LogWidget
+```
+
+Sets the absolute position.
+
+### focus / blur / isFocused
+
+```typescript
+focus(): LogWidget
+blur(): LogWidget
+isFocused(): boolean
+```
+
+Focus management.
+
+### append / getChildren
+
+```typescript
+append(child: Entity): LogWidget
+getChildren(): Entity[]
+```
+
+Hierarchy management for child entities.
+
+### Scrolling Methods
+
+```typescript
+scrollTo(x: number, y: number): LogWidget
+scrollBy(dx: number, dy: number): LogWidget
+setScrollPerc(percX: number, percY: number): LogWidget
+getScrollPerc(): ScrollPercentage
+getScroll(): ScrollPosition
+setViewport(width: number, height: number): LogWidget
+getScrollable(): ScrollableData | undefined
+scrollToTop(): LogWidget
+scrollToBottom(): LogWidget
+scrollToLeft(): LogWidget
+scrollToRight(): LogWidget
+canScroll(): boolean
+canScrollX(): boolean
+canScrollY(): boolean
+isAtTop(): boolean
+isAtBottom(): boolean
+isAtLeft(): boolean
+isAtRight(): boolean
+```
+
+Full scrolling API. All scroll methods return `this` for chaining.
+
+### destroy
+
+```typescript
+destroy(): void
+```
+
+Destroys the widget and removes the entity from the world.
+
+---
+
+## Utility Functions
+
+### isLog
+
+```typescript
+import { isLog } from 'blecsd';
+
+if (isLog(world, entity)) {
+  // Entity is a log widget
+}
+```
+
+### isMouseScrollEnabled
+
+```typescript
+import { isMouseScrollEnabled } from 'blecsd';
+
+if (isMouseScrollEnabled(world, entity)) {
+  // Mouse scrolling is active
+}
+```
+
+### isKeysScrollEnabled
+
+```typescript
+import { isKeysScrollEnabled } from 'blecsd';
+
+if (isKeysScrollEnabled(world, entity)) {
+  // Keyboard scrolling is active
+}
+```
+
+### getScrollback
+
+```typescript
+import { getScrollback } from 'blecsd';
+
+const limit = getScrollback(world, entity);
+// Returns 0 if no limit
+```
+
+---
+
+## Examples
+
+### Application Log Viewer
+
+```typescript
+import { createLog, addEntity, createWorld } from 'blecsd';
+
+const world = createWorld();
+const eid = addEntity(world);
+
+const appLog = createLog(world, eid, {
+  width: 80,
+  height: 20,
+  scrollback: 2000,
+  timestamps: true,
+  timestampFormat: 'HH:mm:ss',
+  border: { type: 'line', ch: 'single' },
+  scrollbar: { mode: 'auto' },
+});
+
+appLog.log('Application started');
+appLog.log('Config loaded from %s', '/etc/app.conf');
+appLog.log('Listening on port %d', 8080);
+```
+
+### Printf-Style Logging
+
+```typescript
+log.log('String: %s', 'hello');
+log.log('Integer: %d', 42);
+log.log('Float: %f', 3.14);
+log.log('JSON: %j', { key: 'value' });
+log.log('Progress: %d%%', 75);     // "Progress: 75%"
+```
+
+### Controlling Scroll
+
+```typescript
+const log = createLog(world, eid, {
+  width: 80,
+  height: 10,
+  scrollOnInput: false,  // Don't auto-scroll
+});
+
+// Manually scroll
+log.scrollToTop();
+log.scrollBy(0, 5);
+
+const perc = log.getScrollPerc();
+console.log(`Scrolled ${perc.y}% vertically`);
+```
+
+---
+
+## See Also
+
+- [Streaming Text](./streaming-text.md) - For character-by-character streaming
+- [Content Manipulation](./content-manipulation.md) - Line-level content editing
+- [ScrollableText Widget](./scrollableText.md) - General scrollable text display

--- a/docs/api/widgets/message.md
+++ b/docs/api/widgets/message.md
@@ -1,0 +1,370 @@
+# Message Widget
+
+Displays temporary notifications with auto-dismiss, click/key dismiss, and styled message types (info, warning, error, success).
+
+## Overview
+
+```typescript
+import { createMessage, showInfo, showError, showWarning, showSuccess } from 'blecsd';
+
+const world = createWorld();
+
+// Create a typed message
+const msg = createMessage(world, {
+  content: 'File saved successfully',
+  type: 'success',
+  timeout: 2000,
+});
+
+// Or use convenience functions
+const info = showInfo(world, 'Operation completed');
+const error = showError(world, 'Connection failed');
+```
+
+---
+
+## Configuration
+
+### MessageConfig
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `content` | `string` | `''` | Message text |
+| `type` | `'info' \| 'warning' \| 'error' \| 'success'` | `'info'` | Message type for preset styling |
+| `timeout` | `number` | `3000` | Auto-dismiss timeout in ms (0 = manual only) |
+| `dismissOnClick` | `boolean` | `true` | Dismiss when clicked |
+| `dismissOnKey` | `boolean` | `true` | Dismiss on any key press |
+| `left` | `number \| string \| 'center'` | - | Left position |
+| `top` | `number \| string \| 'center'` | - | Top position |
+| `width` | `number` | auto | Width (auto-calculated from content) |
+| `height` | `number` | auto | Height (auto-calculated from content) |
+| `fg` | `string \| number` | per type | Foreground color (overrides type style) |
+| `bg` | `string \| number` | per type | Background color (overrides type style) |
+| `border` | `BorderConfig` | - | Border configuration |
+| `padding` | `number` | `1` | Padding around content |
+| `infoStyle` | `MessageStyleConfig` | built-in | Custom info style |
+| `warningStyle` | `MessageStyleConfig` | built-in | Custom warning style |
+| `errorStyle` | `MessageStyleConfig` | built-in | Custom error style |
+| `successStyle` | `MessageStyleConfig` | built-in | Custom success style |
+
+### MessageStyleConfig
+
+```typescript
+interface MessageStyleConfig {
+  readonly fg?: string | number;
+  readonly bg?: string | number;
+  readonly borderFg?: string | number;
+}
+```
+
+### Zod Schema
+
+```typescript
+import { MessageConfigSchema } from 'blecsd';
+
+const validated = MessageConfigSchema.parse({
+  content: 'Hello',
+  type: 'info',
+  timeout: 5000,
+});
+```
+
+---
+
+## Default Type Styles
+
+| Type | Foreground | Background | Border |
+|------|-----------|------------|--------|
+| `info` | `#ffffff` | `#2196f3` | `#64b5f6` |
+| `warning` | `#000000` | `#ff9800` | `#ffb74d` |
+| `error` | `#ffffff` | `#f44336` | `#e57373` |
+| `success` | `#ffffff` | `#4caf50` | `#81c784` |
+
+---
+
+## Factory Function
+
+### createMessage
+
+Creates a Message widget with the given configuration.
+
+```typescript
+import { createMessage } from 'blecsd';
+
+const msg = createMessage(world, {
+  content: 'Changes saved',
+  type: 'success',
+  timeout: 3000,
+  border: { type: 'line', ch: 'rounded' },
+});
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `config?: MessageConfig` - Widget configuration
+
+**Returns:** `MessageWidget`
+
+---
+
+## MessageWidget Interface
+
+### eid
+
+```typescript
+readonly eid: Entity
+```
+
+The underlying entity ID.
+
+### setContent
+
+```typescript
+setContent(text: string): MessageWidget
+```
+
+Sets the message text. Returns `this` for chaining.
+
+### getContent
+
+```typescript
+getContent(): string
+```
+
+Gets the current message text.
+
+### show / hide
+
+```typescript
+show(): MessageWidget
+hide(): MessageWidget
+```
+
+Controls visibility of the message.
+
+### move
+
+```typescript
+move(dx: number, dy: number): MessageWidget
+```
+
+Moves the message by a relative offset.
+
+### setPosition
+
+```typescript
+setPosition(x: number, y: number): MessageWidget
+```
+
+Sets the absolute position.
+
+### center
+
+```typescript
+center(screenWidth: number, screenHeight: number): MessageWidget
+```
+
+Centers the message on screen given the terminal dimensions.
+
+```typescript
+msg.center(80, 24);
+```
+
+### dismiss
+
+```typescript
+dismiss(): void
+```
+
+Manually dismisses the message. Hides it, clears the auto-dismiss timer, and fires the onDismiss callback.
+
+### isDismissed
+
+```typescript
+isDismissed(): boolean
+```
+
+Returns whether the message has been dismissed.
+
+### onDismiss
+
+```typescript
+onDismiss(callback: () => void): MessageWidget
+```
+
+Registers a callback that fires when the message is dismissed.
+
+### destroy
+
+```typescript
+destroy(): void
+```
+
+Destroys the widget, clears timers, and removes the entity from the world.
+
+---
+
+## Convenience Functions
+
+### showInfo
+
+```typescript
+import { showInfo } from 'blecsd';
+
+const msg = showInfo(world, 'Operation completed', { timeout: 5000 });
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `text: string` - Message text
+- `options?: Omit<MessageConfig, 'content' | 'type'>` - Additional options
+
+**Returns:** `MessageWidget`
+
+### showWarning
+
+```typescript
+import { showWarning } from 'blecsd';
+
+const msg = showWarning(world, 'This action cannot be undone');
+```
+
+### showError
+
+```typescript
+import { showError } from 'blecsd';
+
+const msg = showError(world, 'Failed to save file');
+```
+
+### showSuccess
+
+```typescript
+import { showSuccess } from 'blecsd';
+
+const msg = showSuccess(world, 'File saved successfully');
+```
+
+---
+
+## Utility Functions
+
+### isMessage
+
+```typescript
+import { isMessage } from 'blecsd';
+
+if (isMessage(world, entity)) {
+  // Entity is a message widget
+}
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `eid: Entity` - The entity ID
+
+**Returns:** `boolean`
+
+### isDismissOnClick
+
+```typescript
+import { isDismissOnClick } from 'blecsd';
+
+if (isDismissOnClick(world, entity)) {
+  // Click dismiss is enabled
+}
+```
+
+### isDismissOnKey
+
+```typescript
+import { isDismissOnKey } from 'blecsd';
+
+if (isDismissOnKey(world, entity)) {
+  // Key dismiss is enabled
+}
+```
+
+### handleMessageClick
+
+```typescript
+import { handleMessageClick } from 'blecsd';
+
+const wasDismissed = handleMessageClick(world, entity);
+```
+
+Dismisses the message if `dismissOnClick` is enabled and the message is not already dismissed.
+
+**Returns:** `boolean` - true if the message was dismissed
+
+### handleMessageKey
+
+```typescript
+import { handleMessageKey } from 'blecsd';
+
+const wasDismissed = handleMessageKey(world, entity);
+```
+
+Dismisses the message if `dismissOnKey` is enabled and the message is not already dismissed.
+
+**Returns:** `boolean` - true if the message was dismissed
+
+---
+
+## Examples
+
+### Notification with Callback
+
+```typescript
+import { createMessage } from 'blecsd';
+
+const msg = createMessage(world, {
+  content: 'Download complete!',
+  type: 'success',
+  timeout: 3000,
+});
+
+msg.center(80, 24).onDismiss(() => {
+  console.log('Message was dismissed');
+});
+```
+
+### Manual Dismiss Only
+
+```typescript
+import { createMessage } from 'blecsd';
+
+const msg = createMessage(world, {
+  content: 'Critical error: please restart',
+  type: 'error',
+  timeout: 0,           // No auto-dismiss
+  dismissOnClick: false, // Must call dismiss() manually
+  dismissOnKey: false,
+});
+
+// Later, when resolved:
+msg.dismiss();
+```
+
+### Custom Styled Message
+
+```typescript
+import { createMessage } from 'blecsd';
+
+const msg = createMessage(world, {
+  content: 'Custom notification',
+  fg: '#000000',
+  bg: '#e0e0e0',
+  border: { type: 'line', ch: 'double', fg: '#888888' },
+  padding: 2,
+  timeout: 5000,
+});
+```
+
+---
+
+## See Also
+
+- [Modal Widget](./modal.md) - For persistent overlay dialogs
+- [Question Widget](./question.md) - Yes/no confirmation dialogs
+- [Prompt Widget](./prompt.md) - Text input dialogs

--- a/docs/api/widgets/modal.md
+++ b/docs/api/widgets/modal.md
@@ -1,0 +1,377 @@
+# Modal Widget
+
+A modal overlay/backdrop system with support for stacking multiple modals, backdrop click-to-close, escape key handling, and input blocking.
+
+## Overview
+
+```typescript
+import { createModal, openModal, closeAllModals } from 'blecsd';
+
+const world = createWorld();
+
+// Create and show a modal
+const modal = openModal(world, {
+  content: 'Are you sure?',
+  width: 40,
+  height: 10,
+  backdrop: true,
+  closeOnEscape: true,
+});
+
+modal.onClose(() => {
+  console.log('Modal closed');
+});
+```
+
+---
+
+## Configuration
+
+### ModalConfig
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `backdrop` | `boolean` | `true` | Show a backdrop overlay |
+| `backdropColor` | `string \| number` | `'#000000'` | Backdrop color |
+| `backdropOpacity` | `number` | `0.5` | Backdrop opacity (0-1) |
+| `closeOnBackdropClick` | `boolean` | `true` | Close when backdrop is clicked |
+| `closeOnEscape` | `boolean` | `true` | Close when Escape is pressed |
+| `width` | `number` | `40` | Modal width |
+| `height` | `number` | `10` | Modal height |
+| `left` | `number` | `0` | Left position |
+| `top` | `number` | `0` | Top position |
+| `fg` | `string \| number` | - | Foreground color |
+| `bg` | `string \| number` | - | Background color |
+| `border` | `ModalBorderConfig` | - | Border configuration |
+| `padding` | `number \| PaddingConfig` | - | Padding for content area |
+| `content` | `string` | - | Initial content text |
+
+### Zod Schema
+
+```typescript
+import { ModalConfigSchema } from 'blecsd';
+
+const result = ModalConfigSchema.safeParse({
+  backdrop: true,
+  closeOnEscape: true,
+  width: 50,
+  height: 20,
+  content: 'Hello',
+});
+```
+
+---
+
+## Factory Functions
+
+### createModal
+
+Creates a Modal widget in a hidden state. Call `show()` to display it.
+
+```typescript
+import { createModal } from 'blecsd';
+
+const modal = createModal(world, {
+  width: 50,
+  height: 20,
+  content: 'Dialog content here',
+  backdrop: true,
+  closeOnEscape: true,
+  border: { type: 'line', ch: 'rounded' },
+});
+
+modal.show();
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `config?: ModalConfig` - Widget configuration
+
+**Returns:** `ModalWidget`
+
+### openModal
+
+Creates a modal and immediately shows it.
+
+```typescript
+import { openModal } from 'blecsd';
+
+const modal = openModal(world, {
+  content: 'Hello World!',
+  width: 30,
+  height: 8,
+});
+// Modal is already visible
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `config?: ModalConfig` - Widget configuration
+
+**Returns:** `ModalWidget` (already visible)
+
+---
+
+## ModalWidget Interface
+
+### eid
+
+```typescript
+readonly eid: Entity
+```
+
+The underlying entity ID.
+
+### show / hide
+
+```typescript
+show(): ModalWidget
+hide(): ModalWidget
+```
+
+`show()` makes the modal visible and pushes it onto the modal stack, firing onOpen callbacks. `hide()` hides the modal and removes it from the stack (without firing onClose callbacks).
+
+### move
+
+```typescript
+move(dx: number, dy: number): ModalWidget
+```
+
+Moves the modal by a relative offset.
+
+### setPosition
+
+```typescript
+setPosition(x: number, y: number): ModalWidget
+```
+
+Sets the absolute position.
+
+### center
+
+```typescript
+center(termWidth: number, termHeight: number): ModalWidget
+```
+
+Centers the modal within the given terminal dimensions.
+
+```typescript
+modal.center(80, 24);
+```
+
+### setContent / getContent
+
+```typescript
+setContent(text: string): ModalWidget
+getContent(): string
+```
+
+Gets or sets the text content of the modal.
+
+### close
+
+```typescript
+close(): void
+```
+
+Closes the modal. Hides it, removes it from the modal stack, and fires all onClose callbacks. Has no effect if the modal is already closed.
+
+### isOpen
+
+```typescript
+isOpen(): boolean
+```
+
+Returns whether the modal is currently open.
+
+### onClose
+
+```typescript
+onClose(cb: () => void): ModalWidget
+```
+
+Registers a callback for when the modal is closed.
+
+### onOpen
+
+```typescript
+onOpen(cb: () => void): ModalWidget
+```
+
+Registers a callback for when the modal is opened.
+
+### destroy
+
+```typescript
+destroy(): void
+```
+
+Destroys the widget. If the modal is open, it is closed first (firing onClose callbacks), then the entity is removed from the world.
+
+---
+
+## Stack Management Functions
+
+### closeModal
+
+Closes a specific modal by entity ID.
+
+```typescript
+import { closeModal } from 'blecsd';
+
+closeModal(world, modalEid);
+```
+
+### closeAllModals
+
+Closes all currently open modals in reverse stack order (most recent first).
+
+```typescript
+import { closeAllModals } from 'blecsd';
+
+closeAllModals(world);
+```
+
+### isModalOpen
+
+Returns whether any modal is currently open.
+
+```typescript
+import { isModalOpen } from 'blecsd';
+
+if (isModalOpen(world)) {
+  // Block background input
+}
+```
+
+### getModalStack
+
+Returns the stack of currently open modal entity IDs. The last element is the topmost (most recently opened) modal.
+
+```typescript
+import { getModalStack } from 'blecsd';
+
+const stack = getModalStack(world);
+const topmost = stack[stack.length - 1];
+```
+
+---
+
+## Event Handlers
+
+### handleModalBackdropClick
+
+Handles a backdrop click event. Closes the modal if `closeOnBackdropClick` is enabled.
+
+```typescript
+import { handleModalBackdropClick } from 'blecsd';
+
+const wasClosed = handleModalBackdropClick(world, modalEid);
+```
+
+**Returns:** `boolean` - true if the modal was closed
+
+### handleModalEscape
+
+Handles an Escape key event for a modal. Closes the modal if `closeOnEscape` is enabled.
+
+```typescript
+import { handleModalEscape, getModalStack } from 'blecsd';
+
+const stack = getModalStack(world);
+if (stack.length > 0) {
+  handleModalEscape(world, stack[stack.length - 1]);
+}
+```
+
+**Returns:** `boolean` - true if the modal was closed
+
+---
+
+## Utility Functions
+
+### isModal
+
+```typescript
+import { isModal } from 'blecsd';
+
+if (isModal(world, entity)) {
+  // Entity is a modal widget
+}
+```
+
+---
+
+## Examples
+
+### Stacked Modals
+
+```typescript
+import { openModal, getModalStack, closeAllModals } from 'blecsd';
+
+const first = openModal(world, {
+  content: 'First modal',
+  width: 40,
+  height: 10,
+});
+
+const second = openModal(world, {
+  content: 'Second modal (on top)',
+  width: 30,
+  height: 8,
+});
+
+const stack = getModalStack(world);
+console.log(stack.length); // 2
+
+// Close all at once
+closeAllModals(world);
+```
+
+### Confirmation Modal with Callback
+
+```typescript
+import { openModal } from 'blecsd';
+
+const modal = openModal(world, {
+  content: 'Are you sure you want to delete this?',
+  width: 50,
+  height: 8,
+  closeOnEscape: true,
+  border: { type: 'line', ch: 'double' },
+  padding: 1,
+});
+
+modal.center(80, 24).onClose(() => {
+  console.log('Modal dismissed');
+});
+```
+
+### Input Blocking Pattern
+
+```typescript
+import { isModalOpen, getModalStack, handleModalEscape } from 'blecsd';
+
+function handleKeyPress(world, key) {
+  // Block all input when a modal is open, except Escape
+  if (isModalOpen(world)) {
+    if (key === 'escape') {
+      const stack = getModalStack(world);
+      if (stack.length > 0) {
+        handleModalEscape(world, stack[stack.length - 1]);
+      }
+    }
+    return; // Block all other keys
+  }
+
+  // Normal key handling...
+}
+```
+
+---
+
+## See Also
+
+- [Message Widget](./message.md) - Temporary notifications
+- [Question Widget](./question.md) - Yes/no confirmation dialogs
+- [Prompt Widget](./prompt.md) - Text input dialogs

--- a/docs/api/widgets/prompt.md
+++ b/docs/api/widgets/prompt.md
@@ -1,0 +1,320 @@
+# Prompt Widget
+
+A text input dialog with submit/cancel key bindings, optional validation, and a Promise-based convenience API.
+
+## Overview
+
+```typescript
+import { createPrompt, prompt } from 'blecsd';
+
+const world = createWorld();
+
+// Promise-based usage
+const name = await prompt(world, 'Enter your name:', {
+  defaultValue: 'World',
+});
+
+if (name !== null) {
+  console.log('Hello,', name);
+}
+
+// Widget-based usage
+const p = createPrompt(world, {
+  message: 'Enter filename:',
+  placeholder: 'untitled.txt',
+});
+
+p.onSubmit((value) => console.log('Saved as:', value));
+p.onCancel(() => console.log('Cancelled'));
+```
+
+---
+
+## Configuration
+
+### PromptConfig
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `message` | `string` | `''` | Message/label displayed above the input |
+| `defaultValue` | `string` | `''` | Default value pre-filled in the input |
+| `placeholder` | `string` | `''` | Placeholder text when input is empty |
+| `validator` | `PromptValidator` | - | Validator function for input |
+| `width` | `number` | `40` | Width of the dialog |
+| `height` | `number` | `5` | Height of the dialog |
+| `left` | `number` | `0` | Left position |
+| `top` | `number` | `0` | Top position |
+| `fg` | `string \| number` | - | Foreground color |
+| `bg` | `string \| number` | - | Background color |
+| `border` | `PromptBorderConfig` | - | Border configuration |
+| `padding` | `number \| PaddingConfig` | - | Padding |
+
+### PromptValidator
+
+```typescript
+type PromptValidator = (value: string) => boolean | string;
+```
+
+Returns `true` if valid, or a string error message if invalid. Returning `false` also blocks submission.
+
+### Zod Schema
+
+```typescript
+import { PromptConfigSchema } from 'blecsd';
+
+const config = PromptConfigSchema.parse({
+  message: 'Enter name:',
+  width: 50,
+});
+```
+
+---
+
+## Factory Function
+
+### createPrompt
+
+Creates a Prompt widget.
+
+```typescript
+import { createPrompt } from 'blecsd';
+
+const p = createPrompt(world, {
+  message: 'Enter your name:',
+  defaultValue: 'World',
+  border: { type: 'line', ch: 'single' },
+  padding: 1,
+});
+
+p.onSubmit((value) => console.log('Name:', value));
+p.onCancel(() => console.log('Cancelled'));
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `config?: PromptConfig` - Widget configuration
+
+**Returns:** `PromptWidget`
+
+---
+
+## PromptWidget Interface
+
+### eid
+
+```typescript
+readonly eid: Entity
+```
+
+The underlying entity ID.
+
+### show / hide
+
+```typescript
+show(): PromptWidget
+hide(): PromptWidget
+```
+
+Controls visibility.
+
+### move
+
+```typescript
+move(dx: number, dy: number): PromptWidget
+```
+
+Moves the dialog by a relative offset.
+
+### setPosition
+
+```typescript
+setPosition(x: number, y: number): PromptWidget
+```
+
+Sets the absolute position.
+
+### center
+
+```typescript
+center(screenWidth: number, screenHeight: number): PromptWidget
+```
+
+Centers the dialog within the given screen dimensions.
+
+### setMessage / getMessage
+
+```typescript
+setMessage(message: string): PromptWidget
+getMessage(): string
+```
+
+Gets or sets the prompt label text.
+
+### setValue / getValue
+
+```typescript
+setValue(value: string): PromptWidget
+getValue(): string
+```
+
+Gets or sets the current input value.
+
+```typescript
+p.setValue('Alice');
+console.log(p.getValue()); // 'Alice'
+```
+
+### submit
+
+```typescript
+submit(): PromptWidget
+```
+
+Triggers submit with the current value. Runs the validator first if one is configured. If validation fails, the submit callbacks are not called.
+
+### cancel
+
+```typescript
+cancel(): PromptWidget
+```
+
+Triggers cancel, calling all registered onCancel callbacks.
+
+### onSubmit
+
+```typescript
+onSubmit(cb: (value: string) => void): PromptWidget
+```
+
+Registers a callback for when the user submits (Enter key).
+
+### onCancel
+
+```typescript
+onCancel(cb: () => void): PromptWidget
+```
+
+Registers a callback for when the user cancels (Escape key).
+
+### destroy
+
+```typescript
+destroy(): void
+```
+
+Destroys the prompt widget and cleans up all state.
+
+---
+
+## Convenience Function
+
+### prompt
+
+A Promise-based API that creates a prompt and resolves with the result.
+
+```typescript
+import { prompt } from 'blecsd';
+
+const value = await prompt(world, 'Enter filename:', {
+  defaultValue: 'untitled.txt',
+  validator: (v) => v.length > 0 || 'Filename cannot be empty',
+});
+
+if (value !== null) {
+  // User submitted
+  console.log('Filename:', value);
+} else {
+  // User cancelled (Escape)
+  console.log('Cancelled');
+}
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `message: string` - The prompt message
+- `options?: Omit<PromptConfig, 'message'>` - Additional configuration
+
+**Returns:** `Promise<string | null>` - Resolves with the input value on submit, or `null` on cancel. The prompt widget is automatically destroyed after resolution.
+
+---
+
+## Utility Functions
+
+### isPrompt
+
+```typescript
+import { isPrompt } from 'blecsd';
+
+if (isPrompt(entity)) {
+  // Entity is a prompt widget
+}
+```
+
+**Parameters:**
+- `eid: Entity` - The entity ID
+
+**Returns:** `boolean`
+
+### handlePromptKey
+
+```typescript
+import { handlePromptKey } from 'blecsd';
+
+handlePromptKey(promptWidget, 'return');  // triggers submit
+handlePromptKey(promptWidget, 'escape');  // triggers cancel
+```
+
+**Parameters:**
+- `widget: PromptWidget` - The prompt widget
+- `key: string` - Key name (`'return'`, `'enter'`, or `'escape'`)
+
+**Returns:** `boolean` - true if the key was handled
+
+---
+
+## Examples
+
+### With Validation
+
+```typescript
+import { createPrompt } from 'blecsd';
+
+const p = createPrompt(world, {
+  message: 'Enter port number:',
+  defaultValue: '3000',
+  validator: (value) => {
+    const num = parseInt(value, 10);
+    if (isNaN(num)) return 'Must be a number';
+    if (num < 1 || num > 65535) return 'Port must be 1-65535';
+    return true;
+  },
+});
+
+p.onSubmit((value) => {
+  const port = parseInt(value, 10);
+  startServer(port);
+});
+```
+
+### Centered Dialog
+
+```typescript
+import { createPrompt } from 'blecsd';
+
+const p = createPrompt(world, {
+  message: 'Search:',
+  width: 50,
+  border: { type: 'line', ch: 'rounded' },
+  padding: 1,
+});
+
+p.center(80, 24).show();
+```
+
+---
+
+## See Also
+
+- [Question Widget](./question.md) - Yes/no confirmation dialogs
+- [Message Widget](./message.md) - Temporary notifications
+- [Modal Widget](./modal.md) - Overlay dialogs

--- a/docs/api/widgets/question.md
+++ b/docs/api/widgets/question.md
@@ -1,0 +1,337 @@
+# Question Widget
+
+A yes/no confirmation dialog with customizable button text, keyboard bindings, and Promise-based convenience functions.
+
+## Overview
+
+```typescript
+import { createQuestion, ask, confirm } from 'blecsd';
+
+const world = createWorld();
+
+// Promise-based usage
+if (await confirm(world, 'Delete this file?')) {
+  deleteFile();
+}
+
+// Or with custom options
+const answer = await ask(world, 'Save changes?', {
+  yesText: 'Save',
+  noText: 'Discard',
+});
+
+// Widget-based usage
+const q = createQuestion(world, {
+  message: 'Are you sure?',
+  defaultAnswer: true,
+});
+
+q.onConfirm((answer) => {
+  if (answer) doSomething();
+});
+```
+
+---
+
+## Configuration
+
+### QuestionConfig
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `message` | `string` | `'Are you sure?'` | The question message |
+| `yesText` | `string` | `'Yes'` | Text for the yes button |
+| `noText` | `string` | `'No'` | Text for the no button |
+| `defaultAnswer` | `boolean` | `true` | Default selected answer (true = Yes) |
+| `width` | `number` | `40` | Dialog width |
+| `height` | `number` | `5` | Dialog height |
+| `left` | `number` | `0` | Left position |
+| `top` | `number` | `0` | Top position |
+| `fg` | `string \| number` | - | Foreground color |
+| `bg` | `string \| number` | - | Background color |
+| `border` | `QuestionBorderConfig` | - | Border configuration |
+| `padding` | `number \| PaddingConfig` | - | Padding |
+
+### Zod Schema
+
+```typescript
+import { QuestionConfigSchema } from 'blecsd';
+
+const config = QuestionConfigSchema.parse({
+  message: 'Are you sure?',
+  yesText: 'Confirm',
+  noText: 'Cancel',
+});
+```
+
+---
+
+## Factory Function
+
+### createQuestion
+
+Creates a Question widget for yes/no confirmation dialogs.
+
+```typescript
+import { createQuestion } from 'blecsd';
+
+const question = createQuestion(world, {
+  message: 'Save changes?',
+  yesText: 'Save',
+  noText: 'Discard',
+  defaultAnswer: true,
+  border: { type: 'line', ch: 'rounded' },
+});
+
+question.onConfirm((answer) => {
+  if (answer) saveFile();
+});
+
+question.onCancel(() => {
+  // User pressed Escape
+});
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `config?: QuestionConfig` - Widget configuration
+
+**Returns:** `QuestionWidget`
+
+---
+
+## QuestionWidget Interface
+
+### eid
+
+```typescript
+readonly eid: Entity
+```
+
+The underlying entity ID.
+
+### show / hide
+
+```typescript
+show(): QuestionWidget
+hide(): QuestionWidget
+```
+
+Controls visibility.
+
+### move
+
+```typescript
+move(dx: number, dy: number): QuestionWidget
+```
+
+Moves the dialog by a relative offset.
+
+### setPosition
+
+```typescript
+setPosition(x: number, y: number): QuestionWidget
+```
+
+Sets the absolute position.
+
+### center
+
+```typescript
+center(screenWidth: number, screenHeight: number): QuestionWidget
+```
+
+Centers the dialog within the given screen dimensions.
+
+### setMessage / getMessage
+
+```typescript
+setMessage(message: string): QuestionWidget
+getMessage(): string
+```
+
+Gets or sets the question message text.
+
+### selectYes / selectNo
+
+```typescript
+selectYes(): QuestionWidget
+selectNo(): QuestionWidget
+```
+
+Changes the currently highlighted selection.
+
+### getSelectedAnswer
+
+```typescript
+getSelectedAnswer(): boolean
+```
+
+Returns the currently selected answer (`true` for Yes, `false` for No).
+
+### confirm
+
+```typescript
+confirm(): QuestionWidget
+```
+
+Confirms the currently selected answer, firing all onConfirm callbacks with the selected value.
+
+### cancel
+
+```typescript
+cancel(): QuestionWidget
+```
+
+Cancels the dialog, firing all onCancel callbacks.
+
+### onConfirm
+
+```typescript
+onConfirm(cb: (answer: boolean) => void): QuestionWidget
+```
+
+Registers a callback for when the dialog is confirmed.
+
+### onCancel
+
+```typescript
+onCancel(cb: () => void): QuestionWidget
+```
+
+Registers a callback for when the dialog is cancelled.
+
+### destroy
+
+```typescript
+destroy(): void
+```
+
+Destroys the question widget and cleans up all state.
+
+---
+
+## Convenience Functions
+
+### ask
+
+Displays a question dialog and returns a Promise resolving to the user's answer.
+
+```typescript
+import { ask } from 'blecsd';
+
+const answer = await ask(world, 'Save changes before closing?', {
+  yesText: 'Save',
+  noText: 'Discard',
+});
+
+if (answer) {
+  saveFile();
+}
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `message: string` - The question message
+- `options?: Partial<QuestionConfig>` - Additional options
+
+**Returns:** `Promise<boolean>` - Resolves to `true` (yes) or `false` (no/cancel). The widget is automatically destroyed after resolution.
+
+### confirm
+
+Shorthand for a simple yes/no dialog with default button text.
+
+```typescript
+import { confirm } from 'blecsd';
+
+if (await confirm(world, 'Delete this file?')) {
+  deleteFile();
+}
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `message: string` - The confirmation message
+
+**Returns:** `Promise<boolean>`
+
+---
+
+## Utility Functions
+
+### isQuestion
+
+```typescript
+import { isQuestion } from 'blecsd';
+
+if (isQuestion(world, entity)) {
+  // Entity is a question widget
+}
+```
+
+### handleQuestionKey
+
+Handles keyboard input for a question widget.
+
+```typescript
+import { handleQuestionKey } from 'blecsd';
+
+handleQuestionKey(questionWidget, 'y');       // Selects yes and confirms
+handleQuestionKey(questionWidget, 'n');       // Selects no and confirms
+handleQuestionKey(questionWidget, 'enter');   // Confirms current selection
+handleQuestionKey(questionWidget, 'escape');  // Cancels
+```
+
+**Supported keys:**
+- `y` / `Y` - Select Yes and confirm
+- `n` / `N` - Select No and confirm
+- `enter` / `return` - Confirm the current selection
+- `escape` - Cancel
+
+**Returns:** `boolean` - true if the key was handled
+
+---
+
+## Examples
+
+### Confirmation Before Destructive Action
+
+```typescript
+import { ask } from 'blecsd';
+
+async function handleDelete(world, filename) {
+  const confirmed = await ask(world, `Delete "${filename}"?`, {
+    yesText: 'Delete',
+    noText: 'Keep',
+    defaultAnswer: false,  // Default to "No" for safety
+  });
+
+  if (confirmed) {
+    fs.unlinkSync(filename);
+  }
+}
+```
+
+### Centered Question Dialog
+
+```typescript
+import { createQuestion } from 'blecsd';
+
+const q = createQuestion(world, {
+  message: 'Exit without saving?',
+  width: 40,
+  height: 5,
+  border: { type: 'line', ch: 'rounded' },
+  padding: 1,
+});
+
+q.center(80, 24).show();
+```
+
+---
+
+## See Also
+
+- [Prompt Widget](./prompt.md) - Text input dialogs
+- [Message Widget](./message.md) - Temporary notifications
+- [Modal Widget](./modal.md) - Overlay dialogs

--- a/docs/api/widgets/streaming-text.md
+++ b/docs/api/widgets/streaming-text.md
@@ -1,0 +1,398 @@
+# Streaming Text Widget
+
+Efficiently renders text that streams in character-by-character or chunk-by-chunk. Designed for real-time output like terminal logs, LLM responses, or any content that arrives incrementally.
+
+## Overview
+
+```typescript
+import { createStreamingText, addEntity, createWorld } from 'blecsd';
+
+const world = createWorld();
+const eid = addEntity(world);
+
+const stream = createStreamingText(world, eid, {
+  wrapWidth: 80,
+  maxLines: 5000,
+  autoScroll: true,
+});
+
+// Stream content incrementally
+stream.startStream();
+stream.append('Loading');
+stream.append('...');
+stream.appendLine(' done!');
+stream.endStream();
+```
+
+---
+
+## Configuration
+
+### StreamingTextConfig
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxLines` | `number` | `10000` | Maximum lines to retain (0 = unlimited) |
+| `wrapWidth` | `number` | `80` | Width for line wrapping in columns |
+| `autoScroll` | `boolean` | `true` | Auto-scroll to bottom on new content |
+| `stripAnsi` | `boolean` | `false` | Strip ANSI escape sequences |
+
+### Zod Schema
+
+```typescript
+import { StreamingTextConfigSchema } from 'blecsd';
+
+const config = StreamingTextConfigSchema.parse({
+  maxLines: 5000,
+  wrapWidth: 120,
+  autoScroll: true,
+});
+```
+
+---
+
+## Factory Function
+
+### createStreamingText
+
+Creates a streaming text widget attached to an existing entity.
+
+```typescript
+import { createStreamingText, addEntity } from 'blecsd';
+
+const eid = addEntity(world);
+const stream = createStreamingText(world, eid, {
+  wrapWidth: 80,
+  maxLines: 5000,
+  autoScroll: true,
+});
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `entity: Entity` - The entity to attach to
+- `config?: Partial<StreamingTextConfig>` - Optional configuration
+
+**Returns:** `StreamingTextWidget`
+
+---
+
+## StreamingTextWidget Interface
+
+### eid
+
+```typescript
+readonly eid: Entity
+```
+
+The underlying entity ID.
+
+### append
+
+```typescript
+append(text: string): StreamingTextWidget
+```
+
+Appends text to the buffer. Handles partial lines (text without a trailing newline is buffered until a newline arrives). Automatically wraps lines and evicts old content if `maxLines` is exceeded.
+
+```typescript
+stream.append('Hello ');
+stream.append('world\n');
+// Buffer now contains: "Hello world"
+```
+
+### appendLine
+
+```typescript
+appendLine(text: string): StreamingTextWidget
+```
+
+Appends a complete line (adds newline automatically).
+
+```typescript
+stream.appendLine('This is a full line');
+```
+
+### clear
+
+```typescript
+clear(): StreamingTextWidget
+```
+
+Clears all content from the buffer.
+
+### getState
+
+```typescript
+getState(): StreamingTextState
+```
+
+Returns the full internal state, including lines, scroll position, and configuration.
+
+### getVisibleLines
+
+```typescript
+getVisibleLines(): readonly string[]
+```
+
+Returns only the lines visible in the current viewport (based on scrollTop and viewportHeight).
+
+### getProgress
+
+```typescript
+getProgress(): StreamProgress
+```
+
+Returns streaming progress information.
+
+```typescript
+const progress = stream.getProgress();
+console.log(progress.totalBytes);      // Total bytes received
+console.log(progress.totalLines);      // Total lines in buffer
+console.log(progress.visibleLines);    // Lines in viewport
+console.log(progress.isAutoScrolling); // Auto-scroll enabled
+console.log(progress.isStreaming);     // Stream currently active
+```
+
+### consumeDirty
+
+```typescript
+consumeDirty(): StreamDirtyRegion | null
+```
+
+Gets and clears the dirty region. Returns information about what changed since the last call, allowing incremental re-renders.
+
+```typescript
+const dirty = stream.consumeDirty();
+if (dirty) {
+  if (dirty.fullRedraw) {
+    // Re-render everything
+  } else {
+    // Only re-render from dirty.startLine for dirty.lineCount lines
+  }
+}
+```
+
+### scrollTo / scrollBy / scrollToBottom / scrollToTop
+
+```typescript
+scrollTo(line: number): StreamingTextWidget
+scrollBy(delta: number): StreamingTextWidget
+scrollToBottom(): StreamingTextWidget
+scrollToTop(): StreamingTextWidget
+```
+
+Scroll control. `scrollBy` takes positive values to scroll down and negative to scroll up.
+
+### setViewportHeight
+
+```typescript
+setViewportHeight(height: number): StreamingTextWidget
+```
+
+Sets the viewport height in lines.
+
+### setWrapWidth
+
+```typescript
+setWrapWidth(width: number): StreamingTextWidget
+```
+
+Changes the wrap width. Re-wraps all existing content with the new width.
+
+### setAutoScroll
+
+```typescript
+setAutoScroll(enabled: boolean): StreamingTextWidget
+```
+
+Enables or disables auto-scrolling on new content.
+
+### startStream / endStream
+
+```typescript
+startStream(): StreamingTextWidget
+endStream(): StreamingTextWidget
+```
+
+Marks the beginning and end of a streaming session. `endStream` flushes any remaining partial line in the buffer.
+
+---
+
+## Pure State Functions
+
+These functions operate on `StreamingTextState` objects and can be used independently of the widget.
+
+### createStreamingState
+
+```typescript
+import { createStreamingState } from 'blecsd';
+
+const state = createStreamingState({ wrapWidth: 120 }, 24);
+```
+
+**Parameters:**
+- `config?: Partial<StreamingTextConfig>` - Configuration
+- `viewportHeight?: number` - Initial viewport height (default: 24)
+
+**Returns:** `StreamingTextState`
+
+### appendToState
+
+```typescript
+import { appendToState } from 'blecsd';
+
+let state = createStreamingState();
+state = appendToState(state, 'Hello world\n');
+```
+
+Appends text to a state object, handling wrapping, eviction, and auto-scroll.
+
+### clearState
+
+```typescript
+import { clearState } from 'blecsd';
+
+state = clearState(state);
+```
+
+### getStreamVisibleLines
+
+```typescript
+import { getStreamVisibleLines } from 'blecsd';
+
+const visible = getStreamVisibleLines(state);
+```
+
+### scrollToLine / scrollByLines
+
+```typescript
+import { scrollToLine, scrollByLines } from 'blecsd';
+
+state = scrollToLine(state, 100);
+state = scrollByLines(state, -5);
+```
+
+---
+
+## Helper Functions
+
+### wrapLine
+
+```typescript
+import { wrapLine } from 'blecsd';
+
+const lines = wrapLine('Hello World, this is a long line', 10);
+// ['Hello Worl', 'd, this is', ' a long li', 'ne']
+```
+
+### stripAnsiSequences
+
+```typescript
+import { stripAnsiSequences } from 'blecsd';
+
+const clean = stripAnsiSequences('\x1b[31mRed text\x1b[0m');
+// 'Red text'
+```
+
+---
+
+## Types
+
+### StreamingTextState
+
+```typescript
+interface StreamingTextState {
+  readonly lines: readonly string[];
+  readonly scrollTop: number;
+  readonly viewportHeight: number;
+  readonly totalBytes: number;
+  readonly isStreaming: boolean;
+  readonly config: StreamingTextConfig;
+  readonly partialLine: string;
+  readonly dirty: StreamDirtyRegion | null;
+}
+```
+
+### StreamProgress
+
+```typescript
+interface StreamProgress {
+  readonly totalBytes: number;
+  readonly totalLines: number;
+  readonly visibleLines: number;
+  readonly isAutoScrolling: boolean;
+  readonly isStreaming: boolean;
+}
+```
+
+### StreamDirtyRegion
+
+```typescript
+interface StreamDirtyRegion {
+  readonly startLine: number;
+  readonly lineCount: number;
+  readonly fullRedraw: boolean;
+}
+```
+
+---
+
+## Examples
+
+### Streaming from an Async Source
+
+```typescript
+import { createStreamingText, addEntity, createWorld } from 'blecsd';
+
+const world = createWorld();
+const eid = addEntity(world);
+
+const stream = createStreamingText(world, eid, {
+  wrapWidth: 80,
+  maxLines: 10000,
+  autoScroll: true,
+});
+
+stream.startStream();
+for await (const chunk of asyncSource) {
+  stream.append(chunk);
+}
+stream.endStream();
+```
+
+### Manual Scroll with Progress
+
+```typescript
+const stream = createStreamingText(world, eid, {
+  autoScroll: false,
+});
+
+// User scrolls manually
+stream.scrollBy(10);
+
+const progress = stream.getProgress();
+console.log(`${progress.totalLines} total lines`);
+```
+
+### Incremental Rendering
+
+```typescript
+function renderFrame() {
+  const dirty = stream.consumeDirty();
+  if (!dirty) return; // Nothing changed
+
+  if (dirty.fullRedraw) {
+    renderAllLines(stream.getVisibleLines());
+  } else {
+    renderPartialUpdate(dirty.startLine, dirty.lineCount);
+  }
+}
+```
+
+---
+
+## See Also
+
+- [Log Widget](./log.md) - Append-only log with timestamps
+- [Content Manipulation](./content-manipulation.md) - Line-level content editing

--- a/docs/api/widgets/video.md
+++ b/docs/api/widgets/video.md
@@ -1,0 +1,421 @@
+# Video Widget
+
+Plays video files in the terminal using external video players (mpv, mplayer) with ASCII/ANSI rendering via libcaca or other terminal-compatible output drivers.
+
+## Overview
+
+```typescript
+import { createVideo } from 'blecsd';
+
+const world = createWorld();
+
+const video = createVideo(world, {
+  x: 0,
+  y: 0,
+  width: 80,
+  height: 24,
+  path: '/path/to/video.mp4',
+  player: 'mpv',
+  outputDriver: 'caca',
+});
+
+video.play();
+```
+
+---
+
+## Configuration
+
+### VideoConfig
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `x` | `number` | `0` | X position |
+| `y` | `number` | `0` | Y position |
+| `width` | `number` | `80` | Width in terminal columns |
+| `height` | `number` | `24` | Height in terminal rows |
+| `path` | `string` | `''` | Path to the video file |
+| `player` | `'mpv' \| 'mplayer'` | auto-detect | Preferred video player |
+| `outputDriver` | `'caca' \| 'tct' \| 'sixel'` | `'caca'` | Terminal output driver |
+| `speed` | `number` | `1.0` | Playback speed multiplier |
+| `autoPlay` | `boolean` | `false` | Start playback automatically |
+| `loop` | `boolean` | `false` | Loop playback |
+| `mute` | `boolean` | `true` | Mute audio |
+| `visible` | `boolean` | `true` | Whether to show initially |
+
+### VideoOutputDriver
+
+- `'caca'` - Uses libcaca for ASCII art rendering (best quality, works with both players)
+- `'tct'` - True-color terminal output (mpv only)
+- `'sixel'` - Sixel graphics output (mpv only, requires terminal sixel support)
+
+### Zod Schema
+
+```typescript
+import { VideoConfigSchema } from 'blecsd';
+
+const result = VideoConfigSchema.safeParse({
+  path: '/path/to/video.mp4',
+  player: 'mpv',
+});
+```
+
+---
+
+## Factory Function
+
+### createVideo
+
+Creates a Video widget. Accepts an optional `VideoProcessSpawner` for dependency injection (useful for testing).
+
+```typescript
+import { createVideo } from 'blecsd';
+
+const video = createVideo(world, {
+  x: 0,
+  y: 0,
+  width: 80,
+  height: 24,
+  path: '/path/to/video.mp4',
+  player: 'mpv',
+  outputDriver: 'caca',
+});
+
+video.play();
+video.onEnd(() => console.log('Video finished'));
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `config?: VideoConfig` - Widget configuration
+- `spawner?: VideoProcessSpawner` - Optional process spawner for testing
+
+**Returns:** `VideoWidget`
+
+---
+
+## VideoWidget Interface
+
+### eid
+
+```typescript
+readonly eid: Entity
+```
+
+The underlying entity ID.
+
+### show / hide / isVisible
+
+```typescript
+show(): VideoWidget
+hide(): VideoWidget
+isVisible(): boolean
+```
+
+Controls visibility.
+
+### move
+
+```typescript
+move(dx: number, dy: number): VideoWidget
+```
+
+Moves the widget by a relative offset.
+
+### setPosition
+
+```typescript
+setPosition(x: number, y: number): VideoWidget
+```
+
+Sets the absolute position.
+
+### getPosition
+
+```typescript
+getPosition(): { x: number; y: number }
+```
+
+Gets the current position.
+
+### setPath / getPath
+
+```typescript
+setPath(path: string): VideoWidget
+getPath(): string
+```
+
+Gets or sets the video file path.
+
+### play
+
+```typescript
+play(): VideoWidget
+```
+
+Starts or resumes playback. Detects the video player if not configured. For mplayer, resumes a paused process. For mpv, restarts the process from the current seek position.
+
+### pause
+
+```typescript
+pause(): VideoWidget
+```
+
+Pauses playback. Only effective when the player is currently playing.
+
+### stop
+
+```typescript
+stop(): VideoWidget
+```
+
+Stops playback, kills the player process, and resets the seek position.
+
+### togglePlayback
+
+```typescript
+togglePlayback(): VideoWidget
+```
+
+Toggles between playing and paused states.
+
+### seek
+
+```typescript
+seek(seconds: number): VideoWidget
+```
+
+Seeks to a position in seconds. For mplayer, sends a seek command to the running process. For mpv, restarts playback from the new position.
+
+### getPlaybackState
+
+```typescript
+getPlaybackState(): VideoPlaybackState
+```
+
+Returns `'stopped'`, `'playing'`, or `'paused'`.
+
+### setSpeed / getSpeed
+
+```typescript
+setSpeed(speed: number): VideoWidget
+getSpeed(): number
+```
+
+Controls playback speed multiplier (1.0 = normal).
+
+### setLoop / getLoop
+
+```typescript
+setLoop(loop: boolean): VideoWidget
+getLoop(): boolean
+```
+
+Controls whether playback loops.
+
+### setMute / getMute
+
+```typescript
+setMute(mute: boolean): VideoWidget
+getMute(): boolean
+```
+
+Controls audio mute state.
+
+### getPlayer
+
+```typescript
+getPlayer(): VideoPlayer | undefined
+```
+
+Returns the detected or configured player (`'mpv'` or `'mplayer'`).
+
+### isRunning
+
+```typescript
+isRunning(): boolean
+```
+
+Returns whether the video player process is currently running.
+
+### resize
+
+```typescript
+resize(width: number, height: number): VideoWidget
+```
+
+Resizes the video output. If the process supports PTY resize, the running process is resized too.
+
+### onEnd / onError / onData
+
+```typescript
+onEnd(callback: () => void): VideoWidget
+onError(callback: (error: string) => void): VideoWidget
+onData(callback: (data: string) => void): VideoWidget
+```
+
+Event callbacks for playback completion, errors, and process output data.
+
+### destroy
+
+```typescript
+destroy(): void
+```
+
+Kills any running process and removes the entity from the world.
+
+---
+
+## Player Detection
+
+### detectVideoPlayer
+
+Finds the best available video player binary on the system.
+
+```typescript
+import { detectVideoPlayer } from 'blecsd';
+
+const result = detectVideoPlayer();
+if (result) {
+  console.log(`Found ${result.player} at ${result.path}`);
+}
+```
+
+**Parameters:**
+- `checkExists?: (path: string) => boolean` - Custom file existence checker (defaults to `fs.existsSync`)
+
+**Returns:** `{ player: VideoPlayer; path: string } | undefined`
+
+Search paths checked:
+- mpv: `/usr/bin/mpv`, `/usr/local/bin/mpv`, `/opt/homebrew/bin/mpv`, `/snap/bin/mpv`
+- mplayer: `/usr/bin/mplayer`, `/usr/local/bin/mplayer`, `/opt/homebrew/bin/mplayer`
+
+---
+
+## Command Building
+
+### buildMpvArgs
+
+```typescript
+import { buildMpvArgs } from 'blecsd';
+
+const args = buildMpvArgs(
+  { path: 'video.mp4', outputDriver: 'caca', speed: 1.0, loop: false, mute: true, seekPosition: 0 },
+  80,
+  24,
+);
+```
+
+### buildMplayerArgs
+
+```typescript
+import { buildMplayerArgs } from 'blecsd';
+
+const args = buildMplayerArgs(
+  { path: 'video.mp4', outputDriver: 'caca', speed: 1.0, loop: false, mute: true, seekPosition: 0 },
+  80,
+  24,
+);
+```
+
+### buildPlayerArgs
+
+```typescript
+import { buildPlayerArgs } from 'blecsd';
+
+const args = buildPlayerArgs('mpv', videoState, 80, 24);
+```
+
+---
+
+## Utility Functions
+
+### isVideo
+
+```typescript
+import { isVideo } from 'blecsd';
+
+if (isVideo(world, entity)) {
+  // Entity is a video widget
+}
+```
+
+### getVideoPlaybackState
+
+```typescript
+import { getVideoPlaybackState } from 'blecsd';
+
+const state = getVideoPlaybackState(entity);
+// 'stopped' | 'playing' | 'paused'
+```
+
+### getVideoPlayer
+
+```typescript
+import { getVideoPlayer } from 'blecsd';
+
+const player = getVideoPlayer(entity);
+// 'mpv' | 'mplayer' | undefined
+```
+
+### sendPauseCommand / sendSeekCommand
+
+Low-level functions for sending commands to player processes.
+
+```typescript
+import { sendPauseCommand, sendSeekCommand } from 'blecsd';
+
+sendPauseCommand(processHandle, 'mplayer');
+sendSeekCommand(processHandle, 'mplayer', 30);
+```
+
+---
+
+## Examples
+
+### Basic Video Playback
+
+```typescript
+import { createVideo } from 'blecsd';
+
+const video = createVideo(world, {
+  path: '/home/user/movie.mp4',
+  width: 80,
+  height: 24,
+  mute: false,
+  outputDriver: 'caca',
+});
+
+video.play();
+
+video.onEnd(() => {
+  console.log('Playback finished');
+  video.destroy();
+});
+
+video.onError((err) => {
+  console.error('Playback error:', err);
+});
+```
+
+### Looping Background Video
+
+```typescript
+import { createVideo } from 'blecsd';
+
+const bg = createVideo(world, {
+  path: '/assets/background.mp4',
+  width: 80,
+  height: 24,
+  loop: true,
+  mute: true,
+  autoPlay: true,
+});
+```
+
+---
+
+## See Also
+
+- [Image Widget](./image.md) - Static image rendering
+- [Terminal Widget](./terminal.md) - Terminal emulator with PTY

--- a/docs/api/widgets/viewport3d.md
+++ b/docs/api/widgets/viewport3d.md
@@ -1,0 +1,287 @@
+# Viewport3D Widget
+
+A 3D rendering viewport that combines camera setup, viewport configuration, and mesh management into a composable ECS widget.
+
+## Overview
+
+```typescript
+import { createViewport3D, addEntity, createWorld } from 'blecsd';
+
+const world = createWorld();
+const eid = addEntity(world);
+
+const viewport = createViewport3D(world, eid, {
+  left: 5,
+  top: 2,
+  width: 60,
+  height: 20,
+  fov: Math.PI / 3,
+  backend: 'braille',
+});
+
+// Add a mesh to the scene
+const cubeId = createCubeMesh();
+viewport.addMesh(cubeId, { tz: -5 });
+viewport.setCameraPosition(0, 2, 5);
+```
+
+---
+
+## Configuration
+
+### Viewport3DWidgetConfig
+
+Configuration is validated by `Viewport3DWidgetConfigSchema` from the 3D subsystem.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `left` | `number` | `0` | Left position in terminal cells |
+| `top` | `number` | `0` | Top position in terminal cells |
+| `width` | `number` | `60` | Width in terminal cells |
+| `height` | `number` | `20` | Height in terminal cells |
+| `fov` | `number` | `Math.PI / 3` | Camera field of view in radians |
+| `near` | `number` | `0.1` | Near clipping plane |
+| `far` | `number` | `1000` | Far clipping plane |
+| `projectionMode` | `string` | `'perspective'` | Projection mode |
+| `backend` | `BackendType` | `'auto'` | Rendering backend |
+
+### BackendType
+
+- `'auto'` - Automatically selects the best backend (defaults to braille)
+- `'braille'` - Renders using braille Unicode characters
+- Other backend types as supported by the 3D subsystem
+
+---
+
+## Factory Function
+
+### createViewport3D
+
+Creates a Viewport3D widget attached to an existing entity.
+
+```typescript
+import { createViewport3D, addEntity } from 'blecsd';
+
+const eid = addEntity(world);
+const viewport = createViewport3D(world, eid, {
+  left: 5,
+  top: 2,
+  width: 60,
+  height: 20,
+  fov: Math.PI / 3,
+  backend: 'auto',
+});
+```
+
+**Parameters:**
+- `world: World` - The ECS world
+- `entity: Entity` - The entity to attach the viewport to
+- `config?: Viewport3DWidgetConfig` - Widget configuration
+
+**Returns:** `Viewport3DWidget`
+
+This function:
+1. Creates a camera entity with the specified FOV, near/far planes, and aspect ratio
+2. Configures the viewport component on the given entity
+3. Computes pixel dimensions based on the selected rendering backend
+4. Sets up position and dimensions for the UI layout system
+
+---
+
+## Viewport3DWidget Interface
+
+### eid
+
+```typescript
+readonly eid: Entity
+```
+
+The viewport entity ID.
+
+### cameraEid
+
+```typescript
+readonly cameraEid: Entity
+```
+
+The camera entity ID, created automatically by the factory.
+
+### addMesh
+
+```typescript
+addMesh(meshId: number, transform?: Transform3DConfig, material?: Material3DConfig): Entity
+```
+
+Adds a mesh to the viewport scene. Creates a new entity with the mesh component, optional transform, and optional material.
+
+```typescript
+const cubeId = createCubeMesh();
+const meshEid = viewport.addMesh(cubeId, { tz: -5, ry: 0.5 });
+```
+
+**Parameters:**
+- `meshId: number` - Mesh ID from the mesh store
+- `transform?: Transform3DConfig` - Optional transform (position, rotation, scale)
+- `material?: Material3DConfig` - Optional material configuration
+
+**Returns:** `Entity` - The created mesh entity ID
+
+**Throws:** Error if the mesh ID is not found in the mesh store.
+
+### removeMesh
+
+```typescript
+removeMesh(meshEid: Entity): void
+```
+
+Removes a mesh entity from the viewport scene and the ECS world.
+
+### setCameraPosition
+
+```typescript
+setCameraPosition(x: number, y: number, z: number): Viewport3DWidget
+```
+
+Sets the camera position in world space.
+
+```typescript
+viewport.setCameraPosition(0, 2, 10);
+```
+
+### setCameraRotation
+
+```typescript
+setCameraRotation(rx: number, ry: number, rz: number): Viewport3DWidget
+```
+
+Sets the camera rotation in radians.
+
+```typescript
+viewport.setCameraRotation(0, Math.PI / 4, 0);
+```
+
+### setFov
+
+```typescript
+setFov(fov: number): Viewport3DWidget
+```
+
+Sets the camera field of view in radians.
+
+### resize
+
+```typescript
+resize(width: number, height: number): Viewport3DWidget
+```
+
+Resizes the viewport. Updates the pixel dimensions, camera aspect ratio, and UI dimensions.
+
+### show / hide
+
+```typescript
+show(): Viewport3DWidget
+hide(): Viewport3DWidget
+```
+
+Controls visibility.
+
+### destroy
+
+```typescript
+destroy(): void
+```
+
+Cleans up all entities associated with this viewport: removes all mesh entities, the camera entity, the viewport entity itself, and clears internal stores (framebuffer, mesh tracking).
+
+---
+
+## Utility Functions
+
+### isViewport3DWidget
+
+```typescript
+import { isViewport3DWidget } from 'blecsd';
+
+if (isViewport3DWidget(entity)) {
+  // Entity is a Viewport3D widget
+}
+```
+
+**Parameters:**
+- `eid: Entity` - Entity ID
+
+**Returns:** `boolean`
+
+---
+
+## Examples
+
+### Basic 3D Scene
+
+```typescript
+import { createViewport3D, addEntity, createWorld } from 'blecsd';
+
+const world = createWorld();
+const eid = addEntity(world);
+
+const viewport = createViewport3D(world, eid, {
+  width: 60,
+  height: 20,
+  fov: Math.PI / 3,
+});
+
+// Add geometry
+const cubeId = createCubeMesh();
+const cube = viewport.addMesh(cubeId, { tz: -5 });
+
+// Position camera
+viewport.setCameraPosition(0, 2, 0);
+viewport.setCameraRotation(-0.2, 0, 0);
+```
+
+### Animated Camera
+
+```typescript
+const viewport = createViewport3D(world, eid, {
+  width: 80,
+  height: 30,
+});
+
+let angle = 0;
+
+function update() {
+  angle += 0.02;
+  const radius = 10;
+  viewport.setCameraPosition(
+    Math.sin(angle) * radius,
+    3,
+    Math.cos(angle) * radius,
+  );
+  viewport.setCameraRotation(0, -angle, 0);
+}
+```
+
+### Multiple Meshes with Materials
+
+```typescript
+const viewport = createViewport3D(world, eid, {
+  width: 60,
+  height: 20,
+  backend: 'braille',
+});
+
+const cubeId = createCubeMesh();
+const sphereId = createSphereMesh();
+
+viewport.addMesh(cubeId, { tx: -3, tz: -8 }, { color: 0xff0000 });
+viewport.addMesh(sphereId, { tx: 3, tz: -8 }, { color: 0x00ff00 });
+
+viewport.setCameraPosition(0, 5, 0);
+```
+
+---
+
+## See Also
+
+- [Image Widget](./image.md) - 2D bitmap rendering
+- [Terminal Widget](./terminal.md) - Terminal emulator


### PR DESCRIPTION
## Summary

- Added comprehensive API documentation for **80 previously undocumented modules** across all major subsystems
- Each doc includes: overview, import examples, type definitions, function signatures, and usage examples
- 82 files changed, +21,864 lines of documentation

### Coverage by area

| Area | New Docs | Modules |
|------|----------|---------|
| Widgets | 11 | message, log, prompt, question, modal, image, video, streaming-text, viewport3d, file-manager, content-manipulation |
| Systems | 12 | behavior, frame-budget, panel-movement, particle, smooth-scroll, spatial-hash, tilemap-renderer, visibility-culling, worker-pool, animation, movement, state-machine |
| Core | 15 | input-actions, input-state, input-event-buffer, game-loop, state-machine, scene, serialization, entity-data, lifecycle-events, phase-manager, event-bubbling, lazy-init, ecs, world, types |
| Terminal | 15 | bracketed-paste, clipboard, gpm-client, gpu-probe, key-parser, mouse-parser, kitty-protocol, throttled-resize, optimized-output, input-sanitize, graphics-backend/kitty/sixel/iterm2, capability-negotiation |
| Utils | 15 | change-coalescing, component-storage, cursor-navigation, fold-regions, lazy-content, syntax-highlight, virtualized-line-store, text-search, fuzzy-search, rope, markdown-render, diff-render, virtual-scrollback, line-gutter, fast-wrap |
| Components | 11 | animation, behavior, camera, collision, health, particle, sprite, state-machine, terminal-buffer, tilemap, velocity |
| Input | 1 | vi-mode |
| Debug | 2 | memory-profiler, overlay |

## Test plan

- [x] Documentation only, no source changes
- [x] All imports reference `'blecsd'` package name