### PR TITLE
feat: add screen warning events and logging

### DIFF
--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -51,6 +51,12 @@ export interface ScreenEventMap {
 	resize: { width: number; height: number };
 	render: { frameTime: number };
 	destroy: Record<string, never>;
+	warning: {
+		type: string;
+		message: string;
+		metadata: Record<string, unknown>;
+		timestamp: number;
+	};
 }
 
 /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -651,6 +651,31 @@ export {
 } from './styleInheritance';
 export type { Entity, System, Unsubscribe, World } from './types';
 export { LoopPhase } from './types';
+// Warning system
+export type {
+	DeprecatedAPIMetadata,
+	PerformanceIssueMetadata,
+	TerminalTooSmallMetadata,
+	UnsupportedCapabilityMetadata,
+	WarningEmitter,
+	WarningEvent,
+	WarningEventMap,
+	WarningMetadata,
+	WarningTypeValue,
+} from './warnings';
+export {
+	createWarningEmitter,
+	DeprecatedAPIMetadataSchema,
+	emitDeprecatedAPIWarning,
+	emitPerformanceWarning,
+	emitTerminalTooSmallWarning,
+	emitUnsupportedCapabilityWarning,
+	PerformanceIssueMetadataSchema,
+	TerminalTooSmallMetadataSchema,
+	UnsupportedCapabilityMetadataSchema,
+	WarningEventSchema,
+	WarningType,
+} from './warnings';
 export { createWorld, resetWorld } from './world';
 export type {
 	PackedQueryAdapter,

--- a/src/core/warnings.test.ts
+++ b/src/core/warnings.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for warning system.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+	createWarningEmitter,
+	emitDeprecatedAPIWarning,
+	emitPerformanceWarning,
+	emitTerminalTooSmallWarning,
+	emitUnsupportedCapabilityWarning,
+	type WarningEvent,
+	WarningType,
+} from './warnings';
+
+describe('Warning System', () => {
+	describe('createWarningEmitter', () => {
+		it('should create a warning emitter', () => {
+			const emitter = createWarningEmitter();
+
+			expect(emitter).toBeDefined();
+			expect(emitter.on).toBeInstanceOf(Function);
+			expect(emitter.emit).toBeInstanceOf(Function);
+		});
+
+		it('should allow subscribing to warnings', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+
+			emitter.on('warning', handler);
+			emitter.emit('warning', {
+				type: WarningType.TERMINAL_TOO_SMALL,
+				message: 'Test',
+				metadata: { width: 10, height: 10, minWidth: 80, minHeight: 24 },
+				timestamp: Date.now(),
+			});
+
+			expect(handler).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return unsubscribe function', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+
+			const unsubscribe = emitter.on('warning', handler);
+
+			unsubscribe();
+			emitter.emit('warning', {
+				type: WarningType.TERMINAL_TOO_SMALL,
+				message: 'Test',
+				metadata: { width: 10, height: 10, minWidth: 80, minHeight: 24 },
+				timestamp: Date.now(),
+			});
+
+			expect(handler).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('emitTerminalTooSmallWarning', () => {
+		it('should emit terminal too small warning', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitTerminalTooSmallWarning(emitter, 40, 15, 80, 24);
+
+			expect(handler).toHaveBeenCalledTimes(1);
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.type).toBe(WarningType.TERMINAL_TOO_SMALL);
+			expect(event.message).toContain('40x15');
+			expect(event.message).toContain('80x24');
+		});
+
+		it('should include correct metadata', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitTerminalTooSmallWarning(emitter, 40, 15, 80, 24);
+
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.metadata).toEqual({
+				width: 40,
+				height: 15,
+				minWidth: 80,
+				minHeight: 24,
+			});
+		});
+
+		it('should include timestamp', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			const before = Date.now();
+			emitTerminalTooSmallWarning(emitter, 40, 15, 80, 24);
+			const after = Date.now();
+
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.timestamp).toBeGreaterThanOrEqual(before);
+			expect(event.timestamp).toBeLessThanOrEqual(after);
+		});
+	});
+
+	describe('emitUnsupportedCapabilityWarning', () => {
+		it('should emit unsupported capability warning', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitUnsupportedCapabilityWarning(emitter, 'truecolor');
+
+			expect(handler).toHaveBeenCalledTimes(1);
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.type).toBe(WarningType.UNSUPPORTED_CAPABILITY);
+			expect(event.message).toContain('truecolor');
+		});
+
+		it('should include fallback in message when provided', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitUnsupportedCapabilityWarning(emitter, 'truecolor', 'Using 256-color mode');
+
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.message).toContain('Using 256-color mode');
+		});
+
+		it('should include correct metadata', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitUnsupportedCapabilityWarning(emitter, 'truecolor', 'Fallback mode');
+
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.metadata).toEqual({
+				capability: 'truecolor',
+				fallback: 'Fallback mode',
+			});
+		});
+
+		it('should work without fallback', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitUnsupportedCapabilityWarning(emitter, 'mouse');
+
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.metadata).toEqual({
+				capability: 'mouse',
+			});
+		});
+	});
+
+	describe('emitDeprecatedAPIWarning', () => {
+		it('should emit deprecated API warning', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitDeprecatedAPIWarning(emitter, 'oldFunction()', 'newFunction()', 'v2.0.0');
+
+			expect(handler).toHaveBeenCalledTimes(1);
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.type).toBe(WarningType.DEPRECATED_API);
+			expect(event.message).toContain('oldFunction()');
+			expect(event.message).toContain('newFunction()');
+			expect(event.message).toContain('v2.0.0');
+		});
+
+		it('should include correct metadata', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitDeprecatedAPIWarning(emitter, 'oldAPI', 'newAPI', 'v1.5.0');
+
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.metadata).toEqual({
+				api: 'oldAPI',
+				replacement: 'newAPI',
+				since: 'v1.5.0',
+			});
+		});
+	});
+
+	describe('emitPerformanceWarning', () => {
+		it('should emit performance warning', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitPerformanceWarning(emitter, 'frame-time', 35, 16.67);
+
+			expect(handler).toHaveBeenCalledTimes(1);
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.type).toBe(WarningType.PERFORMANCE_ISSUE);
+			expect(event.message).toContain('frame-time');
+			expect(event.message).toContain('35');
+			expect(event.message).toContain('16.67');
+		});
+
+		it('should include correct metadata', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitPerformanceWarning(emitter, 'frame-time', 35, 16.67);
+
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.metadata).toEqual({
+				metric: 'frame-time',
+				value: 35,
+				threshold: 16.67,
+			});
+		});
+
+		it('should include optional frameTime', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitPerformanceWarning(emitter, 'frame-time', 35, 16.67, 35);
+
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event.metadata).toEqual({
+				metric: 'frame-time',
+				value: 35,
+				threshold: 16.67,
+				frameTime: 35,
+			});
+		});
+	});
+
+	describe('Multiple Listeners', () => {
+		it('should notify all listeners', () => {
+			const emitter = createWarningEmitter();
+			const handler1 = vi.fn();
+			const handler2 = vi.fn();
+
+			emitter.on('warning', handler1);
+			emitter.on('warning', handler2);
+
+			emitTerminalTooSmallWarning(emitter, 40, 15, 80, 24);
+
+			expect(handler1).toHaveBeenCalledTimes(1);
+			expect(handler2).toHaveBeenCalledTimes(1);
+		});
+
+		it('should allow filtering by warning type', () => {
+			const emitter = createWarningEmitter();
+			const terminalWarnings: WarningEvent[] = [];
+			const performanceWarnings: WarningEvent[] = [];
+
+			emitter.on('warning', (event) => {
+				if (event.type === WarningType.TERMINAL_TOO_SMALL) {
+					terminalWarnings.push(event);
+				} else if (event.type === WarningType.PERFORMANCE_ISSUE) {
+					performanceWarnings.push(event);
+				}
+			});
+
+			emitTerminalTooSmallWarning(emitter, 40, 15, 80, 24);
+			emitPerformanceWarning(emitter, 'frame-time', 35, 16.67);
+			emitTerminalTooSmallWarning(emitter, 30, 10, 80, 24);
+
+			expect(terminalWarnings).toHaveLength(2);
+			expect(performanceWarnings).toHaveLength(1);
+		});
+	});
+
+	describe('Logging Integration', () => {
+		it('should integrate with console.warn', () => {
+			const emitter = createWarningEmitter();
+			const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+			emitter.on('warning', (event) => {
+				console.warn(`[${event.type}] ${event.message}`);
+			});
+
+			emitTerminalTooSmallWarning(emitter, 40, 15, 80, 24);
+
+			expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('[terminal-too-small]'));
+			expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('40x15'));
+
+			consoleWarn.mockRestore();
+		});
+
+		it('should allow custom formatting', () => {
+			const emitter = createWarningEmitter();
+			const logs: string[] = [];
+
+			emitter.on('warning', (event) => {
+				logs.push(`Warning at ${event.timestamp}: ${event.message}`);
+			});
+
+			emitDeprecatedAPIWarning(emitter, 'oldAPI', 'newAPI', 'v1.0.0');
+
+			expect(logs).toHaveLength(1);
+			expect(logs[0]).toMatch(/^Warning at \d+: API 'oldAPI'/);
+		});
+	});
+
+	describe('Once Listener', () => {
+		it('should support once listeners', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+
+			emitter.once('warning', handler);
+
+			emitTerminalTooSmallWarning(emitter, 40, 15, 80, 24);
+			emitTerminalTooSmallWarning(emitter, 30, 10, 80, 24);
+
+			expect(handler).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('Event Validation', () => {
+		it('should validate warning event structure', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitTerminalTooSmallWarning(emitter, 40, 15, 80, 24);
+
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			expect(event).toHaveProperty('type');
+			expect(event).toHaveProperty('message');
+			expect(event).toHaveProperty('metadata');
+			expect(event).toHaveProperty('timestamp');
+		});
+
+		it('should validate terminal too small metadata structure', () => {
+			const emitter = createWarningEmitter();
+			const handler = vi.fn();
+			emitter.on('warning', handler);
+
+			emitTerminalTooSmallWarning(emitter, 40, 15, 80, 24);
+
+			const event = handler.mock.calls[0]?.[0] as WarningEvent;
+			const metadata = event.metadata as {
+				width: number;
+				height: number;
+				minWidth: number;
+				minHeight: number;
+			};
+			expect(metadata).toHaveProperty('width');
+			expect(metadata).toHaveProperty('height');
+			expect(metadata).toHaveProperty('minWidth');
+			expect(metadata).toHaveProperty('minHeight');
+		});
+	});
+});

