### PR TITLE
test: add test helper utilities module

### DIFF
--- a/src/testing/helpers.test.ts
+++ b/src/testing/helpers.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for test helper utilities.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Border } from '../components/border';
+import { Content } from '../components/content';
+import { Dimensions } from '../components/dimensions';
+import { Focusable } from '../components/focusable';
+import { Hierarchy } from '../components/hierarchy';
+import { Interactive } from '../components/interactive';
+import { Padding } from '../components/padding';
+import { Position } from '../components/position';
+import { Renderable } from '../components/renderable';
+import { hasScreen } from '../components/screen';
+import { Scrollable } from '../components/scrollable';
+import { hasComponent } from '../core/ecs';
+import type { World } from '../core/types';
+import { getZIndex } from '../core/zOrder';
+import {
+	createClickableEntity,
+	createHoverableEntity,
+	createRenderableEntity,
+	createTestEntity,
+	createTestScreen,
+	createTestWorld,
+} from './helpers';
+
+describe('Test Helpers', () => {
+	let world: World;
+
+	beforeEach(() => {
+		world = createTestWorld();
+	});
+
+	describe('createTestWorld', () => {
+		it('creates a valid ECS world', () => {
+			const testWorld = createTestWorld();
+			expect(testWorld).toBeDefined();
+			expect(typeof testWorld).toBe('object');
+		});
+
+		it('creates independent worlds', () => {
+			const world1 = createTestWorld();
+			const world2 = createTestWorld();
+			expect(world1).not.toBe(world2);
+		});
+	});
+
+	describe('createTestEntity', () => {
+		it('creates entity with no config', () => {
+			const eid = createTestEntity(world);
+			expect(eid).toBeGreaterThanOrEqual(0);
+		});
+
+		it('creates entity with position', () => {
+			const eid = createTestEntity(world, { x: 10, y: 5, z: 2 });
+
+			expect(hasComponent(world, eid, Position)).toBe(true);
+			expect(Position.x[eid]).toBe(10);
+			expect(Position.y[eid]).toBe(5);
+			expect(getZIndex(world, eid)).toBe(2);
+		});
+
+		it('creates entity with dimensions', () => {
+			const eid = createTestEntity(world, { width: 20, height: 15 });
+
+			expect(hasComponent(world, eid, Dimensions)).toBe(true);
+			expect(Dimensions.width[eid]).toBe(20);
+			expect(Dimensions.height[eid]).toBe(15);
+		});
+
+		it('creates entity with style', () => {
+			const eid = createTestEntity(world, {
+				style: { fg: 0xff0000, bg: 0x00ff00, bold: true },
+			});
+
+			expect(hasComponent(world, eid, Renderable)).toBe(true);
+			expect(Renderable.fg[eid]).toBe(0xff0000);
+			expect(Renderable.bg[eid]).toBe(0x00ff00);
+			expect(Renderable.bold[eid]).toBe(1);
+		});
+
+		it('creates entity with visibility flags', () => {
+			const visible = createTestEntity(world, { visible: true, style: {} });
+			const hidden = createTestEntity(world, { visible: false, style: {} });
+
+			expect(Renderable.visible[visible]).toBe(1);
+			expect(Renderable.visible[hidden]).toBe(0);
+		});
+
+		it('creates entity with dirty flag', () => {
+			const dirty = createTestEntity(world, { dirty: true, style: {} });
+			const clean = createTestEntity(world, { dirty: false, style: {} });
+
+			expect(Renderable.dirty[dirty]).toBe(1);
+			expect(Renderable.dirty[clean]).toBe(0);
+		});
+
+		it('creates entity with content', () => {
+			const eid = createTestEntity(world, { content: 'Hello, World!' });
+
+			expect(hasComponent(world, eid, Content)).toBe(true);
+		});
+
+		it('creates clickable entity', () => {
+			const eid = createTestEntity(world, { clickable: true });
+
+			expect(hasComponent(world, eid, Interactive)).toBe(true);
+			expect(Interactive.clickable[eid]).toBe(1);
+		});
+
+		it('creates hoverable entity', () => {
+			const eid = createTestEntity(world, { hoverable: true });
+
+			expect(hasComponent(world, eid, Interactive)).toBe(true);
+			expect(Interactive.hoverable[eid]).toBe(1);
+		});
+
+		it('creates focusable entity', () => {
+			const eid = createTestEntity(world, { focusable: true });
+
+			expect(hasComponent(world, eid, Focusable)).toBe(true);
+			expect(Focusable.focusable[eid]).toBe(1);
+		});
+
+		it('creates scrollable entity', () => {
+			const eid = createTestEntity(world, { scrollable: true });
+
+			expect(hasComponent(world, eid, Scrollable)).toBe(true);
+		});
+
+		it('creates entity with border', () => {
+			const eid = createTestEntity(world, { border: true });
+
+			expect(hasComponent(world, eid, Border)).toBe(true);
+		});
+
+		it('creates entity with padding', () => {
+			const eid = createTestEntity(world, { padding: true });
+
+			expect(hasComponent(world, eid, Padding)).toBe(true);
+		});
+
+		it('creates entity with hierarchy', () => {
+			const eid = createTestEntity(world, { hierarchy: true });
+
+			expect(hasComponent(world, eid, Hierarchy)).toBe(true);
+		});
+
+		it('creates complex entity with multiple components', () => {
+			const eid = createTestEntity(world, {
+				x: 10,
+				y: 5,
+				z: 3,
+				width: 30,
+				height: 20,
+				content: 'Button',
+				style: { fg: 0xffffff, bg: 0x0000ff },
+				clickable: true,
+				focusable: true,
+				border: true,
+				padding: true,
+			});
+
+			expect(hasComponent(world, eid, Position)).toBe(true);
+			expect(hasComponent(world, eid, Dimensions)).toBe(true);
+			expect(hasComponent(world, eid, Content)).toBe(true);
+			expect(hasComponent(world, eid, Renderable)).toBe(true);
+			expect(hasComponent(world, eid, Interactive)).toBe(true);
+			expect(hasComponent(world, eid, Focusable)).toBe(true);
+			expect(hasComponent(world, eid, Border)).toBe(true);
+			expect(hasComponent(world, eid, Padding)).toBe(true);
+		});
+	});
+
+	describe('createRenderableEntity', () => {
+		it('creates renderable with default values', () => {
+			const eid = createRenderableEntity(world);
+
+			expect(hasComponent(world, eid, Position)).toBe(true);
+			expect(hasComponent(world, eid, Dimensions)).toBe(true);
+			expect(hasComponent(world, eid, Renderable)).toBe(true);
+			expect(Position.x[eid]).toBe(0);
+			expect(Position.y[eid]).toBe(0);
+			expect(Dimensions.width[eid]).toBe(10);
+			expect(Dimensions.height[eid]).toBe(10);
+			expect(Renderable.visible[eid]).toBe(1);
+			expect(Renderable.dirty[eid]).toBe(1);
+		});
+
+		it('creates renderable with custom position and size', () => {
+			const eid = createRenderableEntity(world, 15, 25, 30, 40);
+
+			expect(Position.x[eid]).toBe(15);
+			expect(Position.y[eid]).toBe(25);
+			expect(Dimensions.width[eid]).toBe(30);
+			expect(Dimensions.height[eid]).toBe(40);
+		});
+
+		it('creates visible and dirty entity', () => {
+			const eid = createRenderableEntity(world);
+
+			expect(Renderable.visible[eid]).toBe(1);
+			expect(Renderable.dirty[eid]).toBe(1);
+		});
+	});
+
+	describe('createClickableEntity', () => {
+		it('creates clickable entity with default z-index', () => {
+			const eid = createClickableEntity(world, 10, 20, 30, 40);
+
+			expect(hasComponent(world, eid, Position)).toBe(true);
+			expect(hasComponent(world, eid, Dimensions)).toBe(true);
+			expect(hasComponent(world, eid, Interactive)).toBe(true);
+			expect(Position.x[eid]).toBe(10);
+			expect(Position.y[eid]).toBe(20);
+			expect(Dimensions.width[eid]).toBe(30);
+			expect(Dimensions.height[eid]).toBe(40);
+			expect(Interactive.clickable[eid]).toBe(1);
+			expect(getZIndex(world, eid)).toBe(0);
+		});
+
+		it('creates clickable entity with custom z-index', () => {
+			const eid = createClickableEntity(world, 0, 0, 10, 10, 50);
+
+			expect(getZIndex(world, eid)).toBe(50);
+		});
+	});
+
+	describe('createHoverableEntity', () => {
+		it('creates hoverable entity with default z-index', () => {
+			const eid = createHoverableEntity(world, 5, 10, 15, 20);
+
+			expect(hasComponent(world, eid, Position)).toBe(true);
+			expect(hasComponent(world, eid, Dimensions)).toBe(true);
+			expect(hasComponent(world, eid, Interactive)).toBe(true);
+			expect(Position.x[eid]).toBe(5);
+			expect(Position.y[eid]).toBe(10);
+			expect(Dimensions.width[eid]).toBe(15);
+			expect(Dimensions.height[eid]).toBe(20);
+			expect(Interactive.hoverable[eid]).toBe(1);
+			expect(getZIndex(world, eid)).toBe(0);
+		});
+
+		it('creates hoverable entity with custom z-index', () => {
+			const eid = createHoverableEntity(world, 0, 0, 10, 10, 25);
+
+			expect(getZIndex(world, eid)).toBe(25);
+		});
+	});
+
+	describe('createTestScreen', () => {
+		it('creates screen with default dimensions', () => {
+			const screen = createTestScreen(world);
+
+			expect(hasScreen(world, screen)).toBe(true);
+		});
+
+		it('creates screen with custom dimensions', () => {
+			const screen = createTestScreen(world, { width: 120, height: 40 });
+
+			expect(hasScreen(world, screen)).toBe(true);
+		});
+
+		it('throws when creating second screen', () => {
+			createTestScreen(world);
+
+			expect(() => createTestScreen(world)).toThrow('A screen already exists');
+		});
+	});
+
+	describe('helper integration', () => {
+		it('can be used together in complex test scenarios', () => {
+			const screen = createTestScreen(world, { width: 100, height: 50 });
+
+			const background = createRenderableEntity(world, 0, 0, 100, 50);
+
+			const button1 = createClickableEntity(world, 10, 10, 20, 5, 1);
+			const button2 = createClickableEntity(world, 40, 10, 20, 5, 1);
+
+			const dialog = createTestEntity(world, {
+				x: 20,
+				y: 15,
+				width: 60,
+				height: 30,
+				z: 10,
+				border: true,
+				padding: true,
+				style: { bg: 0x222222 },
+			});
+
+			expect(hasScreen(world, screen)).toBe(true);
+			expect(hasComponent(world, background, Renderable)).toBe(true);
+			expect(Interactive.clickable[button1]).toBe(1);
+			expect(Interactive.clickable[button2]).toBe(1);
+			expect(hasComponent(world, dialog, Border)).toBe(true);
+			expect(getZIndex(world, dialog)).toBe(10);
+		});
+	});
+});

