### PR TITLE
refactor: eliminate 'this' keyword in src/terminal/

### DIFF
--- a/src/terminal/ansi.ts
+++ b/src/terminal/ansi.ts
@@ -1712,10 +1712,10 @@ export const tmux = {
 		if (!inTmux) {
 			return sequence;
 		}
-		if (this.isWrapped(sequence)) {
+		if (tmux.isWrapped(sequence)) {
 			return sequence;
 		}
-		return this.wrap(sequence);
+		return tmux.wrap(sequence);
 	},
 
 	/**
@@ -2191,14 +2191,14 @@ export const charset = {
 	 * Alias for enterAcs() - enter alternate character set mode.
 	 */
 	smacs(): string {
-		return this.enterAcs();
+		return charset.enterAcs();
 	},
 
 	/**
 	 * Alias for exitAcs() - exit alternate character set mode.
 	 */
 	rmacs(): string {
-		return this.exitAcs();
+		return charset.exitAcs();
 	},
 } as const;
 
@@ -2766,7 +2766,7 @@ export const hyperlink = {
 	 * ```
 	 */
 	link(url: string, text: string, options?: HyperlinkOptions): string {
-		return `${this.start(url, options)}${text}${this.end()}`;
+		return `${hyperlink.start(url, options)}${text}${hyperlink.end()}`;
 	},
 
 	/**
@@ -2852,7 +2852,7 @@ export const hyperlink = {
 		if (!isHyperlinkAllowed(url)) {
 			return text;
 		}
-		return this.link(url, text, options);
+		return hyperlink.link(url, text, options);
 	},
 
 	/**
@@ -2875,7 +2875,7 @@ export const hyperlink = {
 	 * ```
 	 */
 	mailto(email: string, text?: string, options?: HyperlinkOptions): string {
-		return this.link(`mailto:${email}`, text ?? email, options);
+		return hyperlink.link(`mailto:${email}`, text ?? email, options);
 	},
 
 	/**
@@ -2898,7 +2898,7 @@ export const hyperlink = {
 	 * ```
 	 */
 	file(path: string, text?: string, options?: HyperlinkOptions): string {
-		return this.link(`file://${path}`, text ?? path, options);
+		return hyperlink.link(`file://${path}`, text ?? path, options);
 	},
 } as const;
 


### PR DESCRIPTION
Eliminates all \`this\` keyword usage from production code in the \`src/terminal/\` directory to comply with functional programming requirements in CLAUDE.md.

## Changes

### src/terminal/ansi.ts
- **tmux.wrapIf()**: Changed `this.isWrapped()` and `this.wrap()` to `tmux.isWrapped()` and `tmux.wrap()`
- **charset.smacs()**: Changed `this.enterAcs()` to `charset.enterAcs()`
- **charset.rmacs()**: Changed `this.exitAcs()` to `charset.exitAcs()`
- **hyperlink.link()**: Changed `this.start()` and `this.end()` to `hyperlink.start()` and `hyperlink.end()`
- **hyperlink.safeLink()**: Changed `this.link()` to `hyperlink.link()`
- **hyperlink.mailto()**: Changed `this.link()` to `hyperlink.link()`
- **hyperlink.file()**: Changed `this.link()` to `hyperlink.link()`

### Test Mocks Unchanged
Test mocks in `suspend.test.ts` and `process.test.ts` retain `this` usage as they simulate Node.js stream APIs that require `this` for method chaining.

## Validation
- ✅ Tests: 10,775 passed
- ✅ Lint: Passing (pre-existing warnings only)
- ✅ Typecheck: Passing
- ✅ Build: Successful

## Issue
Closes #1095