### PR TITLE
fix: remove registry-url to enable npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           node-version: '24'
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `actions/setup-node` in publish workflow
- The `registry-url` option creates an `.npmrc` expecting `NODE_AUTH_TOKEN`, which overrides the OIDC flow
- Without it, npm's OIDC trusted publisher auth works natively