### PR TITLE
refactor: eliminate `this` keyword from src/core and src/components

### DIFF
--- a/src/core/eventBubbling.ts
+++ b/src/core/eventBubbling.ts
@@ -110,16 +110,16 @@ export function createBubbleableEvent<T>(options: BubbleableEventOptions<T>): Bu
 		payload,
 
 		stopPropagation() {
-			this.propagationStopped = true;
+			event.propagationStopped = true;
 		},
 
 		stopImmediatePropagation() {
-			this.propagationStopped = true;
-			this.immediatePropagationStopped = true;
+			event.propagationStopped = true;
+			event.immediatePropagationStopped = true;
 		},
 
 		preventDefault() {
-			this.defaultPrevented = true;
+			event.defaultPrevented = true;
 		},
 	};
 

--- a/src/core/inputState.ts
+++ b/src/core/inputState.ts
@@ -406,6 +406,30 @@ export function createInputState(config: InputStateConfig = {}): InputState {
 		updateMouseButtonState(button, event.action, timestamp);
 	}
 
+	// Define methods that will be used in the returned object
+	const releaseAllKeys = (): void => {
+		const currentTime = performance.now();
+		for (const [key, state] of keyStates) {
+			if (state.pressed) {
+				processKeyRelease(key, currentTime);
+			}
+		}
+		ctrlDown = false;
+		altDown = false;
+		shiftDown = false;
+	};
+
+	const releaseAllMouseButtons = (): void => {
+		const currentTime = performance.now();
+		for (const button of Object.values(mouseState.buttons)) {
+			if (button.pressed) {
+				button.pressed = false;
+				button.justReleased = true;
+				button.lastEventTime = currentTime;
+			}
+		}
+	};
+
 	return {
 		update(
 			keyEvents: readonly TimestampedKeyEvent[],
@@ -561,32 +585,13 @@ export function createInputState(config: InputStateConfig = {}): InputState {
 			processKeyRelease(key.toLowerCase(), performance.now());
 		},
 
-		releaseAllKeys(): void {
-			const currentTime = performance.now();
-			for (const [key, state] of keyStates) {
-				if (state.pressed) {
-					processKeyRelease(key, currentTime);
-				}
-			}
-			ctrlDown = false;
-			altDown = false;
-			shiftDown = false;
-		},
+		releaseAllKeys,
 
-		releaseAllMouseButtons(): void {
-			const currentTime = performance.now();
-			for (const button of Object.values(mouseState.buttons)) {
-				if (button.pressed) {
-					button.pressed = false;
-					button.justReleased = true;
-					button.lastEventTime = currentTime;
-				}
-			}
-		},
+		releaseAllMouseButtons,
 
 		releaseAll(): void {
-			this.releaseAllKeys();
-			this.releaseAllMouseButtons();
+			releaseAllKeys();
+			releaseAllMouseButtons();
 		},
 
 		getStats(): InputStateStats {

--- a/src/core/lazyInit.ts
+++ b/src/core/lazyInit.ts
@@ -362,7 +362,7 @@ export interface TerminalCapabilities {
  */
 export function detectCapabilities(maxAge = 60000): TerminalCapabilities {
 	// Try to use cached value
-	const cached = capabilityCache.get();
+	const cached = capabilityCache.value;
 	if (cached && Date.now() - cached.cachedAt < maxAge) {
 		return cached;
 	}
@@ -392,27 +392,22 @@ export function detectCapabilities(maxAge = 60000): TerminalCapabilities {
 		cachedAt: Date.now(),
 	};
 
-	capabilityCache.set(caps);
+	capabilityCache.value = caps;
 	return caps;
 }
 
 /** Simple capability cache */
-const capabilityCache = {
-	_value: null as TerminalCapabilities | null,
-	get(): TerminalCapabilities | null {
-		return this._value;
-	},
-	set(value: TerminalCapabilities): void {
-		this._value = value;
-	},
-	clear(): void {
-		this._value = null;
-	},
+interface CapabilityCache {
+	value: TerminalCapabilities | null;
+}
+
+const capabilityCache: CapabilityCache = {
+	value: null,
 };
 
 /**
  * Clears the terminal capability cache.
  */
 export function clearCapabilityCache(): void {
-	capabilityCache.clear();
+	capabilityCache.value = null;
 }


### PR DESCRIPTION
Closes #1092

## Summary

Eliminate all `this` keyword usage in `src/core/` and `src/components/` directories by converting object methods to functional patterns.

## Changes

### src/core/lazyInit.ts
- Convert `capabilityCache` from object with methods to plain data structure
- Replace `capabilityCache.get()` with direct property access `capabilityCache.value`
- Replace `capabilityCache.set(value)` with direct assignment `capabilityCache.value = value`
- Replace `capabilityCache.clear()` with direct assignment `capabilityCache.value = null`

### src/core/eventBubbling.ts
- Replace `this.propagationStopped` with closure reference `event.propagationStopped`
- Replace `this.immediatePropagationStopped` with closure reference `event.immediatePropagationStopped`
- Replace `this.defaultPrevented` with closure reference `event.defaultPrevented`

### src/core/inputState.ts
- Extract `releaseAllKeys` and `releaseAllMouseButtons` as named arrow functions before the return statement
- Replace `this.releaseAllKeys()` with direct function call `releaseAllKeys()`
- Replace `this.releaseAllMouseButtons()` with direct function call `releaseAllMouseButtons()`

## Validation

- ✅ All tests pass (10,742 tests)
- ✅ Linting passes (only pre-existing warnings)
- ✅ Type checking passes
- ✅ Build succeeds

## Notes

- No breaking changes to public API
- All functionality remains identical
- Part of the CLAUDE.md requirement to eliminate OOP patterns in favor of functional programming