### PR TITLE
feat: screen and system-level features (#942, #944, #945, #956, #967, #975)

### DIFF
--- a/docs/api/terminal/focus-tracking.md
+++ b/docs/api/terminal/focus-tracking.md
@@ -1,0 +1,252 @@
+# Terminal Focus Tracking
+
+Provides focus/blur event handling that detects when the terminal window gains or loses focus using terminal focus reporting (CSI ? 1004 h/l sequences).
+
+## Quick Start
+
+<!-- blecsd-doccheck:ignore -->
+```typescript
+import {
+  createInputHandler,
+  createFocusTracker,
+  enableFocusTracking,
+  disableFocusTracking,
+  getTerminalFocusEventBus,
+} from 'blecsd';
+
+const inputHandler = createInputHandler(process.stdin);
+const tracker = createFocusTracker(inputHandler);
+
+// Listen for focus events
+getTerminalFocusEventBus().on('focus', () => {
+  console.log('Terminal gained focus');
+});
+
+getTerminalFocusEventBus().on('blur', () => {
+  console.log('Terminal lost focus');
+});
+
+// Enable focus tracking
+enableFocusTracking(tracker);
+
+// When done
+disableFocusTracking(tracker);
+```
+
+## Types
+
+### FocusTrackingEventMap
+
+```typescript
+interface FocusTrackingEventMap {
+  focus: undefined;    // Terminal window gained focus
+  blur: undefined;     // Terminal window lost focus
+}
+```
+
+### FocusTrackerState
+
+```typescript
+interface FocusTrackerState {
+  readonly inputHandler: InputHandler;
+  enabled: boolean;
+  focused: boolean;
+  readonly handler: (event: FocusEvent) => void;
+  unsubscribe: (() => void) | null;
+}
+```
+
+## Functions
+
+### createFocusTracker
+
+Creates a focus tracker for the given input handler. The tracker will listen for focus events from the terminal, track current focus state, and emit focus/blur events on the event bus.
+
+```typescript
+function createFocusTracker(inputHandler: InputHandler): FocusTrackerState
+```
+
+<!-- blecsd-doccheck:ignore -->
+```typescript
+import { createInputHandler, createFocusTracker } from 'blecsd';
+
+const inputHandler = createInputHandler(process.stdin);
+const tracker = createFocusTracker(inputHandler);
+```
+
+### enableFocusTracking
+
+Enables focus tracking on an input handler. Sends the CSI ? 1004 h sequence to enable terminal focus reporting and starts listening for focus events.
+
+```typescript
+function enableFocusTracking(state: FocusTrackerState): void
+```
+
+<!-- blecsd-doccheck:ignore -->
+```typescript
+import { enableFocusTracking } from 'blecsd';
+
+enableFocusTracking(tracker);
+```
+
+### disableFocusTracking
+
+Disables focus tracking on an input handler. Sends the CSI ? 1004 l sequence to disable terminal focus reporting and stops listening for focus events.
+
+```typescript
+function disableFocusTracking(state: FocusTrackerState): void
+```
+
+<!-- blecsd-doccheck:ignore -->
+```typescript
+import { disableFocusTracking } from 'blecsd';
+
+disableFocusTracking(tracker);
+```
+
+### getTerminalFocusEventBus
+
+Gets the focus event bus, creating if needed. Returns the same event bus instance on subsequent calls.
+
+```typescript
+function getTerminalFocusEventBus(): EventBus<FocusTrackingEventMap>
+```
+
+<!-- blecsd-doccheck:ignore -->
+```typescript
+import { getTerminalFocusEventBus } from 'blecsd';
+
+const bus = getTerminalFocusEventBus();
+
+bus.on('focus', () => {
+  console.log('Terminal window gained focus');
+});
+
+bus.on('blur', () => {
+  console.log('Terminal window lost focus');
+});
+```
+
+### getFocusTracker
+
+Gets the active focus tracker for an input handler.
+
+```typescript
+function getFocusTracker(inputHandler: InputHandler): FocusTrackerState | undefined
+```
+
+Returns the focus tracker state, or `undefined` if not set up.
+
+### isTerminalFocused
+
+Gets the current focus state for an input handler.
+
+```typescript
+function isTerminalFocused(inputHandler: InputHandler): boolean | undefined
+```
+
+<!-- blecsd-doccheck:ignore -->
+```typescript
+import { isTerminalFocused } from 'blecsd';
+
+const focused = isTerminalFocused(inputHandler);
+if (focused) {
+  console.log('Terminal is focused');
+}
+```
+
+Returns `true` if focused, `false` if blurred, `undefined` if no tracker exists.
+
+### triggerFocusEvent
+
+Manually triggers a focus event. Useful for testing or when focus state is obtained externally.
+
+```typescript
+function triggerFocusEvent(inputHandler: InputHandler, focused: boolean): void
+```
+
+<!-- blecsd-doccheck:ignore -->
+```typescript
+import { triggerFocusEvent } from 'blecsd';
+
+// Simulate focus gained
+triggerFocusEvent(inputHandler, true);
+
+// Simulate focus lost
+triggerFocusEvent(inputHandler, false);
+```
+
+### resetTerminalFocusEventBus
+
+Resets the focus event bus. Used for testing.
+
+```typescript
+function resetTerminalFocusEventBus(): void
+```
+
+## Terminal Support
+
+Focus reporting is supported by most modern terminals:
+
+| Terminal | Supported |
+|----------|-----------|
+| xterm | ✓ |
+| VTE-based (GNOME Terminal, etc.) | ✓ |
+| Konsole | ✓ |
+| iTerm2 | ✓ |
+| Alacritty | ✓ |
+| Kitty | ✓ |
+| WezTerm | ✓ |
+
+## Use Cases
+
+Focus tracking is useful for:
+
+- **Pausing animations** when the terminal loses focus
+- **Reducing CPU usage** when the terminal is in the background
+- **Auto-saving** when the user switches away from the terminal
+- **Resuming operations** when the terminal regains focus
+- **Visual indicators** showing focus state
+
+## Example: Pause Updates When Unfocused
+
+<!-- blecsd-doccheck:ignore -->
+```typescript
+import {
+  createInputHandler,
+  createFocusTracker,
+  enableFocusTracking,
+  getTerminalFocusEventBus,
+} from 'blecsd';
+
+const inputHandler = createInputHandler(process.stdin);
+const tracker = createFocusTracker(inputHandler);
+
+let isPaused = false;
+
+getTerminalFocusEventBus().on('blur', () => {
+  isPaused = true;
+  console.log('Pausing updates...');
+});
+
+getTerminalFocusEventBus().on('focus', () => {
+  isPaused = false;
+  console.log('Resuming updates...');
+});
+
+enableFocusTracking(tracker);
+
+// In your render loop
+function update() {
+  if (!isPaused) {
+    // Update UI
+  }
+  requestAnimationFrame(update);
+}
+```
+
+## See Also
+
+- [Input Stream](./input-stream.md) - Input handler and event processing
+- [Mouse Parser](./mouse-parser.md) - Mouse event parsing (includes FocusEvent type)
+- [ANSI](../ansi.md) - ANSI escape sequences (including focus reporting sequences)

--- a/src/terminal/focusTracking.test.ts
+++ b/src/terminal/focusTracking.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for Terminal Focus Tracking
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	createFocusTracker,
+	disableFocusTracking,
+	enableFocusTracking,
+	getFocusTracker,
+	getTerminalFocusEventBus,
+	isTerminalFocused,
+	resetTerminalFocusEventBus,
+	triggerFocusEvent,
+} from './focusTracking';
+import type { InputHandler } from './inputStream';
+import type { FocusEvent } from './mouseParser';
+
+// Mock InputHandler
+function createMockInputHandler(): InputHandler {
+	const listeners = new Set<(event: FocusEvent) => void>();
+
+	return {
+		start: vi.fn(),
+		stop: vi.fn(),
+		onKey: vi.fn(),
+		onMouse: vi.fn(),
+		onFocus: vi.fn((handler: (event: FocusEvent) => void) => {
+			listeners.add(handler);
+			return () => {
+				listeners.delete(handler);
+			};
+		}),
+		isRunning: vi.fn(() => true),
+		getBufferSize: vi.fn(() => 0),
+		// Helper to trigger focus events
+		_triggerFocus(focused: boolean): void {
+			const event: FocusEvent = {
+				focused,
+				raw: new Uint8Array(),
+			};
+			for (const listener of listeners) {
+				listener(event);
+			}
+		},
+	} as unknown as InputHandler & { _triggerFocus: (focused: boolean) => void };
+}
+
+describe('focusTracking', () => {
+	beforeEach(() => {
+		resetTerminalFocusEventBus();
+		vi.clearAllMocks();
+	});
+
+	describe('createFocusTracker', () => {
+		it('creates a focus tracker with initial state', () => {
+			const inputHandler = createMockInputHandler();
+			const tracker = createFocusTracker(inputHandler);
+
+			expect(tracker.inputHandler).toBe(inputHandler);
+			expect(tracker.enabled).toBe(false);
+			expect(tracker.focused).toBe(true);
+			expect(tracker.handler).toBeTypeOf('function');
+			expect(tracker.unsubscribe).toBeNull();
+		});
+
+		it('stores tracker in WeakMap', () => {
+			const inputHandler = createMockInputHandler();
+			const tracker = createFocusTracker(inputHandler);
+
+			expect(getFocusTracker(inputHandler)).toBe(tracker);
+		});
+	});
+
+	describe('enableFocusTracking', () => {
+		it('enables focus tracking and subscribes to events', () => {
+			const inputHandler = createMockInputHandler();
+			const tracker = createFocusTracker(inputHandler);
+
+			enableFocusTracking(tracker);
+
+			expect(tracker.enabled).toBe(true);
+			expect(tracker.unsubscribe).toBeTypeOf('function');
+			expect(inputHandler.onFocus).toHaveBeenCalledWith(tracker.handler);
+		});
+
+		it('does nothing if already enabled', () => {
+			const inputHandler = createMockInputHandler();
+			const tracker = createFocusTracker(inputHandler);
+
+			enableFocusTracking(tracker);
+			const unsubscribe = tracker.unsubscribe;
+
+			enableFocusTracking(tracker);
+
+			expect(tracker.unsubscribe).toBe(unsubscribe);
+		});
+	});
+
+	describe('disableFocusTracking', () => {
+		it('disables focus tracking and unsubscribes from events', () => {
+			const inputHandler = createMockInputHandler();
+			const tracker = createFocusTracker(inputHandler);
+
+			enableFocusTracking(tracker);
+			const unsubscribe = vi.fn(tracker.unsubscribe ?? (() => {}));
+			tracker.unsubscribe = unsubscribe;
+
+			disableFocusTracking(tracker);
+
+			expect(tracker.enabled).toBe(false);
+			expect(tracker.unsubscribe).toBeNull();
+			expect(unsubscribe).toHaveBeenCalled();
+		});
+
+		it('removes tracker from WeakMap', () => {
+			const inputHandler = createMockInputHandler();
+			const tracker = createFocusTracker(inputHandler);
+
+			enableFocusTracking(tracker);
+			disableFocusTracking(tracker);
+
+			expect(getFocusTracker(inputHandler)).toBeUndefined();
+		});
+
+		it('does nothing if already disabled', () => {
+			const inputHandler = createMockInputHandler();
+			const tracker = createFocusTracker(inputHandler);
+
+			disableFocusTracking(tracker);
+
+			expect(tracker.enabled).toBe(false);
+		});
+	});
+
+	describe('getTerminalFocusEventBus', () => {
+		it('returns the same event bus instance', () => {
+			const bus1 = getTerminalFocusEventBus();
+			const bus2 = getTerminalFocusEventBus();
+
+			expect(bus1).toBe(bus2);
+		});
+
+		it('creates new event bus after reset', () => {
+			const bus1 = getTerminalFocusEventBus();
+			resetTerminalFocusEventBus();
+			const bus2 = getTerminalFocusEventBus();
+
+			expect(bus1).not.toBe(bus2);
+		});
+	});
+
+	describe('focus event handling', () => {
+		it('emits focus event when terminal gains focus', () => {
+			const inputHandler = createMockInputHandler() as InputHandler & {
+				_triggerFocus: (focused: boolean) => void;
+			};
+			const tracker = createFocusTracker(inputHandler);
+			enableFocusTracking(tracker);
+
+			const bus = getTerminalFocusEventBus();
+			const focusHandler = vi.fn();
+			const blurHandler = vi.fn();
+
+			bus.on('focus', focusHandler);
+			bus.on('blur', blurHandler);
+
+			inputHandler._triggerFocus(true);
+
+			expect(focusHandler).not.toHaveBeenCalled(); // Already focused
+			expect(blurHandler).not.toHaveBeenCalled();
+		});
+
+		it('emits blur event when terminal loses focus', () => {
+			const inputHandler = createMockInputHandler() as InputHandler & {
+				_triggerFocus: (focused: boolean) => void;
+			};
+			const tracker = createFocusTracker(inputHandler);
+			enableFocusTracking(tracker);
+
+			const bus = getTerminalFocusEventBus();
+			const focusHandler = vi.fn();
+			const blurHandler = vi.fn();
+
+			bus.on('focus', focusHandler);
+			bus.on('blur', blurHandler);
+
+			inputHandler._triggerFocus(false);
+
+			expect(focusHandler).not.toHaveBeenCalled();
+			expect(blurHandler).toHaveBeenCalledTimes(1);
+		});
+
+		it('emits focus event after blur', () => {
+			const inputHandler = createMockInputHandler() as InputHandler & {
+				_triggerFocus: (focused: boolean) => void;
+			};
+			const tracker = createFocusTracker(inputHandler);
+			enableFocusTracking(tracker);
+
+			const bus = getTerminalFocusEventBus();
+			const focusHandler = vi.fn();
+			const blurHandler = vi.fn();
+
+			bus.on('focus', focusHandler);
+			bus.on('blur', blurHandler);
+
+			inputHandler._triggerFocus(false);
+			inputHandler._triggerFocus(true);
+
+			expect(blurHandler).toHaveBeenCalledTimes(1);
+			expect(focusHandler).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not emit events if state unchanged', () => {
+			const inputHandler = createMockInputHandler() as InputHandler & {
+				_triggerFocus: (focused: boolean) => void;
+			};
+			const tracker = createFocusTracker(inputHandler);
+			enableFocusTracking(tracker);
+
+			const bus = getTerminalFocusEventBus();
+			const focusHandler = vi.fn();
+			const blurHandler = vi.fn();
+
+			bus.on('focus', focusHandler);
+			bus.on('blur', blurHandler);
+
+			inputHandler._triggerFocus(true);
+			inputHandler._triggerFocus(true);
+
+			expect(focusHandler).not.toHaveBeenCalled();
+			expect(blurHandler).not.toHaveBeenCalled();
+		});
+
+		it('does not emit events if tracking is disabled', () => {
+			const inputHandler = createMockInputHandler() as InputHandler & {
+				_triggerFocus: (focused: boolean) => void;
+			};
+			// Create tracker but don't enable it
+			void createFocusTracker(inputHandler);
+
+			const bus = getTerminalFocusEventBus();
+			const focusHandler = vi.fn();
+			const blurHandler = vi.fn();
+
+			bus.on('focus', focusHandler);
+			bus.on('blur', blurHandler);
+
+			inputHandler._triggerFocus(false);
+
+			expect(focusHandler).not.toHaveBeenCalled();
+			expect(blurHandler).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('isTerminalFocused', () => {
+		it('returns current focus state', () => {
+			const inputHandler = createMockInputHandler() as InputHandler & {
+				_triggerFocus: (focused: boolean) => void;
+			};
+			const tracker = createFocusTracker(inputHandler);
+			enableFocusTracking(tracker);
+
+			expect(isTerminalFocused(inputHandler)).toBe(true);
+
+			inputHandler._triggerFocus(false);
+			expect(isTerminalFocused(inputHandler)).toBe(false);
+
+			inputHandler._triggerFocus(true);
+			expect(isTerminalFocused(inputHandler)).toBe(true);
+		});
+
+		it('returns undefined if no tracker', () => {
+			const inputHandler = createMockInputHandler();
+			expect(isTerminalFocused(inputHandler)).toBeUndefined();
+		});
+	});
+
+	describe('triggerFocusEvent', () => {
+		it('manually triggers focus change', () => {
+			const inputHandler = createMockInputHandler();
+			const tracker = createFocusTracker(inputHandler);
+			enableFocusTracking(tracker);
+
+			const bus = getTerminalFocusEventBus();
+			const blurHandler = vi.fn();
+			bus.on('blur', blurHandler);
+
+			triggerFocusEvent(inputHandler, false);
+
+			expect(blurHandler).toHaveBeenCalledTimes(1);
+			expect(tracker.focused).toBe(false);
+		});
+
+		it('does nothing if no tracker exists', () => {
+			const inputHandler = createMockInputHandler();
+
+			expect(() => {
+				triggerFocusEvent(inputHandler, false);
+			}).not.toThrow();
+		});
+	});
+});

--- a/src/terminal/focusTracking.ts
+++ b/src/terminal/focusTracking.ts
@@ -1,0 +1,298 @@
+/**
+ * Terminal Focus Tracking
+ *
+ * Provides focus/blur event handling that detects when the terminal window
+ * gains or loses focus using terminal focus reporting (CSI ? 1004 h/l).
+ *
+ * @module terminal/focusTracking
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   createInputHandler,
+ *   createFocusTracker,
+ *   enableFocusTracking,
+ *   disableFocusTracking,
+ *   getTerminalFocusEventBus,
+ * } from 'blecsd';
+ *
+ * const inputHandler = createInputHandler(process.stdin);
+ * const tracker = createFocusTracker(inputHandler);
+ *
+ * // Listen for focus events
+ * getTerminalFocusEventBus().on('focus', () => {
+ *   console.log('Terminal gained focus');
+ * });
+ *
+ * getTerminalFocusEventBus().on('blur', () => {
+ *   console.log('Terminal lost focus');
+ * });
+ *
+ * // Enable focus tracking
+ * enableFocusTracking(tracker);
+ *
+ * // When done
+ * disableFocusTracking(tracker);
+ * ```
+ */
+
+import { createEventBus, type EventBus } from '../core/events';
+import { mouse } from './ansi';
+import type { InputHandler } from './inputStream';
+import type { FocusEvent } from './mouseParser';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Focus tracking event map for type-safe event handling.
+ */
+export interface FocusTrackingEventMap {
+	/** Terminal window gained focus */
+	focus: undefined;
+	/** Terminal window lost focus */
+	blur: undefined;
+}
+
+/**
+ * Focus tracker state.
+ */
+export interface FocusTrackerState {
+	/** The input handler */
+	readonly inputHandler: InputHandler;
+	/** Whether tracking is currently enabled */
+	enabled: boolean;
+	/** Current focus state (true = focused, false = blurred) */
+	focused: boolean;
+	/** The focus handler function (for removal) */
+	readonly handler: (event: FocusEvent) => void;
+	/** Unsubscribe function from input handler */
+	unsubscribe: (() => void) | null;
+}
+
+// =============================================================================
+// MODULE STATE
+// =============================================================================
+
+/** Event bus for focus tracking events */
+let focusEventBus: EventBus<FocusTrackingEventMap> | null = null;
+
+/** Active focus trackers by input handler */
+const activeTrackers = new WeakMap<InputHandler, FocusTrackerState>();
+
+// =============================================================================
+// EVENT BUS
+// =============================================================================
+
+/**
+ * Gets the focus event bus, creating if needed.
+ *
+ * @returns The focus event bus
+ *
+ * @example
+ * ```typescript
+ * const bus = getTerminalFocusEventBus();
+ * bus.on('focus', () => {
+ *   console.log('Terminal window gained focus');
+ * });
+ * bus.on('blur', () => {
+ *   console.log('Terminal window lost focus');
+ * });
+ * ```
+ */
+export function getTerminalFocusEventBus(): EventBus<FocusTrackingEventMap> {
+	if (!focusEventBus) {
+		focusEventBus = createEventBus<FocusTrackingEventMap>();
+	}
+	return focusEventBus;
+}
+
+/**
+ * Resets the focus event bus. Used for testing.
+ * @internal
+ */
+export function resetTerminalFocusEventBus(): void {
+	focusEventBus = null;
+}
+
+// =============================================================================
+// FOCUS TRACKING
+// =============================================================================
+
+/**
+ * Creates a focus tracker for the given input handler.
+ *
+ * The tracker will:
+ * 1. Listen for focus events from the terminal
+ * 2. Track current focus state
+ * 3. Emit focus/blur events on the event bus
+ *
+ * @param inputHandler - The input handler
+ * @returns A focus tracker state object
+ *
+ * @example
+ * ```typescript
+ * import { createFocusTracker, enableFocusTracking } from 'blecsd';
+ *
+ * const tracker = createFocusTracker(inputHandler);
+ * enableFocusTracking(tracker);
+ * ```
+ */
+export function createFocusTracker(inputHandler: InputHandler): FocusTrackerState {
+	const handler = (event: FocusEvent): void => {
+		handleFocusEvent(event, state);
+	};
+
+	const state: FocusTrackerState = {
+		inputHandler,
+		enabled: false,
+		focused: true, // Assume focused initially
+		handler,
+		unsubscribe: null,
+	};
+
+	activeTrackers.set(inputHandler, state);
+	return state;
+}
+
+/**
+ * Internal focus event handling logic.
+ */
+function handleFocusEvent(event: FocusEvent, state: FocusTrackerState): void {
+	if (!state.enabled) {
+		return;
+	}
+
+	// Skip if focus state hasn't changed
+	if (event.focused === state.focused) {
+		return;
+	}
+
+	// Update state
+	state.focused = event.focused;
+
+	// Emit appropriate event
+	const bus = getTerminalFocusEventBus();
+	if (event.focused) {
+		bus.emit('focus', undefined);
+	} else {
+		bus.emit('blur', undefined);
+	}
+}
+
+/**
+ * Enables focus tracking on an input handler.
+ *
+ * Sends the CSI ? 1004 h sequence to enable terminal focus reporting
+ * and starts listening for focus events.
+ *
+ * @param state - The focus tracker state from createFocusTracker
+ *
+ * @example
+ * ```typescript
+ * const tracker = createFocusTracker(inputHandler);
+ * enableFocusTracking(tracker);
+ * ```
+ */
+export function enableFocusTracking(state: FocusTrackerState): void {
+	if (state.enabled) {
+		return;
+	}
+
+	// Enable terminal focus reporting
+	const seq = mouse.enableFocus();
+	process.stdout.write(seq);
+
+	// Start listening for focus events
+	state.unsubscribe = state.inputHandler.onFocus(state.handler);
+	state.enabled = true;
+}
+
+/**
+ * Disables focus tracking on an input handler.
+ *
+ * Sends the CSI ? 1004 l sequence to disable terminal focus reporting
+ * and stops listening for focus events.
+ *
+ * @param state - The focus tracker state from createFocusTracker
+ *
+ * @example
+ * ```typescript
+ * disableFocusTracking(tracker);
+ * ```
+ */
+export function disableFocusTracking(state: FocusTrackerState): void {
+	if (!state.enabled) {
+		return;
+	}
+
+	// Disable terminal focus reporting
+	const seq = mouse.disableFocus();
+	process.stdout.write(seq);
+
+	// Stop listening for focus events
+	if (state.unsubscribe) {
+		state.unsubscribe();
+		state.unsubscribe = null;
+	}
+
+	state.enabled = false;
+	activeTrackers.delete(state.inputHandler);
+}
+
+/**
+ * Gets the active focus tracker for an input handler.
+ *
+ * @param inputHandler - The input handler
+ * @returns The focus tracker state, or undefined if not set up
+ */
+export function getFocusTracker(inputHandler: InputHandler): FocusTrackerState | undefined {
+	return activeTrackers.get(inputHandler);
+}
+
+/**
+ * Gets the current focus state for an input handler.
+ *
+ * @param inputHandler - The input handler
+ * @returns true if focused, false if blurred, undefined if no tracker
+ *
+ * @example
+ * ```typescript
+ * const focused = isFocused(inputHandler);
+ * if (focused) {
+ *   console.log('Terminal is focused');
+ * }
+ * ```
+ */
+export function isTerminalFocused(inputHandler: InputHandler): boolean | undefined {
+	const tracker = activeTrackers.get(inputHandler);
+	return tracker?.focused;
+}
+
+/**
+ * Manually triggers a focus event.
+ * Useful for testing or when focus state is obtained externally.
+ *
+ * @param inputHandler - The input handler
+ * @param focused - Whether the terminal is focused
+ *
+ * @example
+ * ```typescript
+ * // Simulate focus gained
+ * triggerFocusEvent(inputHandler, true);
+ *
+ * // Simulate focus lost
+ * triggerFocusEvent(inputHandler, false);
+ * ```
+ */
+export function triggerFocusEvent(inputHandler: InputHandler, focused: boolean): void {
+	const state = activeTrackers.get(inputHandler);
+	if (state) {
+		const event: FocusEvent = {
+			focused,
+			raw: new Uint8Array(),
+		};
+		handleFocusEvent(event, state);
+	}
+}

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -229,6 +229,18 @@ export {
 	isWindowsTerminal,
 	isXterm,
 } from './detection';
+// Focus tracking
+export type { FocusTrackerState, FocusTrackingEventMap } from './focusTracking';
+export {
+	createFocusTracker,
+	disableFocusTracking,
+	enableFocusTracking,
+	getFocusTracker,
+	getTerminalFocusEventBus,
+	isTerminalFocused,
+	resetTerminalFocusEventBus,
+	triggerFocusEvent,
+} from './focusTracking';
 // GPM mouse client (Linux console mouse support)
 export type { GpmClient, GpmClientConfig, GpmClientState, GpmRawEvent } from './gpmClient';
 export {


### PR DESCRIPTION
## Summary
Closes already-implemented issues and adds terminal focus tracking.

## Issues Closed
- Closes #942 (screenshot) - already implemented in src/terminal/screen/screenshot.ts
- Closes #944 (clipboard) - already implemented in src/terminal/clipboardManager.ts
- Closes #945 (focus/blur) - **new implementation** in src/terminal/focusTracking.ts
- Closes #956 (cursor) - already implemented in src/terminal/cursor/artificial.ts
- Closes #967 (lockKeys/grabKeys) - already implemented in src/core/keyLock.ts
- Closes #975 (insertLine/deleteLine) - already implemented in src/terminal/screen/csr.ts and regions.ts

## New Implementation
Added terminal focus tracking with CSI ? 1004 h/l sequences:
- createFocusTracker(), enable/disableFocusTracking()
- getTerminalFocusEventBus() for focus/blur event listeners
- Integrated with existing InputHandler for focus events
- Comprehensive test coverage (18 tests)

## Testing
- All tests pass (10626 tests)
- Typecheck passes
- Build passes
- Only pre-existing lint warnings

## Remaining Issues for This Worker
Still working on:
- #1024: resizeTimeout option to debounce terminal resize events
- #1028: tabSize option for tab character width
- #1032: Screen warning events and logging