--- a/src/testing/helpers.ts
+++ b/src/testing/helpers.ts
@@ -1,0 +1,333 @@
+/**
+ * Test helper utilities for creating and managing ECS test worlds and entities.
+ * @module testing/helpers
+ */
+
+import { Border } from '../components/border';
+import { setContent } from '../components/content';
+import { setDimensions } from '../components/dimensions';
+import { setFocusable } from '../components/focusable';
+import { Hierarchy } from '../components/hierarchy';
+import { setInteractive } from '../components/interactive';
+import { Padding } from '../components/padding';
+import { setPosition } from '../components/position';
+import type { StyleOptions } from '../components/renderable';
+import { Renderable, setStyle } from '../components/renderable';
+import { setScrollable } from '../components/scrollable';
+import { addComponent, addEntity, createWorld } from '../core/ecs';
+import { createScreenEntity } from '../core/entities';
+import type { Entity, World } from '../core/types';
+import { setZIndex } from '../core/zOrder';
+
+// =============================================================================
+// WORLD CREATION
+// =============================================================================
+
+/**
+ * Creates a pre-configured world for tests.
+ * This is a simple wrapper around createWorld() but provides a consistent
+ * pattern and allows for future test-specific world configuration.
+ *
+ * @returns A new ECS world ready for testing
+ *
+ * @example
+ * ```typescript
+ * import { createTestWorld } from 'blecsd/testing';
+ *
+ * const world = createTestWorld();
+ * // Use world in tests...
+ * ```
+ */
+export function createTestWorld(): World {
+	return createWorld();
+}
+
+// =============================================================================
+// ENTITY CREATION
+// =============================================================================
+
+/**
+ * Configuration for creating a test entity with common components.
+ */
+export interface TestEntityConfig {
+	/** Position x coordinate */
+	readonly x?: number;
+	/** Position y coordinate */
+	readonly y?: number;
+	/**
+	 * Z-index for layering (sets ZOrder.zIndex, not Position.z).
+	 * Higher values render on top. Use setPosition directly if you need Position.z.
+	 */
+	readonly z?: number;
+	/** Width of the entity */
+	readonly width?: number;
+	/** Height of the entity */
+	readonly height?: number;
+	/** Style options (colors, text attributes) */
+	readonly style?: StyleOptions;
+	/** Whether entity should be visible */
+	readonly visible?: boolean;
+	/** Whether entity should be marked dirty */
+	readonly dirty?: boolean;
+	/** Text content */
+	readonly content?: string;
+	/** Whether entity is clickable */
+	readonly clickable?: boolean;
+	/** Whether entity is hoverable */
+	readonly hoverable?: boolean;
+	/** Whether entity is focusable */
+	readonly focusable?: boolean;
+	/** Whether entity is scrollable */
+	readonly scrollable?: boolean;
+	/** Whether to add border component */
+	readonly border?: boolean;
+	/** Whether to add padding component */
+	readonly padding?: boolean;
+	/** Whether to add hierarchy component */
+	readonly hierarchy?: boolean;
+}
+
+/**
+ * Creates a test entity with specified components.
+ * This helper automatically adds common components based on the configuration,
+ * making it easy to set up test entities without boilerplate.
+ *
+ * @param world - The ECS world to create the entity in
+ * @param config - Configuration for the entity's components
+ * @returns The newly created entity ID
+ *
+ * @example
+ * ```typescript
+ * import { createTestWorld, createTestEntity } from 'blecsd/testing';
+ *
+ * const world = createTestWorld();
+ *
+ * // Create a simple positioned entity
+ * const box = createTestEntity(world, { x: 10, y: 5, width: 20, height: 10 });
+ *
+ * // Create a clickable entity with content
+ * const button = createTestEntity(world, {
+ *   x: 0, y: 0, width: 10, height: 3,
+ *   content: 'Click me',
+ *   clickable: true,
+ *   style: { fg: 0xffffff, bg: 0x0000ff }
+ * });
+ * ```
+ */
+export function createTestEntity(world: World, config: TestEntityConfig = {}): Entity {
+	const eid = addEntity(world);
+
+	// Position (almost always needed)
+	if (config.x !== undefined || config.y !== undefined) {
+		setPosition(world, eid, config.x ?? 0, config.y ?? 0);
+	}
+
+	// Z-index for layering (separate from Position.z)
+	if (config.z !== undefined) {
+		setZIndex(world, eid, config.z);
+	}
+
+	// Dimensions (needed for rendering and hit testing)
+	if (config.width !== undefined || config.height !== undefined) {
+		setDimensions(world, eid, config.width ?? 0, config.height ?? 0);
+	}
+
+	// Renderable (for visible entities)
+	if (config.style !== undefined || config.visible !== undefined) {
+		addComponent(world, eid, Renderable);
+		if (config.style !== undefined) {
+			setStyle(world, eid, config.style);
+		}
+		if (config.visible !== undefined) {
+			Renderable.visible[eid] = config.visible ? 1 : 0;
+		}
+		if (config.dirty !== undefined) {
+			Renderable.dirty[eid] = config.dirty ? 1 : 0;
+		}
+	}
+
+	// Content (for text)
+	if (config.content !== undefined) {
+		setContent(world, eid, config.content);
+	}
+
+	// Interactive (for clickable/hoverable)
+	if (config.clickable !== undefined || config.hoverable !== undefined) {
+		setInteractive(world, eid, {
+			clickable: config.clickable ?? false,
+			hoverable: config.hoverable ?? false,
+		});
+	}
+
+	// Focusable
+	if (config.focusable !== undefined) {
+		setFocusable(world, eid, { focusable: config.focusable });
+	}
+
+	// Scrollable
+	if (config.scrollable !== undefined) {
+		setScrollable(world, eid, {});
+	}
+
+	// Border
+	if (config.border !== undefined && config.border) {
+		addComponent(world, eid, Border);
+	}
+
+	// Padding
+	if (config.padding !== undefined && config.padding) {
+		addComponent(world, eid, Padding);
+	}
+
+	// Hierarchy
+	if (config.hierarchy !== undefined && config.hierarchy) {
+		addComponent(world, eid, Hierarchy);
+	}
+
+	return eid;
+}
+
+/**
+ * Creates a renderable entity with Position, Dimensions, and Renderable components.
+ * This is a common pattern in tests for entities that need to be rendered.
+ *
+ * @param world - The ECS world to create the entity in
+ * @param x - X coordinate (default: 0)
+ * @param y - Y coordinate (default: 0)
+ * @param width - Width (default: 10)
+ * @param height - Height (default: 10)
+ * @returns The newly created entity ID
+ *
+ * @example
+ * ```typescript
+ * import { createTestWorld, createRenderableEntity } from 'blecsd/testing';
+ *
+ * const world = createTestWorld();
+ * const box = createRenderableEntity(world, 5, 5, 20, 15);
+ * ```
+ */
+export function createRenderableEntity(
+	world: World,
+	x: number = 0,
+	y: number = 0,
+	width: number = 10,
+	height: number = 10,
+): Entity {
+	const eid = addEntity(world);
+	setPosition(world, eid, x, y);
+	setDimensions(world, eid, width, height);
+	addComponent(world, eid, Renderable);
+	Renderable.visible[eid] = 1;
+	Renderable.dirty[eid] = 1;
+	return eid;
+}
+
+/**
+ * Creates a clickable entity with Interactive component.
+ *
+ * @param world - The ECS world to create the entity in
+ * @param x - X coordinate
+ * @param y - Y coordinate
+ * @param width - Width
+ * @param height - Height
+ * @param zIndex - Z-index for layering (default: 0)
+ * @returns The newly created entity ID
+ *
+ * @example
+ * ```typescript
+ * import { createTestWorld, createClickableEntity } from 'blecsd/testing';
+ *
+ * const world = createTestWorld();
+ * const button = createClickableEntity(world, 0, 0, 10, 3, 5);
+ * ```
+ */
+export function createClickableEntity(
+	world: World,
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+	zIndex: number = 0,
+): Entity {
+	const eid = addEntity(world);
+	setPosition(world, eid, x, y);
+	setDimensions(world, eid, width, height);
+	setInteractive(world, eid, { clickable: true });
+	setZIndex(world, eid, zIndex);
+	return eid;
+}
+
+/**
+ * Creates a hoverable entity with Interactive component.
+ *
+ * @param world - The ECS world to create the entity in
+ * @param x - X coordinate
+ * @param y - Y coordinate
+ * @param width - Width
+ * @param height - Height
+ * @param zIndex - Z-index for layering (default: 0)
+ * @returns The newly created entity ID
+ *
+ * @example
+ * ```typescript
+ * import { createTestWorld, createHoverableEntity } from 'blecsd/testing';
+ *
+ * const world = createTestWorld();
+ * const tooltip = createHoverableEntity(world, 10, 10, 20, 5);
+ * ```
+ */
+export function createHoverableEntity(
+	world: World,
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+	zIndex: number = 0,
+): Entity {
+	const eid = addEntity(world);
+	setPosition(world, eid, x, y);
+	setDimensions(world, eid, width, height);
+	setInteractive(world, eid, { hoverable: true });
+	setZIndex(world, eid, zIndex);
+	return eid;
+}
+
+// =============================================================================
+// SCREEN CREATION
+// =============================================================================
+
+/**
+ * Configuration for creating a test screen.
+ */
+export interface TestScreenConfig {
+	/** Screen width in columns (default: 80) */
+	readonly width?: number;
+	/** Screen height in rows (default: 24) */
+	readonly height?: number;
+}
+
+/**
+ * Creates a test screen entity with default terminal dimensions.
+ * This is useful for tests that need screen rendering context.
+ *
+ * @param world - The ECS world to create the screen in
+ * @param config - Screen configuration (default: 80x24)
+ * @returns The screen entity ID
+ *
+ * @example
+ * ```typescript
+ * import { createTestWorld, createTestScreen } from 'blecsd/testing';
+ *
+ * const world = createTestWorld();
+ * const screen = createTestScreen(world);
+ *
+ * // Custom size
+ * const largeScreen = createTestScreen(world, { width: 120, height: 40 });
+ * ```
+ */
+export function createTestScreen(world: World, config: TestScreenConfig = {}): Entity {
+	return createScreenEntity(world, {
+		width: config.width ?? 80,
+		height: config.height ?? 24,
+	});
+}

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,16 +1,25 @@
 /**
  * Testing utilities for blECSd.
  *
- * Provides snapshot testing helpers, render utilities, and test buffer
- * setup for visual regression testing of terminal UI components.
+ * Provides test helpers for creating worlds and entities, snapshot testing
+ * helpers, render utilities, and test buffer setup for visual regression
+ * testing of terminal UI components.
  *
  * @module testing
  */
 
