### PR TITLE
feat: migrate widget stateMap hot paths to iterable ComponentStore

### DIFF
--- a/src/components/list.ts
+++ b/src/components/list.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import type { StateMachineConfig } from '../core/stateMachine';
 import type { Entity, World } from '../core/types';
 import { ListBehaviorOptionsSchema, ListItemSchema } from '../schemas/components';
+import { createComponentStore } from '../utils/componentStorage';
 import { markDirty } from './renderable';
 import { attachStateMachine, getState, hasStateMachine, sendEvent } from './stateMachine';
 
@@ -215,8 +216,12 @@ export const listStore: ListStore = {
 	isLoading: new Uint8Array(MAX_ENTITIES),
 };
 
-/** Store for list items */
-const itemsStore = new Map<Entity, ListItem[]>();
+/**
+ * Store for list items.
+ * Uses iterable ComponentStore backed by PackedStore for cache-friendly
+ * dense iteration when rendering all list entities.
+ */
+const itemsStore = createComponentStore<ListItem[]>({ iterable: true });
 
 /** Store for lazy load callbacks */
 const lazyLoadCallbacks = new Map<Entity, ListLazyLoadCallback>();

--- a/src/widgets/tabs.ts
+++ b/src/widgets/tabs.ts
@@ -17,6 +17,7 @@ import { markDirty, setStyle, setVisible } from '../components/renderable';
 import { removeEntity } from '../core/ecs';
 import type { Entity, World } from '../core/types';
 import { parseColor } from '../utils/color';
+import { createComponentStore } from '../utils/componentStorage';
 
 // =============================================================================
 // TYPES
@@ -344,8 +345,10 @@ export const Tabs = {
 
 /**
  * Store for tab data (arrays can't be stored in typed arrays).
+ * Uses iterable ComponentStore backed by PackedStore for cache-friendly
+ * dense iteration when rendering all tab entities.
  */
-const tabDataStore = new Map<Entity, TabData[]>();
+const tabDataStore = createComponentStore<TabData[]>({ iterable: true });
 
 // =============================================================================
 // INTERNAL HELPERS

--- a/src/widgets/tree.ts
+++ b/src/widgets/tree.ts
@@ -13,6 +13,7 @@ import { Position, setPosition } from '../components/position';
 import { markDirty, setVisible } from '../components/renderable';
 import { removeEntity } from '../core/ecs';
 import type { Entity, World } from '../core/types';
+import { createComponentStore } from '../utils/componentStorage';
 
 // =============================================================================
 // CONSTANTS
@@ -338,8 +339,12 @@ const treeStore = {
 	visibleCount: new Uint32Array(MAX_ENTITIES),
 };
 
-/** Store for tree nodes */
-const nodesStore = new Map<Entity, InternalTreeNode[]>();
+/**
+ * Store for tree nodes.
+ * Uses iterable ComponentStore backed by PackedStore for cache-friendly
+ * dense iteration when rendering all tree entities.
+ */
+const nodesStore = createComponentStore<InternalTreeNode[]>({ iterable: true });
 
 /** Store for selected path */
 const selectedPathStore = new Map<Entity, string>();


### PR DESCRIPTION
## Summary

- Migrates three `Map<Entity, T[]>` stores to `createComponentStore<T[]>({ iterable: true })`:
  - `src/widgets/tabs.ts` - `tabDataStore` (tab panel data)
  - `src/widgets/tree.ts` - `nodesStore` (tree node hierarchy)
  - `src/components/list.ts` - `itemsStore` (list items)
- All existing `get`/`set`/`delete`/`clear` call sites remain unchanged (API-compatible)
- PackedStore-backed iterable mode enables cache-friendly dense iteration for future system-level rendering passes

Depends on #904
Closes #905

## Test plan

- [x] All 10156 existing tests pass (including tabs, tree, and list widget test suites)
- [x] Lint, typecheck, and build all pass
- [x] No public API changes; all widget behavior unchanged