### PR TITLE
feat: implement text tags/markup system

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ export {
 	writeChar,
 	writeRaw,
 } from './terminal';
+export * from './text';
 export * from './types';
 export * from './utils';
 

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Text processing and markup utilities
+ * @module text
+ */
+
+export type { MarkupStyle, StyledSegment } from './markup';
+export {
+	MarkupStyleSchema,
+	markupLength,
+	parseMarkup,
+	renderMarkup,
+	stripMarkup,
+} from './markup';

--- a/src/text/markup.test.ts
+++ b/src/text/markup.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for text markup parser
+ * @module text/markup
+ */
+
+import { describe, expect, it } from 'vitest';
+import { markupLength, parseMarkup, renderMarkup, stripMarkup } from './markup';
+
+describe('stripMarkup', () => {
+	it('removes all tags and returns plain text', () => {
+		expect(stripMarkup('{bold}hello{/bold}')).toBe('hello');
+		expect(stripMarkup('{red-fg}text{/red-fg}')).toBe('text');
+		expect(stripMarkup('{bold}{underline}nested{/underline}{/bold}')).toBe('nested');
+	});
+
+	it('handles empty tags', () => {
+		expect(stripMarkup('{bold}{/bold}')).toBe('');
+	});
+
+	it('handles text without tags', () => {
+		expect(stripMarkup('plain text')).toBe('plain text');
+	});
+
+	it('handles escaped braces', () => {
+		expect(stripMarkup('{open}left brace')).toBe('{left brace');
+		expect(stripMarkup('right{close} brace')).toBe('right} brace');
+		expect(stripMarkup('{open}{close}')).toBe('{}');
+	});
+
+	it('handles malformed tags gracefully', () => {
+		expect(stripMarkup('unclosed {bold}tag')).toBe('unclosed tag');
+		expect(stripMarkup('{/bold} closing without opening')).toBe(' closing without opening');
+	});
+
+	it('handles multiple tag types', () => {
+		expect(stripMarkup('{bold}bold {red-fg}red{/red-fg}{/bold} normal')).toBe('bold red normal');
+	});
+});
+
+describe('markupLength', () => {
+	it('calculates visible text length excluding tags', () => {
+		expect(markupLength('hello')).toBe(5);
+		expect(markupLength('{bold}hello{/bold}')).toBe(5);
+		expect(markupLength('{red-fg}hello{/red-fg} world')).toBe(11);
+	});
+
+	it('handles empty strings', () => {
+		expect(markupLength('')).toBe(0);
+		expect(markupLength('{bold}{/bold}')).toBe(0);
+	});
+
+	it('handles escaped braces', () => {
+		expect(markupLength('{open}{close}')).toBe(2); // '{}'
+	});
+});
+
+describe('parseMarkup', () => {
+	it('parses simple bold tag', () => {
+		const segments = parseMarkup('{bold}hello{/bold}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('hello');
+		expect(segments[0]?.style.bold).toBe(true);
+	});
+
+	it('parses underline tag', () => {
+		const segments = parseMarkup('{underline}text{/underline}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+		expect(segments[0]?.style.underline).toBe(true);
+	});
+
+	it('parses italic tag', () => {
+		const segments = parseMarkup('{italic}text{/italic}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+		expect(segments[0]?.style.italic).toBe(true);
+	});
+
+	it('parses dim tag', () => {
+		const segments = parseMarkup('{dim}text{/dim}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+		expect(segments[0]?.style.dim).toBe(true);
+	});
+
+	it('parses blink tag', () => {
+		const segments = parseMarkup('{blink}text{/blink}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+		expect(segments[0]?.style.blink).toBe(true);
+	});
+
+	it('parses inverse tag', () => {
+		const segments = parseMarkup('{inverse}text{/inverse}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+		expect(segments[0]?.style.inverse).toBe(true);
+	});
+
+	it('parses named foreground color', () => {
+		const segments = parseMarkup('{red-fg}text{/red-fg}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+		expect(segments[0]?.style.fg).toBeDefined();
+	});
+
+	it('parses named background color', () => {
+		const segments = parseMarkup('{blue-bg}text{/blue-bg}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+		expect(segments[0]?.style.bg).toBeDefined();
+	});
+
+	it('parses hex foreground color', () => {
+		const segments = parseMarkup('{#ff0000-fg}text{/#ff0000-fg}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+		expect(segments[0]?.style.fg).toBeDefined();
+	});
+
+	it('parses hex background color', () => {
+		const segments = parseMarkup('{#00ff00-bg}text{/#00ff00-bg}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+		expect(segments[0]?.style.bg).toBeDefined();
+	});
+
+	it('parses center alignment tag', () => {
+		const segments = parseMarkup('{center}text{/center}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+		expect(segments[0]?.style.align).toBe('center');
+	});
+
+	it('parses right alignment tag', () => {
+		const segments = parseMarkup('{right}text{/right}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+		expect(segments[0]?.style.align).toBe('right');
+	});
+
+	it('handles nested tags', () => {
+		const segments = parseMarkup('{bold}{red-fg}bold red{/red-fg}{/bold}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('bold red');
+		expect(segments[0]?.style.bold).toBe(true);
+		expect(segments[0]?.style.fg).toBeDefined();
+	});
+
+	it('handles multiple segments', () => {
+		const segments = parseMarkup('normal {bold}bold{/bold} normal');
+		expect(segments).toHaveLength(3);
+		expect(segments[0]?.text).toBe('normal ');
+		expect(segments[0]?.style.bold).toBeUndefined();
+		expect(segments[1]?.text).toBe('bold');
+		expect(segments[1]?.style.bold).toBe(true);
+		expect(segments[2]?.text).toBe(' normal');
+		expect(segments[2]?.style.bold).toBeUndefined();
+	});
+
+	it('handles reset tag {/}', () => {
+		const segments = parseMarkup('{bold}bold{/} normal');
+		expect(segments).toHaveLength(2);
+		expect(segments[0]?.text).toBe('bold');
+		expect(segments[0]?.style.bold).toBe(true);
+		expect(segments[1]?.text).toBe(' normal');
+		expect(segments[1]?.style.bold).toBeUndefined();
+	});
+
+	it('handles escaped braces', () => {
+		const segments = parseMarkup('{open}{close}');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('{}');
+	});
+
+	it('handles empty input', () => {
+		const segments = parseMarkup('');
+		expect(segments).toHaveLength(0);
+	});
+
+	it('handles plain text without tags', () => {
+		const segments = parseMarkup('plain text');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('plain text');
+		expect(Object.keys(segments[0]?.style ?? {})).toHaveLength(0);
+	});
+
+	it('handles unclosed tags gracefully', () => {
+		const segments = parseMarkup('{bold}unclosed');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('unclosed');
+		expect(segments[0]?.style.bold).toBe(true);
+	});
+
+	it('handles closing tags without opening', () => {
+		const segments = parseMarkup('{/bold}text');
+		expect(segments).toHaveLength(1);
+		expect(segments[0]?.text).toBe('text');
+	});
+
+	it('handles complex nested case', () => {
+		const segments = parseMarkup(
+			'{bold}outer {red-fg}nested {underline}deep{/underline}{/red-fg}{/bold}',
+		);
+		expect(segments).toHaveLength(3);
+
+		// "outer "
+		expect(segments[0]?.text).toBe('outer ');
+		expect(segments[0]?.style.bold).toBe(true);
+
+		// "nested "
+		expect(segments[1]?.text).toBe('nested ');
+		expect(segments[1]?.style.bold).toBe(true);
+		expect(segments[1]?.style.fg).toBeDefined();
+
+		// "deep"
+		expect(segments[2]?.text).toBe('deep');
+		expect(segments[2]?.style.bold).toBe(true);
+		expect(segments[2]?.style.fg).toBeDefined();
+		expect(segments[2]?.style.underline).toBe(true);
+	});
+});
+
+describe('renderMarkup', () => {
+	it('converts styled segments to ANSI escape sequences', () => {
+		const segments = parseMarkup('{bold}hello{/bold}');
+		const rendered = renderMarkup(segments);
+		// Should contain bold codes and reset
+		expect(rendered).toContain('\x1b[');
+		expect(rendered).toContain('hello');
+	});
+
+	it('handles empty segments', () => {
+		const rendered = renderMarkup([]);
+		expect(rendered).toBe('');
+	});
+
+	it('handles plain text segments', () => {
+		const segments = parseMarkup('plain text');
+		const rendered = renderMarkup(segments);
+		expect(rendered).toContain('plain text');
+	});
+
+	it('handles multiple style attributes', () => {
+		const segments = parseMarkup('{bold}{underline}text{/underline}{/bold}');
+		const rendered = renderMarkup(segments);
+		expect(rendered).toContain('text');
+		// Should contain both bold and underline codes
+		expect(rendered).toContain('\x1b[');
+	});
+});

--- a/src/text/markup.ts
+++ b/src/text/markup.ts
@@ -1,0 +1,433 @@
+/**
+ * Text markup parser for inline styling tags
+ *
+ * Supports tags like {bold}text{/bold}, {red-fg}text{/red-fg}, etc.
+ * for inline text styling in terminal applications.
+ *
+ * @module text/markup
+ *
+ * @example
+ * ```typescript
+ * import { parseMarkup, renderMarkup, stripMarkup } from 'blecsd';
+ *
+ * // Parse markup into styled segments
+ * const segments = parseMarkup('{bold}{red-fg}Error{/red-fg}{/bold}');
+ *
+ * // Strip all tags
+ * const plain = stripMarkup('{bold}text{/bold}'); // 'text'
+ *
+ * // Get visible length
+ * const len = markupLength('{bold}hello{/bold}'); // 5
+ *
+ * // Render to ANSI escape sequences
+ * const ansi = renderMarkup(segments);
+ * ```
+ */
+
+import { z } from 'zod';
+import {
+	color256ToTruecolor,
+	cssNameToColor,
+	hexToTruecolor,
+	nameToColor,
+} from '../terminal/colors';
+
+// =============================================================================
+// TYPES AND SCHEMAS
+// =============================================================================
+
+/**
+ * Text style attributes that can be applied to text segments.
+ */
+export interface MarkupStyle {
+	readonly bold?: boolean;
+	readonly underline?: boolean;
+	readonly italic?: boolean;
+	readonly dim?: boolean;
+	readonly blink?: boolean;
+	readonly inverse?: boolean;
+	readonly fg?: number; // Packed truecolor value
+	readonly bg?: number; // Packed truecolor value
+	readonly align?: 'left' | 'center' | 'right';
+}
+
+/**
+ * Zod schema for validating MarkupStyle objects.
+ */
+export const MarkupStyleSchema = z.object({
+	bold: z.boolean().optional(),
+	underline: z.boolean().optional(),
+	italic: z.boolean().optional(),
+	dim: z.boolean().optional(),
+	blink: z.boolean().optional(),
+	inverse: z.boolean().optional(),
+	fg: z.number().int().nonnegative().optional(),
+	bg: z.number().int().nonnegative().optional(),
+	align: z.enum(['left', 'center', 'right']).optional(),
+});
+
+/**
+ * A segment of text with associated style information.
+ */
+export interface StyledSegment {
+	readonly text: string;
+	readonly style: MarkupStyle;
+}
+
+// =============================================================================
+// TAG PARSING
+// =============================================================================
+
+/**
+ * Supported style tag types.
+ */
+type StyleTag = 'bold' | 'underline' | 'italic' | 'dim' | 'blink' | 'inverse' | 'center' | 'right';
+
+/**
+ * Checks if a tag name is a style tag.
+ */
+function isStyleTag(tag: string): tag is StyleTag {
+	return ['bold', 'underline', 'italic', 'dim', 'blink', 'inverse', 'center', 'right'].includes(
+		tag,
+	);
+}
+
+/**
+ * Parses a color tag like 'red-fg' or '#ff0000-bg'.
+ * Returns the packed truecolor value or null if invalid.
+ */
+function parseColorTag(tag: string): { type: 'fg' | 'bg'; color: number } | null {
+	const fgMatch = /^(.+)-fg$/.exec(tag);
+	const bgMatch = /^(.+)-bg$/.exec(tag);
+
+	if (!fgMatch && !bgMatch) {
+		return null;
+	}
+
+	const isFg = !!fgMatch;
+	const colorName = (isFg ? fgMatch[1] : bgMatch?.[1]) ?? '';
+
+	// Try hex color first
+	if (colorName.startsWith('#')) {
+		try {
+			const color = hexToTruecolor(colorName);
+			return { type: isFg ? 'fg' : 'bg', color };
+		} catch {
+			return null;
+		}
+	}
+
+	// Try named color
+	const namedColor = nameToColor(colorName);
+	if (namedColor !== null) {
+		const color = color256ToTruecolor(namedColor);
+		return { type: isFg ? 'fg' : 'bg', color };
+	}
+
+	// Try CSS color names
+	const cssColor = cssNameToColor(colorName);
+	if (cssColor !== null) {
+		const color = color256ToTruecolor(cssColor);
+		return { type: isFg ? 'fg' : 'bg', color };
+	}
+
+	return null;
+}
+
+/**
+ * Applies a tag to the current style state.
+ */
+function applyTag(style: MarkupStyle, tag: string): MarkupStyle {
+	// Handle reset tag
+	if (tag === '/') {
+		return {};
+	}
+
+	// Handle style tags
+	if (isStyleTag(tag)) {
+		if (tag === 'center' || tag === 'right') {
+			return { ...style, align: tag };
+		}
+		return { ...style, [tag]: true };
+	}
+
+	// Handle color tags
+	const colorTag = parseColorTag(tag);
+	if (colorTag) {
+		return { ...style, [colorTag.type]: colorTag.color };
+	}
+
+	// Unknown tag - ignore
+	return style;
+}
+
+/**
+ * Removes a tag from the current style state.
+ */
+function removeTag(style: MarkupStyle, tag: string): MarkupStyle {
+	// Handle style tags
+	if (isStyleTag(tag)) {
+		const newStyle = { ...style };
+		if (tag === 'center' || tag === 'right') {
+			const { align: _, ...rest } = newStyle;
+			return rest;
+		}
+		const { [tag]: _, ...rest } = newStyle;
+		return rest;
+	}
+
+	// Handle color tags
+	const colorTag = parseColorTag(tag);
+	if (colorTag) {
+		const { [colorTag.type]: _, ...rest } = style;
+		return rest;
+	}
+
+	return style;
+}
+
+/**
+ * Parses markup string into styled segments.
+ *
+ * @param input - String containing markup tags
+ * @returns Array of styled text segments
+ *
+ * @example
+ * ```typescript
+ * import { parseMarkup } from 'blecsd';
+ *
+ * const segments = parseMarkup('{bold}hello{/bold}');
+ * // [{ text: 'hello', style: { bold: true } }]
+ *
+ * const nested = parseMarkup('{bold}{red-fg}text{/red-fg}{/bold}');
+ * // [{ text: 'text', style: { bold: true, fg: 0xff0000 } }]
+ * ```
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Markup parsing requires complex state tracking
+export function parseMarkup(input: string): StyledSegment[] {
+	if (!input) {
+		return [];
+	}
+
+	const segments: StyledSegment[] = [];
+	let currentStyle: MarkupStyle = {};
+	const tagStack: string[] = [];
+	let currentText = '';
+	let i = 0;
+
+	const flushText = (): void => {
+		if (currentText) {
+			segments.push({ text: currentText, style: { ...currentStyle } });
+			currentText = '';
+		}
+	};
+
+	while (i < input.length) {
+		const char = input[i];
+
+		if (char === '{') {
+			// Look for closing brace
+			const closeIdx = input.indexOf('}', i + 1);
+			if (closeIdx === -1) {
+				// No closing brace - treat as literal
+				currentText += char;
+				i++;
+				continue;
+			}
+
+			const tag = input.slice(i + 1, closeIdx);
+
+			// Handle escaped braces
+			if (tag === 'open') {
+				currentText += '{';
+				i = closeIdx + 1;
+				continue;
+			}
+			if (tag === 'close') {
+				currentText += '}';
+				i = closeIdx + 1;
+				continue;
+			}
+
+			// Handle closing tags
+			if (tag.startsWith('/')) {
+				flushText();
+				const closingTag = tag.slice(1);
+
+				if (closingTag === '') {
+					// Reset all styles
+					currentStyle = {};
+					tagStack.length = 0;
+				} else {
+					// Remove specific style
+					currentStyle = removeTag(currentStyle, closingTag);
+					// Remove from tag stack
+					const stackIdx = tagStack.lastIndexOf(closingTag);
+					if (stackIdx !== -1) {
+						tagStack.splice(stackIdx, 1);
+					}
+				}
+
+				i = closeIdx + 1;
+				continue;
+			}
+
+			// Handle opening tags
+			flushText();
+			currentStyle = applyTag(currentStyle, tag);
+			tagStack.push(tag);
+			i = closeIdx + 1;
+			continue;
+		}
+
+		// Regular character
+		currentText += char;
+		i++;
+	}
+
+	// Flush any remaining text
+	flushText();
+
+	return segments;
+}
+
+/**
+ * Strips all markup tags from a string, returning only visible text.
+ *
+ * @param input - String containing markup tags
+ * @returns Plain text without tags
+ *
+ * @example
+ * ```typescript
+ * import { stripMarkup } from 'blecsd';
+ *
+ * stripMarkup('{bold}hello{/bold}'); // 'hello'
+ * stripMarkup('{red-fg}test{/red-fg}'); // 'test'
+ * ```
+ */
+export function stripMarkup(input: string): string {
+	let result = '';
+	let i = 0;
+
+	while (i < input.length) {
+		const char = input[i];
+
+		if (char === '{') {
+			const closeIdx = input.indexOf('}', i + 1);
+			if (closeIdx === -1) {
+				// No closing brace - treat as literal (but we remove it for cleanliness)
+				i++;
+				continue;
+			}
+
+			const tag = input.slice(i + 1, closeIdx);
+
+			// Handle escaped braces
+			if (tag === 'open') {
+				result += '{';
+				i = closeIdx + 1;
+				continue;
+			}
+			if (tag === 'close') {
+				result += '}';
+				i = closeIdx + 1;
+				continue;
+			}
+
+			// Skip the tag
+			i = closeIdx + 1;
+			continue;
+		}
+
+		result += char;
+		i++;
+	}
+
+	return result;
+}
+
+/**
+ * Calculates the visible text length, excluding markup tags.
+ *
+ * @param input - String containing markup tags
+ * @returns Length of visible text
+ *
+ * @example
+ * ```typescript
+ * import { markupLength } from 'blecsd';
+ *
+ * markupLength('hello'); // 5
+ * markupLength('{bold}hello{/bold}'); // 5
+ * markupLength('{red-fg}hello{/red-fg} world'); // 11
+ * ```
+ */
+export function markupLength(input: string): number {
+	return stripMarkup(input).length;
+}
+
+/**
+ * Converts styled segments back to ANSI escape sequences.
+ *
+ * @param segments - Array of styled text segments
+ * @returns String with ANSI escape codes
+ *
+ * @example
+ * ```typescript
+ * import { parseMarkup, renderMarkup } from 'blecsd';
+ *
+ * const segments = parseMarkup('{bold}hello{/bold}');
+ * const ansi = renderMarkup(segments);
+ * // '\x1b[1mhello\x1b[0m'
+ * ```
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: ANSI code generation requires checking multiple style flags
+export function renderMarkup(segments: StyledSegment[]): string {
+	if (!segments.length) {
+		return '';
+	}
+
+	let result = '';
+
+	for (const segment of segments) {
+		const codes: string[] = [];
+
+		// Collect SGR codes
+		if (segment.style.bold) codes.push('1');
+		if (segment.style.dim) codes.push('2');
+		if (segment.style.italic) codes.push('3');
+		if (segment.style.underline) codes.push('4');
+		if (segment.style.blink) codes.push('5');
+		if (segment.style.inverse) codes.push('7');
+
+		// Foreground color
+		if (segment.style.fg !== undefined) {
+			const r = (segment.style.fg >> 16) & 0xff;
+			const g = (segment.style.fg >> 8) & 0xff;
+			const b = segment.style.fg & 0xff;
+			codes.push(`38;2;${r};${g};${b}`);
+		}
+
+		// Background color
+		if (segment.style.bg !== undefined) {
+			const r = (segment.style.bg >> 16) & 0xff;
+			const g = (segment.style.bg >> 8) & 0xff;
+			const b = segment.style.bg & 0xff;
+			codes.push(`48;2;${r};${g};${b}`);
+		}
+
+		// Apply codes if any
+		if (codes.length > 0) {
+			result += `\x1b[${codes.join(';')}m`;
+		}
+
+		// Add the text
+		result += segment.text;
+
+		// Reset after each segment if it had styles
+		if (codes.length > 0) {
+			result += '\x1b[0m';
+		}
+	}
+
+	return result;
+}


### PR DESCRIPTION
Closes #937

## Summary
- Tag parser for inline text styling in terminal applications
- Support for bold, underline, italic, dim, blink, inverse styling
- Support for named colors (red, blue, etc.) and hex colors (#ff0000)
- Support for alignment tags (center, right)
- Nested tags and proper tag stacking
- Escaped braces ({open} → `{`, {close} → `}`)
- Reset tag ({/} to clear all styles)
- Comprehensive test suite with 34 tests

## API

### Types
- `MarkupStyle` - Style attributes (bold, colors, etc.)
- `StyledSegment` - Text segment with associated style

### Functions
- `parseMarkup(input: string): StyledSegment[]` - Parse markup into styled segments
- `stripMarkup(input: string): string` - Remove all tags, return plain text
- `markupLength(input: string): number` - Calculate visible text length
- `renderMarkup(segments: StyledSegment[]): string` - Convert to ANSI escape sequences

## Examples

```typescript
import { parseMarkup, renderMarkup, stripMarkup } from 'blecsd';

// Parse markup
const segments = parseMarkup('{bold}{red-fg}Error{/red-fg}{/bold}');

// Strip tags
const plain = stripMarkup('{bold}text{/bold}'); // 'text'

// Get visible length
const len = markupLength('{bold}hello{/bold}'); // 5

// Render to ANSI
const ansi = renderMarkup(segments);
```

## Test plan
- [x] All tag types parsed correctly (bold, underline, italic, dim, blink, inverse)
- [x] Named colors work (red-fg, blue-bg, etc.)
- [x] Hex colors work (#ff0000-fg, #00ff00-bg)
- [x] Alignment tags work (center, right)
- [x] Nested tags work correctly
- [x] Edge cases handled (malformed, unclosed, empty tags)
- [x] Escaped braces work ({open}, {close})
- [x] Reset tag {/} clears all styles
- [x] Performance acceptable for render loop
- [x] All tests pass (34/34)
- [x] Lint clean
- [x] Type check passes
- [x] Build succeeds