### PR TITLE
perf: migrate 4 critical hot-path Maps to PackedStore

### DIFF
--- a/src/systems/index.ts
+++ b/src/systems/index.ts
@@ -271,6 +271,7 @@ export {
 // Spatial hash system
 export type {
 	CellCoord,
+	PrevBounds,
 	SpatialHashConfig,
 	SpatialHashGrid,
 	SpatialHashStats,
@@ -354,6 +355,7 @@ export {
 } from './virtualizedRenderSystem';
 // Visibility culling system
 export type {
+	CachedBounds,
 	CullingResult,
 	PositionCache,
 	Viewport,

--- a/src/systems/spatialHash.test.ts
+++ b/src/systems/spatialHash.test.ts
@@ -348,7 +348,7 @@ describe('spatialHash', () => {
 			const state = createSpatialHashSystemState();
 			expect(state.dirtyEntities.size).toBe(0);
 			expect(state.dirtyLookup.size).toBe(0);
-			expect(state.prevX.size).toBe(0);
+			expect(state.prevBounds.size).toBe(0);
 			expect(state.initialized).toBe(false);
 			expect(state.dirtyThreshold).toBe(0.5);
 		});
@@ -386,14 +386,14 @@ describe('spatialHash', () => {
 			markSpatialDirty(1 as Entity);
 			markSpatialDirty(2 as Entity);
 			const state = getSpatialHashSystemState();
-			state.prevX.set(1, 10);
+			state.prevBounds.set(1 as Entity, { x: 10, y: 0, w: 0, h: 0 });
 			state.initialized = true;
 
 			resetSpatialHashState();
 
 			expect(getSpatialDirtyCount()).toBe(0);
 			const newState = getSpatialHashSystemState();
-			expect(newState.prevX.size).toBe(0);
+			expect(newState.prevBounds.size).toBe(0);
 			expect(newState.initialized).toBe(false);
 		});
 
@@ -442,7 +442,7 @@ describe('spatialHash', () => {
 			const stats = getSpatialHashStats(grid);
 			expect(stats.entityCount).toBe(1);
 			// Position cache populated
-			expect(state.prevX.has(eid as number)).toBe(true);
+			expect(state.prevBounds.has(eid)).toBe(true);
 		});
 
 		it('detects moved entities and re-hashes them incrementally', () => {

--- a/src/systems/visibilityCulling.test.ts
+++ b/src/systems/visibilityCulling.test.ts
@@ -14,7 +14,7 @@ describe('VisibilityCulling', () => {
 	describe('PositionCache', () => {
 		it('creates an empty cache', () => {
 			const cache = createPositionCache();
-			expect(cache.prevX.size).toBe(0);
+			expect(cache.bounds.size).toBe(0);
 		});
 
 		it('detects entity movement', () => {
@@ -56,7 +56,7 @@ describe('VisibilityCulling', () => {
 			updateEntityIfMoved(grid, cache, 2 as Entity, 30, 40, 4, 4);
 
 			clearPositionCache(cache);
-			expect(cache.prevX.size).toBe(0);
+			expect(cache.bounds.size).toBe(0);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- **spatialHash.ts**: Consolidate 4 prevCache Maps (prevX/Y/W/H) into single `ComponentStore<PrevBounds>({ iterable: true })`, reducing 4 hash lookups per entity per frame to 1
- **visibilityCulling.ts**: Consolidate 4 PositionCache Maps into single `ComponentStore<CachedBounds>`, same 4-to-1 hash lookup reduction
- **smoothScroll.ts**: Replace `Map<number, ScrollAnimationState>` with `ComponentStore({ iterable: true })` for cache-friendly dense iteration in per-frame system tick
- **dirtyRects.ts**: Replace `Map<Entity, EntityBoundsEntry>` with `ComponentStore({ iterable: true })` for cache-friendly iteration in markAllEntitiesDirty and resize

All 4 were identified as CRITICAL adoption gaps during the v0.2.0 audit. Each migration uses in-place mutation of cached objects to avoid per-frame allocation overhead.

Closes the final PackedStore adoption gaps for v0.2.0.

## Test plan
- [x] All 10,234 tests pass (256 test files)
- [x] TypeScript typecheck clean
- [x] Biome lint clean (1 pre-existing warning)
- [x] Production build succeeds
- [x] Updated tests for spatialHash and visibilityCulling to use new API