### PR TITLE
fix: add registry-url for OIDC registry discovery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           node-version: '24'
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Adds registry-url back to actions/setup-node so npm knows which registry to authenticate with via OIDC
- Without registry-url, npm doesn't attempt OIDC authentication and fails with ENEEDAUTH
- The previous stale NPM_TOKEN secret that caused "expired token" errors has been removed