+export type { TestEntityConfig, TestScreenConfig } from './helpers';
+export {
+	createClickableEntity,
+	createHoverableEntity,
+	createRenderableEntity,
+	createTestEntity,
+	createTestScreen,
+	createTestWorld,
+} from './helpers';
 export type { IntegrationTestContext } from './integration';
 export {
 	createInteractiveEntity,
-	createTestScreen,
 	simulateClick,
 	simulateKey,
 	simulateMouse,


### PR DESCRIPTION
Closes #987

## Summary
- Created `src/testing/helpers.ts` with reusable test utilities for creating worlds, entities, and screens
- Added comprehensive test coverage in `src/testing/helpers.test.ts`
- Updated `src/testing/index.ts` to export new helpers

## Test Helpers Added
- `createTestWorld()` - creates pre-configured world for tests
- `createTestEntity(config)` - creates entity with specified components based on config
- `createRenderableEntity()` - creates renderable entity with Position, Dimensions, Renderable  
- `createClickableEntity()` - creates clickable entity with Interactive component
- `createHoverableEntity()` - creates hoverable entity with Interactive component
- `createTestScreen(width, height)` - creates test screen entity with default or custom dimensions

## Test Coverage
- All helpers have comprehensive unit tests
- Integration test demonstrates helpers working together in complex scenarios
- 28 test cases total, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)