--- a/src/core/warnings.ts
+++ b/src/core/warnings.ts
@@ -1,0 +1,333 @@
+/**
+ * Warning system for non-fatal screen issues.
+ *
+ * Provides typed warnings for terminal/screen issues like small sizes,
+ * unsupported capabilities, deprecated APIs, and performance problems.
+ *
+ * @module core/warnings
+ *
+ * @example
+ * ```typescript
+ * import { createWarningEmitter, WarningType } from 'blecsd';
+ *
+ * const warnings = createWarningEmitter();
+ *
+ * warnings.on('warning', (event) => {
+ *   console.warn(`[${event.type}] ${event.message}`);
+ * });
+ *
+ * // Emit a warning
+ * warnings.emit('warning', {
+ *   type: WarningType.TERMINAL_TOO_SMALL,
+ *   message: 'Terminal size is very small',
+ *   metadata: { width: 20, height: 10, minWidth: 80, minHeight: 24 },
+ *   timestamp: Date.now(),
+ * });
+ * ```
+ */
+
+import { z } from 'zod';
+import { createEventBus, type EventBus } from './events';
+
+/**
+ * Warning type enumeration.
+ */
+export const WarningType = {
+	/** Terminal resized to very small dimensions */
+	TERMINAL_TOO_SMALL: 'terminal-too-small',
+	/** Requested terminal capability is not supported */
+	UNSUPPORTED_CAPABILITY: 'unsupported-capability',
+	/** Using deprecated API */
+	DEPRECATED_API: 'deprecated-api',
+	/** Performance issue detected (frame drops) */
+	PERFORMANCE_ISSUE: 'performance-issue',
+} as const;
+
+export type WarningTypeValue = (typeof WarningType)[keyof typeof WarningType];
+
+/**
+ * Metadata for terminal too small warnings.
+ */
+export interface TerminalTooSmallMetadata {
+	readonly width: number;
+	readonly height: number;
+	readonly minWidth: number;
+	readonly minHeight: number;
+}
+
+/**
+ * Metadata for unsupported capability warnings.
+ */
+export interface UnsupportedCapabilityMetadata {
+	readonly capability: string;
+	readonly fallback?: string;
+}
+
+/**
+ * Metadata for deprecated API warnings.
+ */
+export interface DeprecatedAPIMetadata {
+	readonly api: string;
+	readonly replacement: string;
+	readonly since: string;
+}
+
+/**
+ * Metadata for performance warnings.
+ */
+export interface PerformanceIssueMetadata {
+	readonly metric: string;
+	readonly value: number;
+	readonly threshold: number;
+	readonly frameTime?: number;
+}
+
+/**
+ * Union type for warning metadata.
+ */
+export type WarningMetadata =
+	| TerminalTooSmallMetadata
+	| UnsupportedCapabilityMetadata
+	| DeprecatedAPIMetadata
+	| PerformanceIssueMetadata;
+
+/**
+ * Warning event payload.
+ */
+export interface WarningEvent {
+	readonly type: WarningTypeValue;
+	readonly message: string;
+	readonly metadata: WarningMetadata;
+	readonly timestamp: number;
+}
+
+/**
+ * Zod schema for terminal too small metadata.
+ */
+export const TerminalTooSmallMetadataSchema = z.object({
+	width: z.number().int().nonnegative(),
+	height: z.number().int().nonnegative(),
+	minWidth: z.number().int().positive(),
+	minHeight: z.number().int().positive(),
+});
+
+/**
+ * Zod schema for unsupported capability metadata.
+ */
+export const UnsupportedCapabilityMetadataSchema = z.object({
+	capability: z.string(),
+	fallback: z.string().optional(),
+});
+
+/**
+ * Zod schema for deprecated API metadata.
+ */
+export const DeprecatedAPIMetadataSchema = z.object({
+	api: z.string(),
+	replacement: z.string(),
+	since: z.string(),
+});
+
+/**
+ * Zod schema for performance issue metadata.
+ */
+export const PerformanceIssueMetadataSchema = z.object({
+	metric: z.string(),
+	value: z.number(),
+	threshold: z.number(),
+	frameTime: z.number().optional(),
+});
+
+/**
+ * Zod schema for warning events.
+ */
+export const WarningEventSchema = z.object({
+	type: z.enum([
+		WarningType.TERMINAL_TOO_SMALL,
+		WarningType.UNSUPPORTED_CAPABILITY,
+		WarningType.DEPRECATED_API,
+		WarningType.PERFORMANCE_ISSUE,
+	]),
+	message: z.string(),
+	metadata: z.union([
+		TerminalTooSmallMetadataSchema,
+		UnsupportedCapabilityMetadataSchema,
+		DeprecatedAPIMetadataSchema,
+		PerformanceIssueMetadataSchema,
+	]),
+	timestamp: z.number(),
+});
+
+/**
+ * Warning event map for typed event bus.
+ */
+export interface WarningEventMap {
+	warning: WarningEvent;
+}
+
+/**
+ * Warning emitter type.
+ */
+export type WarningEmitter = EventBus<WarningEventMap>;
+
+/**
+ * Creates a new warning event emitter.
+ *
+ * @returns A new warning emitter
+ *
+ * @example
+ * ```typescript
+ * import { createWarningEmitter } from 'blecsd';
+ *
+ * const warnings = createWarningEmitter();
+ *
+ * // Listen for all warnings
+ * warnings.on('warning', (event) => {
+ *   console.warn(`Warning: ${event.message}`);
+ * });
+ * ```
+ */
+export function createWarningEmitter(): WarningEmitter {
+	return createEventBus<WarningEventMap>();
+}
+
+/**
+ * Creates and emits a terminal too small warning.
+ *
+ * @param emitter - The warning emitter
+ * @param width - Current terminal width
+ * @param height - Current terminal height
+ * @param minWidth - Minimum recommended width
+ * @param minHeight - Minimum recommended height
+ *
+ * @example
+ * ```typescript
+ * import { emitTerminalTooSmallWarning } from 'blecsd';
+ *
+ * emitTerminalTooSmallWarning(warnings, 40, 15, 80, 24);
+ * ```
+ */
+export function emitTerminalTooSmallWarning(
+	emitter: WarningEmitter,
+	width: number,
+	height: number,
+	minWidth: number,
+	minHeight: number,
+): void {
+	const metadata: TerminalTooSmallMetadata = { width, height, minWidth, minHeight };
+	const event: WarningEvent = {
+		type: WarningType.TERMINAL_TOO_SMALL,
+		message: `Terminal size (${width}x${height}) is smaller than recommended (${minWidth}x${minHeight})`,
+		metadata,
+		timestamp: Date.now(),
+	};
+	emitter.emit('warning', WarningEventSchema.parse(event));
+}
+
+/**
+ * Creates and emits an unsupported capability warning.
+ *
+ * @param emitter - The warning emitter
+ * @param capability - The unsupported capability name
+ * @param fallback - Optional fallback description
+ *
+ * @example
+ * ```typescript
+ * import { emitUnsupportedCapabilityWarning } from 'blecsd';
+ *
+ * emitUnsupportedCapabilityWarning(
+ *   warnings,
+ *   'truecolor',
+ *   'Falling back to 256-color mode'
+ * );
+ * ```
+ */
+export function emitUnsupportedCapabilityWarning(
+	emitter: WarningEmitter,
+	capability: string,
+	fallback?: string,
+): void {
+	const metadata: UnsupportedCapabilityMetadata = { capability, fallback };
+	const event: WarningEvent = {
+		type: WarningType.UNSUPPORTED_CAPABILITY,
+		message: `Terminal capability '${capability}' is not supported${fallback ? `. ${fallback}` : ''}`,
+		metadata,
+		timestamp: Date.now(),
+	};
+	emitter.emit('warning', WarningEventSchema.parse(event));
+}
+
+/**
+ * Creates and emits a deprecated API warning.
+ *
+ * @param emitter - The warning emitter
+ * @param api - The deprecated API name
+ * @param replacement - The replacement API
+ * @param since - Version since deprecated
+ *
+ * @example
+ * ```typescript
+ * import { emitDeprecatedAPIWarning } from 'blecsd';
+ *
+ * emitDeprecatedAPIWarning(
+ *   warnings,
+ *   'oldFunction()',
+ *   'newFunction()',
+ *   'v2.0.0'
+ * );
+ * ```
+ */
+export function emitDeprecatedAPIWarning(
+	emitter: WarningEmitter,
+	api: string,
+	replacement: string,
+	since: string,
+): void {
+	const metadata: DeprecatedAPIMetadata = { api, replacement, since };
+	const event: WarningEvent = {
+		type: WarningType.DEPRECATED_API,
+		message: `API '${api}' is deprecated since ${since}. Use '${replacement}' instead.`,
+		metadata,
+		timestamp: Date.now(),
+	};
+	emitter.emit('warning', WarningEventSchema.parse(event));
+}
+
+/**
+ * Creates and emits a performance issue warning.
+ *
+ * @param emitter - The warning emitter
+ * @param metric - The performance metric name
+ * @param value - The measured value
+ * @param threshold - The threshold value
+ * @param frameTime - Optional frame time in milliseconds
+ *
+ * @example
+ * ```typescript
+ * import { emitPerformanceWarning } from 'blecsd';
+ *
+ * emitPerformanceWarning(
+ *   warnings,
+ *   'frame-time',
+ *   35,
+ *   16.67,
+ *   35
+ * );
+ * ```
+ */
+export function emitPerformanceWarning(
+	emitter: WarningEmitter,
+	metric: string,
+	value: number,
+	threshold: number,
+	frameTime?: number,
+): void {
+	const metadata: PerformanceIssueMetadata = { metric, value, threshold, frameTime };
+	const event: WarningEvent = {
+		type: WarningType.PERFORMANCE_ISSUE,
+		message: `Performance issue: ${metric} (${value.toFixed(2)}) exceeds threshold (${threshold.toFixed(2)})`,
+		metadata,
+		timestamp: Date.now(),
+	};
+	emitter.emit('warning', WarningEventSchema.parse(event));
+}


