### PR TITLE
fix: use npm publish for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,4 +50,4 @@ jobs:
         run: pnpm verify-pack
 
       - name: Publish to npm
-        run: pnpm publish --no-git-checks --provenance --access public
+        run: npm publish --provenance --access public


### PR DESCRIPTION
pnpm publish doesn't support npm's OIDC trusted publisher flow. Switch to npm publish directly.