### PR TITLE
feat: add scrollbar rendering and dashed border styles

### DIFF
--- a/src/components/border.ts
+++ b/src/components/border.ts
@@ -97,6 +97,32 @@ export const BORDER_ASCII: BorderCharset = {
 };
 
 /**
+ * Dashed border characters (┄ ┆ + + + +).
+ * Uses light dashed lines with simple corners.
+ */
+export const BORDER_DASHED: BorderCharset = {
+	topLeft: 0x2b, // +
+	topRight: 0x2b, // +
+	bottomLeft: 0x2b, // +
+	bottomRight: 0x2b, // +
+	horizontal: 0x2504, // ┄ (light triple dash horizontal)
+	vertical: 0x2506, // ┆ (light triple dash vertical)
+};
+
+/**
+ * Heavy dashed border characters (┅ ┇ + + + +).
+ * Uses heavy dashed lines with simple corners.
+ */
+export const BORDER_DASHED_HEAVY: BorderCharset = {
+	topLeft: 0x2b, // +
+	topRight: 0x2b, // +
+	bottomLeft: 0x2b, // +
+	bottomRight: 0x2b, // +
+	horizontal: 0x2505, // ┅ (heavy triple dash horizontal)
+	vertical: 0x2507, // ┇ (heavy triple dash vertical)
+};
+
+/**
  * Default foreground color for borders (white).
  */
 export const DEFAULT_BORDER_FG = 0xffffffff;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -83,6 +83,8 @@ export type { BorderCharset, BorderData, BorderOptions } from './border';
 export {
 	BORDER_ASCII,
 	BORDER_BOLD,
+	BORDER_DASHED,
+	BORDER_DASHED_HEAVY,
 	BORDER_DOUBLE,
 	BORDER_ROUNDED,
 	BORDER_SINGLE,
@@ -799,6 +801,32 @@ export {
 	setScrollbarVisibility,
 	setScrollSize,
 } from './scrollable';
+// Scrollbar component
+export type {
+	ScrollbarData,
+	ScrollbarOptions,
+	ScrollbarRenderCell,
+} from './scrollbar';
+export {
+	calculateHorizontalScrollbar,
+	calculateVerticalScrollbar,
+	DEFAULT_THUMB_CHAR as DEFAULT_SCROLLBAR_THUMB_CHAR,
+	DEFAULT_THUMB_COLOR,
+	DEFAULT_TRACK_CHAR as DEFAULT_SCROLLBAR_TRACK_CHAR,
+	DEFAULT_TRACK_CHAR_H,
+	DEFAULT_TRACK_COLOR,
+	disableScrollbar,
+	enableScrollbar,
+	getScrollbar,
+	hasScrollbar,
+	isScrollbarEnabled,
+	Scrollbar,
+	setScrollbar,
+	setScrollbarChars,
+	setScrollbarColors,
+	shouldShowHorizontalScrollbar,
+	shouldShowVerticalScrollbar,
+} from './scrollbar';
 // Select component
 export type {
 	SelectAction,

--- a/src/components/scrollbar.test.ts
+++ b/src/components/scrollbar.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Tests for scrollbar component.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { addEntity, createWorld } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+import type { ScrollbarRenderCell } from './scrollbar';
+import {
+	calculateHorizontalScrollbar,
+	calculateVerticalScrollbar,
+	DEFAULT_THUMB_CHAR,
+	DEFAULT_THUMB_COLOR,
+	DEFAULT_TRACK_CHAR,
+	DEFAULT_TRACK_CHAR_H,
+	DEFAULT_TRACK_COLOR,
+	disableScrollbar,
+	enableScrollbar,
+	getScrollbar,
+	hasScrollbar,
+	isScrollbarEnabled,
+	Scrollbar,
+	setScrollbar,
+	setScrollbarChars,
+	setScrollbarColors,
+	shouldShowHorizontalScrollbar,
+	shouldShowVerticalScrollbar,
+} from './scrollbar';
+
+describe('Scrollbar component', () => {
+	let world: World;
+	let entity: Entity;
+
+	beforeEach(() => {
+		world = createWorld();
+		entity = addEntity(world);
+	});
+
+	describe('setScrollbar', () => {
+		it('should add scrollbar component with default values', () => {
+			setScrollbar(world, entity, { enabled: true });
+
+			expect(hasScrollbar(world, entity)).toBe(true);
+			const scrollbar = getScrollbar(world, entity);
+			expect(scrollbar).toBeDefined();
+			expect(scrollbar?.enabled).toBe(true);
+			expect(scrollbar?.vertical).toBe(true);
+			expect(scrollbar?.horizontal).toBe(true);
+			expect(scrollbar?.trackChar).toBe(DEFAULT_TRACK_CHAR);
+			expect(scrollbar?.thumbChar).toBe(DEFAULT_THUMB_CHAR);
+			expect(scrollbar?.trackColor).toBe(DEFAULT_TRACK_COLOR);
+			expect(scrollbar?.thumbColor).toBe(DEFAULT_THUMB_COLOR);
+		});
+
+		it('should set custom scrollbar options', () => {
+			setScrollbar(world, entity, {
+				enabled: true,
+				thumbColor: '#ff0000',
+				trackColor: '#333333',
+				alwaysShow: true,
+			});
+
+			const scrollbar = getScrollbar(world, entity);
+			expect(scrollbar?.thumbColor).toBe(0xffff0000);
+			expect(scrollbar?.trackColor).toBe(0xff333333);
+			expect(scrollbar?.alwaysShow).toBe(true);
+		});
+
+		it('should update existing scrollbar', () => {
+			setScrollbar(world, entity, { enabled: true });
+			setScrollbar(world, entity, { vertical: false });
+
+			const scrollbar = getScrollbar(world, entity);
+			expect(scrollbar?.enabled).toBe(true);
+			expect(scrollbar?.vertical).toBe(false);
+		});
+
+		it('should return entity for chaining', () => {
+			const result = setScrollbar(world, entity, { enabled: true });
+			expect(result).toBe(entity);
+		});
+	});
+
+	describe('getScrollbar', () => {
+		it('should return undefined if no scrollbar component', () => {
+			expect(getScrollbar(world, entity)).toBeUndefined();
+		});
+
+		it('should return scrollbar data', () => {
+			setScrollbar(world, entity, {
+				enabled: true,
+				thumbColor: 0xffaabbcc,
+			});
+
+			const scrollbar = getScrollbar(world, entity);
+			expect(scrollbar).toBeDefined();
+			expect(scrollbar?.thumbColor).toBe(0xffaabbcc);
+		});
+	});
+
+	describe('hasScrollbar', () => {
+		it('should return false if no scrollbar component', () => {
+			expect(hasScrollbar(world, entity)).toBe(false);
+		});
+
+		it('should return true if scrollbar component exists', () => {
+			setScrollbar(world, entity, { enabled: true });
+			expect(hasScrollbar(world, entity)).toBe(true);
+		});
+	});
+
+	describe('isScrollbarEnabled', () => {
+		it('should return false if no scrollbar component', () => {
+			expect(isScrollbarEnabled(world, entity)).toBe(false);
+		});
+
+		it('should return true if scrollbar is enabled', () => {
+			setScrollbar(world, entity, { enabled: true });
+			expect(isScrollbarEnabled(world, entity)).toBe(true);
+		});
+
+		it('should return false if scrollbar is disabled', () => {
+			setScrollbar(world, entity, { enabled: false });
+			expect(isScrollbarEnabled(world, entity)).toBe(false);
+		});
+	});
+
+	describe('enableScrollbar / disableScrollbar', () => {
+		it('should enable scrollbar', () => {
+			setScrollbar(world, entity, { enabled: false });
+			enableScrollbar(world, entity);
+
+			expect(isScrollbarEnabled(world, entity)).toBe(true);
+		});
+
+		it('should disable scrollbar', () => {
+			setScrollbar(world, entity, { enabled: true });
+			disableScrollbar(world, entity);
+
+			expect(isScrollbarEnabled(world, entity)).toBe(false);
+		});
+
+		it('should create component if not exists when enabling', () => {
+			enableScrollbar(world, entity);
+			expect(hasScrollbar(world, entity)).toBe(true);
+			expect(isScrollbarEnabled(world, entity)).toBe(true);
+		});
+	});
+
+	describe('setScrollbarChars', () => {
+		it('should set scrollbar characters', () => {
+			setScrollbarChars(world, entity, 0x007c, 0x0023); // | and #
+
+			const scrollbar = getScrollbar(world, entity);
+			expect(scrollbar?.trackChar).toBe(0x007c);
+			expect(scrollbar?.thumbChar).toBe(0x0023);
+		});
+
+		it('should create component if not exists', () => {
+			setScrollbarChars(world, entity, 0x007c, 0x0023);
+			expect(hasScrollbar(world, entity)).toBe(true);
+		});
+	});
+
+	describe('setScrollbarColors', () => {
+		it('should set scrollbar colors', () => {
+			setScrollbarColors(world, entity, '#123456', 0xffaabbcc);
+
+			const scrollbar = getScrollbar(world, entity);
+			expect(scrollbar?.trackColor).toBe(0xff123456);
+			expect(scrollbar?.thumbColor).toBe(0xffaabbcc);
+		});
+	});
+
+	describe('calculateVerticalScrollbar', () => {
+		it('should return empty array if height is zero', () => {
+			const cells = calculateVerticalScrollbar(
+				10,
+				0,
+				0, // height = 0
+				0,
+				100,
+				20,
+				DEFAULT_TRACK_CHAR,
+				DEFAULT_THUMB_CHAR,
+				DEFAULT_TRACK_COLOR,
+				DEFAULT_THUMB_COLOR,
+			);
+
+			expect(cells).toEqual([]);
+		});
+
+		it('should return empty array if content fits in viewport', () => {
+			const cells = calculateVerticalScrollbar(
+				10,
+				0,
+				20,
+				0,
+				100, // scrollSize
+				100, // viewportSize = scrollSize, no scrolling needed
+				DEFAULT_TRACK_CHAR,
+				DEFAULT_THUMB_CHAR,
+				DEFAULT_TRACK_COLOR,
+				DEFAULT_THUMB_COLOR,
+			);
+
+			expect(cells).toEqual([]);
+		});
+
+		it('should calculate scrollbar for content larger than viewport', () => {
+			const cells = calculateVerticalScrollbar(
+				10,
+				5,
+				20, // height
+				0, // scrollOffset
+				1000, // scrollSize
+				200, // viewportSize
+				DEFAULT_TRACK_CHAR,
+				DEFAULT_THUMB_CHAR,
+				DEFAULT_TRACK_COLOR,
+				DEFAULT_THUMB_COLOR,
+			);
+
+			expect(cells.length).toBe(20); // height
+			expect(cells[0]?.x).toBe(10);
+			expect(cells[0]?.y).toBe(5);
+
+			// Check that some cells are thumb, some are track
+			const thumbCells = cells.filter((c) => c.isThumb);
+			const trackCells = cells.filter((c) => !c.isThumb);
+
+			expect(thumbCells.length).toBeGreaterThan(0);
+			expect(trackCells.length).toBeGreaterThan(0);
+			expect(thumbCells.length + trackCells.length).toBe(20);
+		});
+
+		it('should position thumb based on scroll offset', () => {
+			// Scrolled to middle
+			const cells = calculateVerticalScrollbar(
+				10,
+				0,
+				20,
+				400, // scrollOffset = 50% of scrollable range (800)
+				1000,
+				200,
+				DEFAULT_TRACK_CHAR,
+				DEFAULT_THUMB_CHAR,
+				DEFAULT_TRACK_COLOR,
+				DEFAULT_THUMB_COLOR,
+			);
+
+			const thumbCells = cells.filter((c) => c.isThumb);
+			const firstThumbIndex = cells.findIndex((c) => c.isThumb);
+
+			// Thumb should be roughly in the middle
+			expect(firstThumbIndex).toBeGreaterThan(5);
+			expect(firstThumbIndex).toBeLessThan(15);
+			expect(thumbCells.length).toBeGreaterThan(0);
+		});
+
+		it('should use correct character for thumb and track', () => {
+			const cells = calculateVerticalScrollbar(
+				10,
+				0,
+				20,
+				0,
+				1000,
+				200,
+				0x007c,
+				0x0023,
+				0xff000000,
+				0xffffffff,
+			);
+
+			const thumbCells = cells.filter((c) => c.isThumb);
+			const trackCells = cells.filter((c) => !c.isThumb);
+
+			expect(thumbCells[0]?.char).toBe(0x0023);
+			expect(trackCells[0]?.char).toBe(0x007c);
+		});
+
+		it('should use correct colors for thumb and track', () => {
+			const cells = calculateVerticalScrollbar(
+				10,
+				0,
+				20,
+				0,
+				1000,
+				200,
+				0x007c,
+				0x0023,
+				0xff111111,
+				0xff222222,
+			);
+
+			const thumbCells = cells.filter((c) => c.isThumb);
+			const trackCells = cells.filter((c) => !c.isThumb);
+
+			expect(thumbCells[0]?.color).toBe(0xff222222);
+			expect(trackCells[0]?.color).toBe(0xff111111);
+		});
+	});
+
+	describe('calculateHorizontalScrollbar', () => {
+		it('should return empty array if width is zero', () => {
+			const cells = calculateHorizontalScrollbar(
+				0,
+				10,
+				0, // width = 0
+				0,
+				100,
+				20,
+				DEFAULT_TRACK_CHAR_H,
+				DEFAULT_THUMB_CHAR,
+				DEFAULT_TRACK_COLOR,
+				DEFAULT_THUMB_COLOR,
+			);
+
+			expect(cells).toEqual([]);
+		});
+
+		it('should return empty array if content fits in viewport', () => {
+			const cells = calculateHorizontalScrollbar(
+				0,
+				10,
+				80,
+				0,
+				100,
+				100, // viewportSize = scrollSize
+				DEFAULT_TRACK_CHAR_H,
+				DEFAULT_THUMB_CHAR,
+				DEFAULT_TRACK_COLOR,
+				DEFAULT_THUMB_COLOR,
+			);
+
+			expect(cells).toEqual([]);
+		});
+
+		it('should calculate horizontal scrollbar', () => {
+			const cells = calculateHorizontalScrollbar(
+				5,
+				10,
+				80,
+				0,
+				1000,
+				200,
+				DEFAULT_TRACK_CHAR_H,
+				DEFAULT_THUMB_CHAR,
+				DEFAULT_TRACK_COLOR,
+				DEFAULT_THUMB_COLOR,
+			);
+
+			expect(cells.length).toBe(80); // width
+			expect(cells[0]?.x).toBe(5);
+			expect(cells[0]?.y).toBe(10);
+
+			const thumbCells = cells.filter((c) => c.isThumb);
+			const trackCells = cells.filter((c) => !c.isThumb);
+
+			expect(thumbCells.length).toBeGreaterThan(0);
+			expect(trackCells.length).toBeGreaterThan(0);
+		});
+
+		it('should position thumb based on horizontal scroll offset', () => {
+			const cells = calculateHorizontalScrollbar(
+				0,
+				10,
+				80,
+				400, // 50% of scrollable range
+				1000,
+				200,
+				DEFAULT_TRACK_CHAR_H,
+				DEFAULT_THUMB_CHAR,
+				DEFAULT_TRACK_COLOR,
+				DEFAULT_THUMB_COLOR,
+			);
+
+			const firstThumbIndex = cells.findIndex((c) => c.isThumb);
+
+			// Thumb should be roughly in the middle
+			expect(firstThumbIndex).toBeGreaterThan(20);
+			expect(firstThumbIndex).toBeLessThan(60);
+		});
+	});
+
+	describe('shouldShowVerticalScrollbar', () => {
+		it('should return false if content fits', () => {
+			expect(shouldShowVerticalScrollbar(100, 100, false)).toBe(false);
+			expect(shouldShowVerticalScrollbar(50, 100, false)).toBe(false);
+		});
+
+		it('should return true if content overflows', () => {
+			expect(shouldShowVerticalScrollbar(200, 100, false)).toBe(true);
+		});
+
+		it('should return true if alwaysShow is true', () => {
+			expect(shouldShowVerticalScrollbar(50, 100, true)).toBe(true);
+			expect(shouldShowVerticalScrollbar(100, 100, true)).toBe(true);
+		});
+	});
+
+	describe('shouldShowHorizontalScrollbar', () => {
+		it('should return false if content fits', () => {
+			expect(shouldShowHorizontalScrollbar(100, 100, false)).toBe(false);
+			expect(shouldShowHorizontalScrollbar(50, 100, false)).toBe(false);
+		});
+
+		it('should return true if content overflows', () => {
+			expect(shouldShowHorizontalScrollbar(200, 100, false)).toBe(true);
+		});
+
+		it('should return true if alwaysShow is true', () => {
+			expect(shouldShowHorizontalScrollbar(50, 100, true)).toBe(true);
+		});
+	});
+
+	describe('Scrollbar component direct access', () => {
+		it('should store values in component arrays', () => {
+			setScrollbar(world, entity, {
+				enabled: true,
+				vertical: false,
+				trackChar: 0x007c,
+			});
+
+			expect(Scrollbar.enabled[entity]).toBe(1);
+			expect(Scrollbar.vertical[entity]).toBe(0);
+			expect(Scrollbar.trackChar[entity]).toBe(0x007c);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle scrollbar at top', () => {
+			const cells = calculateVerticalScrollbar(
+				10,
+				0,
+				20,
+				0,
+				1000,
+				200,
+				0x007c,
+				0x0023,
+				0xff000000,
+				0xffffffff,
+			);
+
+			const firstThumbIndex = cells.findIndex((c) => c.isThumb);
+			expect(firstThumbIndex).toBe(0); // Thumb starts at top
+		});
+
+		it('should handle scrollbar at bottom', () => {
+			const cells = calculateVerticalScrollbar(
+				10,
+				0,
+				20,
+				800, // scrolled to bottom (scrollable range = 1000 - 200 = 800)
+				1000,
+				200,
+				0x007c,
+				0x0023,
+				0xff000000,
+				0xffffffff,
+			);
+
+			const lastThumbIndex = cells.reverse().findIndex((c: ScrollbarRenderCell) => c.isThumb);
+			expect(lastThumbIndex).toBeGreaterThanOrEqual(0);
+			expect(lastThumbIndex).toBeLessThan(5); // Thumb ends near bottom
+		});
+
+		it('should handle minimum thumb size', () => {
+			// Very small viewport relative to content
+			const cells = calculateVerticalScrollbar(
+				10,
+				0,
+				100, // height
+				0,
+				10000, // very large scroll size
+				100, // small viewport
+				0x007c,
+				0x0023,
+				0xff000000,
+				0xffffffff,
+			);
+
+			const thumbCells = cells.filter((c) => c.isThumb);
+			// Thumb should be at least 1 cell
+			expect(thumbCells.length).toBeGreaterThanOrEqual(1);
+		});
+	});
+});

--- a/src/components/scrollbar.ts
+++ b/src/components/scrollbar.ts
@@ -1,0 +1,555 @@
+/**
+ * Scrollbar component for rendering scrollbars on scrollable widgets.
+ *
+ * Provides visual feedback for scroll position with configurable characters,
+ * colors, and auto-hide behavior.
+ *
+ * @module components/scrollbar
+ */
+
+import { addComponent, hasComponent } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+import { parseColor } from '../utils/color';
+
+/** Default entity capacity for typed arrays */
+const DEFAULT_CAPACITY = 10000;
+
+/**
+ * Default scrollbar track character (light vertical bar).
+ */
+export const DEFAULT_TRACK_CHAR = 0x2502; // │
+
+/**
+ * Default scrollbar thumb character (full block).
+ */
+export const DEFAULT_THUMB_CHAR = 0x2588; // █
+
+/**
+ * Default horizontal track character (light horizontal bar).
+ */
+export const DEFAULT_TRACK_CHAR_H = 0x2500; // ─
+
+/**
+ * Default track color (dark gray).
+ */
+export const DEFAULT_TRACK_COLOR = 0xff333333;
+
+/**
+ * Default thumb color (light gray).
+ */
+export const DEFAULT_THUMB_COLOR = 0xff888888;
+
+/**
+ * Scrollbar component store using SoA (Structure of Arrays) for performance.
+ *
+ * - `enabled`: Whether scrollbar is enabled (0=disabled, 1=enabled)
+ * - `vertical`: Whether vertical scrollbar is visible (0=no, 1=yes)
+ * - `horizontal`: Whether horizontal scrollbar is visible (0=no, 1=yes)
+ * - `trackChar`: Unicode codepoint for track character (vertical)
+ * - `thumbChar`: Unicode codepoint for thumb character (vertical)
+ * - `trackCharH`: Unicode codepoint for horizontal track character
+ * - `thumbCharH`: Unicode codepoint for horizontal thumb character
+ * - `trackColor`: Track color (packed RGBA)
+ * - `thumbColor`: Thumb color (packed RGBA)
+ * - `alwaysShow`: Always show scrollbar (0=auto, 1=always)
+ *
+ * @example
+ * ```typescript
+ * import { Scrollbar, setScrollbar, getScrollbar } from 'blecsd';
+ *
+ * setScrollbar(world, entity, { enabled: true });
+ * setScrollbar(world, entity, { thumbColor: '#ff0000', alwaysShow: true });
+ *
+ * const scrollbar = getScrollbar(world, entity);
+ * if (scrollbar?.enabled) {
+ *   console.log(`Track char: ${String.fromCodePoint(scrollbar.trackChar)}`);
+ * }
+ * ```
+ */
+export const Scrollbar = {
+	/** 0 = disabled, 1 = enabled */
+	enabled: new Uint8Array(DEFAULT_CAPACITY),
+	/** Vertical scrollbar visible (0=no, 1=yes) */
+	vertical: new Uint8Array(DEFAULT_CAPACITY),
+	/** Horizontal scrollbar visible (0=no, 1=yes) */
+	horizontal: new Uint8Array(DEFAULT_CAPACITY),
+	/** Track character for vertical scrollbar */
+	trackChar: new Uint32Array(DEFAULT_CAPACITY),
+	/** Thumb character for vertical scrollbar */
+	thumbChar: new Uint32Array(DEFAULT_CAPACITY),
+	/** Track character for horizontal scrollbar */
+	trackCharH: new Uint32Array(DEFAULT_CAPACITY),
+	/** Thumb character for horizontal scrollbar */
+	thumbCharH: new Uint32Array(DEFAULT_CAPACITY),
+	/** Track color (packed RGBA) */
+	trackColor: new Uint32Array(DEFAULT_CAPACITY),
+	/** Thumb color (packed RGBA) */
+	thumbColor: new Uint32Array(DEFAULT_CAPACITY),
+	/** Always show scrollbar (0=auto, 1=always) */
+	alwaysShow: new Uint8Array(DEFAULT_CAPACITY),
+};
+
+/**
+ * Scrollbar configuration options.
+ */
+export interface ScrollbarOptions {
+	/** Enable or disable scrollbar */
+	enabled?: boolean;
+	/** Show vertical scrollbar */
+	vertical?: boolean;
+	/** Show horizontal scrollbar */
+	horizontal?: boolean;
+	/** Track character for vertical scrollbar */
+	trackChar?: number;
+	/** Thumb character for vertical scrollbar */
+	thumbChar?: number;
+	/** Track character for horizontal scrollbar */
+	trackCharH?: number;
+	/** Thumb character for horizontal scrollbar */
+	thumbCharH?: number;
+	/** Track color (hex string or packed number) */
+	trackColor?: string | number;
+	/** Thumb color (hex string or packed number) */
+	thumbColor?: string | number;
+	/** Always show scrollbar (even when content fits) */
+	alwaysShow?: boolean;
+}
+
+/**
+ * Scrollbar data returned by getScrollbar.
+ */
+export interface ScrollbarData {
+	readonly enabled: boolean;
+	readonly vertical: boolean;
+	readonly horizontal: boolean;
+	readonly trackChar: number;
+	readonly thumbChar: number;
+	readonly trackCharH: number;
+	readonly thumbCharH: number;
+	readonly trackColor: number;
+	readonly thumbColor: number;
+	readonly alwaysShow: boolean;
+}
+
+/**
+ * Scrollbar render position for a single cell.
+ */
+export interface ScrollbarRenderCell {
+	readonly x: number;
+	readonly y: number;
+	readonly char: number;
+	readonly color: number;
+	readonly isThumb: boolean;
+}
+
+/**
+ * Initializes a Scrollbar component with default values.
+ */
+function initScrollbar(eid: Entity): void {
+	Scrollbar.enabled[eid] = 1;
+	Scrollbar.vertical[eid] = 1;
+	Scrollbar.horizontal[eid] = 1;
+	Scrollbar.trackChar[eid] = DEFAULT_TRACK_CHAR;
+	Scrollbar.thumbChar[eid] = DEFAULT_THUMB_CHAR;
+	Scrollbar.trackCharH[eid] = DEFAULT_TRACK_CHAR_H;
+	Scrollbar.thumbCharH[eid] = DEFAULT_THUMB_CHAR;
+	Scrollbar.trackColor[eid] = DEFAULT_TRACK_COLOR;
+	Scrollbar.thumbColor[eid] = DEFAULT_THUMB_COLOR;
+	Scrollbar.alwaysShow[eid] = 0;
+}
+
+/**
+ * Ensures an entity has the Scrollbar component, initializing if needed.
+ */
+function ensureScrollbar(world: World, eid: Entity): void {
+	if (!hasComponent(world, eid, Scrollbar)) {
+		addComponent(world, eid, Scrollbar);
+		initScrollbar(eid);
+	}
+}
+
+/**
+ * Applies boolean scrollbar options.
+ * @internal
+ */
+function applyScrollbarBooleans(eid: Entity, options: ScrollbarOptions): void {
+	if (options.enabled !== undefined) Scrollbar.enabled[eid] = options.enabled ? 1 : 0;
+	if (options.vertical !== undefined) Scrollbar.vertical[eid] = options.vertical ? 1 : 0;
+	if (options.horizontal !== undefined) Scrollbar.horizontal[eid] = options.horizontal ? 1 : 0;
+	if (options.alwaysShow !== undefined) Scrollbar.alwaysShow[eid] = options.alwaysShow ? 1 : 0;
+}
+
+/**
+ * Applies character scrollbar options.
+ * @internal
+ */
+function applyScrollbarChars(eid: Entity, options: ScrollbarOptions): void {
+	if (options.trackChar !== undefined) Scrollbar.trackChar[eid] = options.trackChar;
+	if (options.thumbChar !== undefined) Scrollbar.thumbChar[eid] = options.thumbChar;
+	if (options.trackCharH !== undefined) Scrollbar.trackCharH[eid] = options.trackCharH;
+	if (options.thumbCharH !== undefined) Scrollbar.thumbCharH[eid] = options.thumbCharH;
+}
+
+/**
+ * Applies color scrollbar options.
+ * @internal
+ */
+function applyScrollbarColors(eid: Entity, options: ScrollbarOptions): void {
+	if (options.trackColor !== undefined) Scrollbar.trackColor[eid] = parseColor(options.trackColor);
+	if (options.thumbColor !== undefined) Scrollbar.thumbColor[eid] = parseColor(options.thumbColor);
+}
+
+/**
+ * Applies scrollbar options to an entity.
+ * @internal
+ */
+function applyScrollbarOptions(eid: Entity, options: ScrollbarOptions): void {
+	applyScrollbarBooleans(eid, options);
+	applyScrollbarChars(eid, options);
+	applyScrollbarColors(eid, options);
+}
+
+/**
+ * Sets the scrollbar configuration of an entity.
+ * Adds the Scrollbar component if not already present.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity ID
+ * @param options - Scrollbar configuration options
+ * @returns The entity ID for chaining
+ *
+ * @example
+ * ```typescript
+ * import { createWorld, addEntity } from '../core/ecs';
+ * import { setScrollbar } from 'blecsd';
+ *
+ * const world = createWorld();
+ * const entity = addEntity(world);
+ *
+ * // Enable scrollbar with default settings
+ * setScrollbar(world, entity, { enabled: true });
+ *
+ * // Custom scrollbar configuration
+ * setScrollbar(world, entity, {
+ *   enabled: true,
+ *   thumbColor: '#ff0000',
+ *   trackColor: '#333333',
+ *   alwaysShow: true,
+ * });
+ * ```
+ */
+export function setScrollbar(world: World, eid: Entity, options: ScrollbarOptions): Entity {
+	ensureScrollbar(world, eid);
+	applyScrollbarOptions(eid, options);
+	return eid;
+}
+
+/**
+ * Gets the scrollbar data of an entity.
+ * Returns undefined if the entity doesn't have a Scrollbar component.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity ID
+ * @returns Scrollbar data or undefined
+ *
+ * @example
+ * ```typescript
+ * import { getScrollbar } from 'blecsd';
+ *
+ * const scrollbar = getScrollbar(world, entity);
+ * if (scrollbar?.enabled) {
+ *   console.log(`Track: ${scrollbar.trackColor.toString(16)}`);
+ * }
+ * ```
+ */
+export function getScrollbar(world: World, eid: Entity): ScrollbarData | undefined {
+	if (!hasComponent(world, eid, Scrollbar)) {
+		return undefined;
+	}
+	return {
+		enabled: Scrollbar.enabled[eid] === 1,
+		vertical: Scrollbar.vertical[eid] === 1,
+		horizontal: Scrollbar.horizontal[eid] === 1,
+		trackChar: Scrollbar.trackChar[eid] as number,
+		thumbChar: Scrollbar.thumbChar[eid] as number,
+		trackCharH: Scrollbar.trackCharH[eid] as number,
+		thumbCharH: Scrollbar.thumbCharH[eid] as number,
+		trackColor: Scrollbar.trackColor[eid] as number,
+		thumbColor: Scrollbar.thumbColor[eid] as number,
+		alwaysShow: Scrollbar.alwaysShow[eid] === 1,
+	};
+}
+
+/**
+ * Checks if an entity has a Scrollbar component.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity ID
+ * @returns true if entity has Scrollbar component
+ */
+export function hasScrollbar(world: World, eid: Entity): boolean {
+	return hasComponent(world, eid, Scrollbar);
+}
+
+/**
+ * Checks if scrollbar is enabled for an entity.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity ID
+ * @returns true if scrollbar is enabled
+ */
+export function isScrollbarEnabled(world: World, eid: Entity): boolean {
+	if (!hasComponent(world, eid, Scrollbar)) {
+		return false;
+	}
+	return Scrollbar.enabled[eid] === 1;
+}
+
+/**
+ * Enables the scrollbar for an entity.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity ID
+ * @returns The entity ID for chaining
+ */
+export function enableScrollbar(world: World, eid: Entity): Entity {
+	ensureScrollbar(world, eid);
+	Scrollbar.enabled[eid] = 1;
+	return eid;
+}
+
+/**
+ * Disables the scrollbar for an entity.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity ID
+ * @returns The entity ID for chaining
+ */
+export function disableScrollbar(world: World, eid: Entity): Entity {
+	if (hasComponent(world, eid, Scrollbar)) {
+		Scrollbar.enabled[eid] = 0;
+	}
+	return eid;
+}
+
+/**
+ * Sets scrollbar characters for vertical scrollbar.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity ID
+ * @param trackChar - Track character codepoint
+ * @param thumbChar - Thumb character codepoint
+ * @returns The entity ID for chaining
+ */
+export function setScrollbarChars(
+	world: World,
+	eid: Entity,
+	trackChar: number,
+	thumbChar: number,
+): Entity {
+	ensureScrollbar(world, eid);
+	Scrollbar.trackChar[eid] = trackChar;
+	Scrollbar.thumbChar[eid] = thumbChar;
+	return eid;
+}
+
+/**
+ * Sets scrollbar colors.
+ *
+ * @param world - The ECS world
+ * @param eid - The entity ID
+ * @param trackColor - Track color (hex string or packed number)
+ * @param thumbColor - Thumb color (hex string or packed number)
+ * @returns The entity ID for chaining
+ */
+export function setScrollbarColors(
+	world: World,
+	eid: Entity,
+	trackColor: string | number,
+	thumbColor: string | number,
+): Entity {
+	ensureScrollbar(world, eid);
+	Scrollbar.trackColor[eid] = parseColor(trackColor);
+	Scrollbar.thumbColor[eid] = parseColor(thumbColor);
+	return eid;
+}
+
+/**
+ * Calculates vertical scrollbar render positions.
+ *
+ * @param x - Scrollbar X position (typically right edge of widget)
+ * @param y - Scrollbar Y position (typically widget top)
+ * @param height - Scrollbar height (typically widget height)
+ * @param scrollOffset - Current scroll offset
+ * @param scrollSize - Total scrollable content size
+ * @param viewportSize - Visible area size
+ * @param trackChar - Track character codepoint
+ * @param thumbChar - Thumb character codepoint
+ * @param trackColor - Track color
+ * @param thumbColor - Thumb color
+ * @returns Array of scrollbar cells to render
+ *
+ * @example
+ * ```typescript
+ * import { calculateVerticalScrollbar } from 'blecsd';
+ *
+ * const cells = calculateVerticalScrollbar(
+ *   79, 0, 24,  // x, y, height
+ *   100, 1000, 200,  // scrollOffset, scrollSize, viewportSize
+ *   0x2502, 0x2588,  // track, thumb chars
+ *   0xff333333, 0xff888888  // track, thumb colors
+ * );
+ *
+ * for (const cell of cells) {
+ *   renderCell(cell.x, cell.y, cell.char, cell.color);
+ * }
+ * ```
+ */
+export function calculateVerticalScrollbar(
+	x: number,
+	y: number,
+	height: number,
+	scrollOffset: number,
+	scrollSize: number,
+	viewportSize: number,
+	trackChar: number,
+	thumbChar: number,
+	trackColor: number,
+	thumbColor: number,
+): ScrollbarRenderCell[] {
+	const cells: ScrollbarRenderCell[] = [];
+
+	if (height <= 0 || scrollSize <= 0 || viewportSize <= 0) {
+		return cells;
+	}
+
+	// Calculate thumb size and position
+	const scrollableRange = Math.max(0, scrollSize - viewportSize);
+	if (scrollableRange === 0) {
+		// Content fits, no scrolling needed
+		return cells;
+	}
+
+	// Thumb size as a ratio of viewport to content size
+	const thumbRatio = Math.min(1, viewportSize / scrollSize);
+	const thumbHeight = Math.max(1, Math.round(height * thumbRatio));
+
+	// Thumb position as a ratio of scroll offset to scrollable range
+	const scrollRatio = scrollableRange > 0 ? scrollOffset / scrollableRange : 0;
+	const thumbStart = Math.round((height - thumbHeight) * scrollRatio);
+
+	// Render track and thumb
+	for (let row = 0; row < height; row++) {
+		const isThumb = row >= thumbStart && row < thumbStart + thumbHeight;
+		cells.push({
+			x,
+			y: y + row,
+			char: isThumb ? thumbChar : trackChar,
+			color: isThumb ? thumbColor : trackColor,
+			isThumb,
+		});
+	}
+
+	return cells;
+}
+
+/**
+ * Calculates horizontal scrollbar render positions.
+ *
+ * @param x - Scrollbar X position (typically widget left)
+ * @param y - Scrollbar Y position (typically bottom edge of widget)
+ * @param width - Scrollbar width (typically widget width)
+ * @param scrollOffset - Current scroll offset
+ * @param scrollSize - Total scrollable content size
+ * @param viewportSize - Visible area size
+ * @param trackChar - Track character codepoint
+ * @param thumbChar - Thumb character codepoint
+ * @param trackColor - Track color
+ * @param thumbColor - Thumb color
+ * @returns Array of scrollbar cells to render
+ */
+export function calculateHorizontalScrollbar(
+	x: number,
+	y: number,
+	width: number,
+	scrollOffset: number,
+	scrollSize: number,
+	viewportSize: number,
+	trackChar: number,
+	thumbChar: number,
+	trackColor: number,
+	thumbColor: number,
+): ScrollbarRenderCell[] {
+	const cells: ScrollbarRenderCell[] = [];
+
+	if (width <= 0 || scrollSize <= 0 || viewportSize <= 0) {
+		return cells;
+	}
+
+	// Calculate thumb size and position
+	const scrollableRange = Math.max(0, scrollSize - viewportSize);
+	if (scrollableRange === 0) {
+		// Content fits, no scrolling needed
+		return cells;
+	}
+
+	// Thumb size as a ratio of viewport to content size
+	const thumbRatio = Math.min(1, viewportSize / scrollSize);
+	const thumbWidth = Math.max(1, Math.round(width * thumbRatio));
+
+	// Thumb position as a ratio of scroll offset to scrollable range
+	const scrollRatio = scrollableRange > 0 ? scrollOffset / scrollableRange : 0;
+	const thumbStart = Math.round((width - thumbWidth) * scrollRatio);
+
+	// Render track and thumb
+	for (let col = 0; col < width; col++) {
+		const isThumb = col >= thumbStart && col < thumbStart + thumbWidth;
+		cells.push({
+			x: x + col,
+			y,
+			char: isThumb ? thumbChar : trackChar,
+			color: isThumb ? thumbColor : trackColor,
+			isThumb,
+		});
+	}
+
+	return cells;
+}
+
+/**
+ * Determines if vertical scrollbar should be visible.
+ *
+ * @param scrollSize - Total scrollable height
+ * @param viewportSize - Visible area height
+ * @param alwaysShow - Always show even if content fits
+ * @returns true if vertical scrollbar should be shown
+ */
+export function shouldShowVerticalScrollbar(
+	scrollSize: number,
+	viewportSize: number,
+	alwaysShow: boolean,
+): boolean {
+	if (alwaysShow) {
+		return true;
+	}
+	return scrollSize > viewportSize;
+}
+
+/**
+ * Determines if horizontal scrollbar should be visible.
+ *
+ * @param scrollSize - Total scrollable width
+ * @param viewportSize - Visible area width
+ * @param alwaysShow - Always show even if content fits
+ * @returns true if horizontal scrollbar should be shown
+ */
+export function shouldShowHorizontalScrollbar(
+	scrollSize: number,
+	viewportSize: number,
+	alwaysShow: boolean,
+): boolean {
+	if (alwaysShow) {
+		return true;
+	}
+	return scrollSize > viewportSize;
+}


### PR DESCRIPTION
## Summary
Implements **scrollbar rendering** for scrollable widgets and adds **dashed border style variations**.

### Scrollbar Rendering (#999)
- ✅ Vertical and horizontal scrollbar support
- ✅ Configurable track/thumb characters and colors
- ✅ Auto-hide when content fits in viewport
- ✅ Calculate render positions for scrollbar cells based on scroll state
- ✅ Thumb size proportional to viewport:content ratio
- ✅ Thumb position based on scroll offset

### Border Styles (#1001)
- ✅ `BORDER_DASHED`: light dashed lines (┄ ┆)
- ✅ `BORDER_DASHED_HEAVY`: heavy dashed lines (┅ ┇)

### Already Implemented
The following issues were already complete and are **NOT** included in this PR:
- #938 (Shadow rendering): Exists in `src/components/shadow.ts`
- #958 (Hover states): Exists in `src/widgets/hoverText.ts`
- #950 (Element dragging): Exists in `src/systems/dragSystem.ts`

## Files Changed
- `src/components/scrollbar.ts` (new) - Scrollbar component with render calculation
- `src/components/scrollbar.test.ts` (new) - 37 comprehensive tests
- `src/components/border.ts` - Added dashed border charsets
- `src/components/index.ts` - Exports for new features

## Test Results
```
✓ src/components/scrollbar.test.ts (37 tests)
```

All tests passing, lint clean, typecheck passing.

## Closes
- Closes #999 (scrollbar rendering)
- Closes #1001 (border style variations)