### PR TITLE
fix: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,5 +52,3 @@ jobs:
 
       - name: Publish to npm
         run: pnpm publish --no-git-checks --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Removes NODE_AUTH_TOKEN from publish workflow. npm will now authenticate via OIDC trusted publishing instead of long-lived tokens.