### PR TITLE
fix: remove direct bitecs require() in widget registry

### DIFF
--- a/src/widgets/registry.ts
+++ b/src/widgets/registry.ts
@@ -24,6 +24,7 @@
  * ```
  */
 
+import { addEntity } from '../core/ecs';
 import type { Entity, World } from '../core/types';
 
 // =============================================================================
@@ -223,7 +224,6 @@ export function createWidgetRegistry(): WidgetRegistry {
 		},
 
 		create<TWidget = unknown>(world: World, name: string, config?: unknown): TWidget {
-			const { addEntity } = require('bitecs');
 			const entity = addEntity(world);
 			return registry.createWithEntity<TWidget>(world, entity, name, config);
 		},


### PR DESCRIPTION
Closes #881

## Summary

Remove direct `require('bitecs')` call in `src/widgets/registry.ts` and replace with proper import from `../core/ecs` module.

## Changes

- Add `import { addEntity } from '../core/ecs'` at the top of the file
- Remove `const { addEntity } = require('bitecs')` inline require call

## Validation

- ✅ All tests pass (10,742 tests)
- ✅ Linting passes
- ✅ Type checking passes
- ✅ Build succeeds

This aligns with CLAUDE.md requirement that only `src/core/ecs.ts`, `src/core/world.ts`, and `src/core/types.ts` may import directly from 'bitecs'.