### PR TITLE
fix: add NPM_CONFIG_PROVENANCE for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,3 +51,5 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
+        env:
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Add NPM_CONFIG_PROVENANCE=true env var required for npm OIDC auth.