### PR DESCRIPTION
Closes #1032

## Summary
Add a warning system that emits typed events for non-fatal screen/terminal issues. Users can subscribe to warnings and implement custom logging or handling.

## Warning Types
1. **Terminal Too Small** - Terminal resized to very small dimensions
2. **Unsupported Capability** - Requested terminal capability not supported
3. **Deprecated API** - Using deprecated API
4. **Performance Issue** - Performance warnings (frame drops)

## Changes
- Add `WarningType` enum with 4 warning types
- Add typed warning event interfaces (`TerminalTooSmallMetadata`, `UnsupportedCapabilityMetadata`, etc.)
- Add `WarningEvent` type with type, message, metadata, timestamp
- Add warning event to `ScreenEventMap`
- Add `createWarningEmitter()` to create typed event emitters
- Add helper functions for each warning type:
  - `emitTerminalTooSmallWarning()`
  - `emitUnsupportedCapabilityWarning()`
  - `emitDeprecatedAPIWarning()`
  - `emitPerformanceWarning()`
- Add Zod schemas for validation of all warning metadata
- Export warning system from `core/index.ts`
- Add comprehensive tests (22 tests covering all functionality)

## Features
- **Subscribable events** - Users can listen for warnings via event emitter
- **Typed metadata** - Each warning type has specific metadata structure
- **Validated with Zod** - All warning data validated at runtime
- **Timestamps** - All warnings include timestamp
- **Helper functions** - Convenient functions for common warning scenarios
- **Integrates with existing event system** - Uses same `EventBus` pattern

## Testing
- 22 tests covering:
  - Event emitter creation
  - All 4 warning types
  - Metadata validation
  - Multiple listeners
  - Once listeners
  - Logging integration
  - Event validation
- All tests pass ✅
- Lint passes ✅ (pre-existing warnings unaffected)
- Typecheck passes ✅
- Build succeeds ✅

## Usage Example
```typescript
import { createWarningEmitter, emitTerminalTooSmallWarning } from 'blecsd';

const warnings = createWarningEmitter();

// Listen for all warnings
warnings.on('warning', (event) => {
  console.warn(`[${event.type}] ${event.message}`);
});

// Emit a warning
emitTerminalTooSmallWarning(warnings, 40, 15, 80, 24);
// Output: [terminal-too-small] Terminal size (40x15) is smaller than recommended (80x24)
```