### PR TITLE
fix: use Node 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Summary
- Bump Node.js from 22 to 24 in publish workflow
- npm >= 11.5.1 (shipped with Node 24) is required for OIDC trusted publishing
- Stale NPM_TOKEN secret has been deleted from repo settings

## Context
The v0.1.1 publish failed because the npm CLI on Node 22 doesn't support OIDC-based auth. With Node 24, the workflow uses the GitHub Actions OIDC token directly with npm's trusted publisher configuration.