### PR TITLE
fix: upgrade to actions/setup-node@v6 for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'pnpm'


### PR DESCRIPTION
## Summary
- Upgrades actions/setup-node from v4 to v6 in the publish workflow
- v6 removes the `always-auth` configuration handling that interfered with OIDC token-based auth
- This should allow npm OIDC trusted publishing to work without static tokens