### PR TITLE
chore: update LICENSE to Jeremy Stover (Kadajett) for 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,7 @@
-Copyright (c) 2013-2015, Christopher Jeffrey and contributors
-https://github.com/chjj/
+MIT License
+
+Copyright (c) 2026 Jeremy Stover (Kadajett) and contributors
+https://github.com/Kadajett/blECSd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update the LICENSE copyright from Christopher Jeffrey (2013-2015) to Jeremy Stover (Kadajett) (2026) and point the URL to the blECSd repo.