### PR TITLE
fix: match working OIDC trusted publishing config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,14 +4,13 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -51,6 +50,6 @@ jobs:
         run: pnpm verify-pack
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: pnpm publish --no-git-checks --access public
         env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Moves permissions to job level (matching known working configs)
- Switches to pnpm publish with NPM_CONFIG_PROVENANCE env var
- Based on working config from streetsidesoftware/jest-mock-vscode