### PR TITLE
Move doccheck from pre-push to non-blocking CI

### DIFF
--- a/.github/workflows/doccheck.yml
+++ b/.github/workflows/doccheck.yml
@@ -1,0 +1,35 @@
+name: Doc Code Check
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  doccheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run doc code check
+        run: pnpm doccheck

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,4 +3,3 @@ set -e
 
 pnpm test
 pnpm build
-pnpm doccheck


### PR DESCRIPTION
Removes doccheck from the pre-push hook (was blocking pushes on pre-existing doc drift) and adds a separate GitHub Actions workflow that runs on push to main. Uses continue-on-error so it reports results without blocking merges or deploys.