### PR TITLE
feat: add emitDescendants() for downward event propagation

### DIFF
--- a/src/core/eventDescendants.test.ts
+++ b/src/core/eventDescendants.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Tests for event descendants propagation.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { ZodError } from 'zod';
+import { appendChild } from '../components/hierarchy';
+import { addEntity } from './ecs';
+import {
+	createEntityEventBusStore,
+	type EmitDescendantsOptions,
+	emitDescendants,
+	type GetEntityEventBus,
+} from './eventDescendants';
+import type { EventMap } from './events';
+import { createEventBus } from './events';
+import type { Entity, World } from './types';
+import { createWorld } from './world';
+
+interface TestEvents extends EventMap {
+	action: { type: string; value: number };
+	custom: { message: string };
+}
+
+describe('emitDescendants', () => {
+	it('should emit event to root entity only', () => {
+		const world = createWorld();
+		const root = addEntity(world);
+
+		const eventBuses = new Map();
+		const rootBus = createEventBus<TestEvents>();
+		eventBuses.set(root, rootBus);
+
+		const handler = vi.fn();
+		rootBus.on('action', handler);
+
+		const getEventBus: GetEntityEventBus<TestEvents> = (_w: World, eid: Entity) =>
+			eventBuses.get(eid);
+
+		const result = emitDescendants(world, root, 'action', { type: 'test', value: 42 }, getEventBus);
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(handler).toHaveBeenCalledWith({ type: 'test', value: 42 });
+		expect(result.dispatchCount).toBe(1);
+		expect(result.maxDepth).toBe(0);
+		expect(result.circularReferenceDetected).toBe(false);
+	});
+
+	it('should emit event to root and all descendants', () => {
+		const world = createWorld();
+		const root = addEntity(world);
+		const child1 = addEntity(world);
+		const child2 = addEntity(world);
+		const grandchild = addEntity(world);
+
+		appendChild(world, root, child1);
+		appendChild(world, root, child2);
+		appendChild(world, child1, grandchild);
+
+		const eventBuses = new Map();
+		const rootBus = createEventBus<TestEvents>();
+		const child1Bus = createEventBus<TestEvents>();
+		const child2Bus = createEventBus<TestEvents>();
+		const grandchildBus = createEventBus<TestEvents>();
+		eventBuses.set(root, rootBus);
+		eventBuses.set(child1, child1Bus);
+		eventBuses.set(child2, child2Bus);
+		eventBuses.set(grandchild, grandchildBus);
+
+		const rootHandler = vi.fn();
+		const child1Handler = vi.fn();
+		const child2Handler = vi.fn();
+		const grandchildHandler = vi.fn();
+		rootBus.on('action', rootHandler);
+		child1Bus.on('action', child1Handler);
+		child2Bus.on('action', child2Handler);
+		grandchildBus.on('action', grandchildHandler);
+
+		const getEventBus: GetEntityEventBus<TestEvents> = (_w: World, eid: Entity) =>
+			eventBuses.get(eid);
+
+		const result = emitDescendants(
+			world,
+			root,
+			'action',
+			{ type: 'activate', value: 100 },
+			getEventBus,
+		);
+
+		expect(rootHandler).toHaveBeenCalledTimes(1);
+		expect(child1Handler).toHaveBeenCalledTimes(1);
+		expect(child2Handler).toHaveBeenCalledTimes(1);
+		expect(grandchildHandler).toHaveBeenCalledTimes(1);
+		expect(result.dispatchCount).toBe(4);
+		expect(result.maxDepth).toBe(2);
+		expect(result.circularReferenceDetected).toBe(false);
+	});
+
+	it('should skip root when includeRoot is false', () => {
+		const world = createWorld();
+		const root = addEntity(world);
+		const child = addEntity(world);
+
+		appendChild(world, root, child);
+
+		const eventBuses = new Map();
+		const rootBus = createEventBus<TestEvents>();
+		const childBus = createEventBus<TestEvents>();
+		eventBuses.set(root, rootBus);
+		eventBuses.set(child, childBus);
+
+		const rootHandler = vi.fn();
+		const childHandler = vi.fn();
+		rootBus.on('action', rootHandler);
+		childBus.on('action', childHandler);
+
+		const getEventBus: GetEntityEventBus<TestEvents> = (_w: World, eid: Entity) =>
+			eventBuses.get(eid);
+
+		const result = emitDescendants(world, root, 'action', { type: 'test', value: 1 }, getEventBus, {
+			includeRoot: false,
+		});
+
+		expect(rootHandler).not.toHaveBeenCalled();
+		expect(childHandler).toHaveBeenCalledTimes(1);
+		expect(result.dispatchCount).toBe(1);
+		expect(result.maxDepth).toBe(1);
+	});
+
+	it('should respect maxDepth option', () => {
+		const world = createWorld();
+		const root = addEntity(world);
+		const child = addEntity(world);
+		const grandchild = addEntity(world);
+		const greatGrandchild = addEntity(world);
+
+		appendChild(world, root, child);
+		appendChild(world, child, grandchild);
+		appendChild(world, grandchild, greatGrandchild);
+
+		const eventBuses = new Map();
+		const rootBus = createEventBus<TestEvents>();
+		const childBus = createEventBus<TestEvents>();
+		const grandchildBus = createEventBus<TestEvents>();
+		const greatGrandchildBus = createEventBus<TestEvents>();
+		eventBuses.set(root, rootBus);
+		eventBuses.set(child, childBus);
+		eventBuses.set(grandchild, grandchildBus);
+		eventBuses.set(greatGrandchild, greatGrandchildBus);
+
+		const rootHandler = vi.fn();
+		const childHandler = vi.fn();
+		const grandchildHandler = vi.fn();
+		const greatGrandchildHandler = vi.fn();
+		rootBus.on('action', rootHandler);
+		childBus.on('action', childHandler);
+		grandchildBus.on('action', grandchildHandler);
+		greatGrandchildBus.on('action', greatGrandchildHandler);
+
+		const getEventBus: GetEntityEventBus<TestEvents> = (_w: World, eid: Entity) =>
+			eventBuses.get(eid);
+
+		const result = emitDescendants(world, root, 'action', { type: 'test', value: 1 }, getEventBus, {
+			maxDepth: 1,
+		});
+
+		expect(rootHandler).toHaveBeenCalledTimes(1);
+		expect(childHandler).toHaveBeenCalledTimes(1);
+		expect(grandchildHandler).not.toHaveBeenCalled();
+		expect(greatGrandchildHandler).not.toHaveBeenCalled();
+		expect(result.dispatchCount).toBe(2);
+		expect(result.maxDepth).toBe(1);
+	});
+
+	it('should handle entities without event buses', () => {
+		const world = createWorld();
+		const root = addEntity(world);
+		const child1 = addEntity(world);
+		const child2 = addEntity(world);
+
+		appendChild(world, root, child1);
+		appendChild(world, root, child2);
+
+		const eventBuses = new Map();
+		const rootBus = createEventBus<TestEvents>();
+		const child2Bus = createEventBus<TestEvents>();
+		eventBuses.set(root, rootBus);
+		eventBuses.set(child2, child2Bus); // child1 has no bus
+
+		const rootHandler = vi.fn();
+		const child2Handler = vi.fn();
+		rootBus.on('action', rootHandler);
+		child2Bus.on('action', child2Handler);
+
+		const getEventBus: GetEntityEventBus<TestEvents> = (_w: World, eid: Entity) =>
+			eventBuses.get(eid);
+
+		const result = emitDescendants(world, root, 'action', { type: 'test', value: 1 }, getEventBus);
+
+		expect(rootHandler).toHaveBeenCalledTimes(1);
+		expect(child2Handler).toHaveBeenCalledTimes(1);
+		expect(result.dispatchCount).toBe(2); // Only root and child2
+	});
+
+	it('should handle entities without hierarchy component', () => {
+		const world = createWorld();
+		const standalone = addEntity(world);
+
+		const eventBuses = new Map();
+		const standaloneBus = createEventBus<TestEvents>();
+		eventBuses.set(standalone, standaloneBus);
+
+		const handler = vi.fn();
+		standaloneBus.on('action', handler);
+
+		const getEventBus: GetEntityEventBus<TestEvents> = (_w: World, eid: Entity) =>
+			eventBuses.get(eid);
+
+		const result = emitDescendants(
+			world,
+			standalone,
+			'action',
+			{ type: 'test', value: 1 },
+			getEventBus,
+		);
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(result.dispatchCount).toBe(1);
+		expect(result.maxDepth).toBe(0);
+	});
+
+	it('should not detect circular references in normal hierarchies', () => {
+		// Circular reference detection is defensive programming for corrupted data.
+		// In normal usage with appendChild/removeChild, circular refs cannot happen.
+		// This test verifies that normal hierarchies don't trigger false positives.
+		const world = createWorld();
+		const root = addEntity(world);
+		const child = addEntity(world);
+		const grandchild = addEntity(world);
+
+		appendChild(world, root, child);
+		appendChild(world, child, grandchild);
+
+		const eventBuses = new Map();
+		eventBuses.set(root, createEventBus<TestEvents>());
+		eventBuses.set(child, createEventBus<TestEvents>());
+		eventBuses.set(grandchild, createEventBus<TestEvents>());
+
+		const getEventBus: GetEntityEventBus<TestEvents> = (_w: World, eid: Entity) =>
+			eventBuses.get(eid);
+
+		const result = emitDescendants(world, root, 'action', { type: 'test', value: 1 }, getEventBus);
+
+		expect(result.circularReferenceDetected).toBe(false);
+		expect(result.dispatchCount).toBe(3);
+	});
+
+	it('should emit different event types', () => {
+		const world = createWorld();
+		const root = addEntity(world);
+		const child = addEntity(world);
+
+		appendChild(world, root, child);
+
+		const eventBuses = new Map();
+		const rootBus = createEventBus<TestEvents>();
+		const childBus = createEventBus<TestEvents>();
+		eventBuses.set(root, rootBus);
+		eventBuses.set(child, childBus);
+
+		const actionHandler = vi.fn();
+		const customHandler = vi.fn();
+		rootBus.on('action', actionHandler);
+		rootBus.on('custom', customHandler);
+		childBus.on('action', actionHandler);
+		childBus.on('custom', customHandler);
+
+		const getEventBus: GetEntityEventBus<TestEvents> = (_w: World, eid: Entity) =>
+			eventBuses.get(eid);
+
+		// Emit action event
+		emitDescendants(world, root, 'action', { type: 'test', value: 1 }, getEventBus);
+		expect(actionHandler).toHaveBeenCalledTimes(2);
+		expect(customHandler).not.toHaveBeenCalled();
+
+		// Emit custom event
+		emitDescendants(world, root, 'custom', { message: 'hello' }, getEventBus);
+		expect(customHandler).toHaveBeenCalledTimes(2);
+	});
+
+	it('should validate options schema', () => {
+		const world = createWorld();
+		const root = addEntity(world);
+
+		const eventBuses = new Map();
+		eventBuses.set(root, createEventBus<TestEvents>());
+
+		const getEventBus: GetEntityEventBus<TestEvents> = (_w: World, eid: Entity) =>
+			eventBuses.get(eid);
+
+		// Invalid maxDepth (not positive)
+		expect(() =>
+			emitDescendants(world, root, 'action', { type: 'test', value: 1 }, getEventBus, {
+				maxDepth: 0,
+			} as EmitDescendantsOptions),
+		).toThrow(ZodError);
+
+		// Invalid maxDepth (negative)
+		expect(() =>
+			emitDescendants(world, root, 'action', { type: 'test', value: 1 }, getEventBus, {
+				maxDepth: -1,
+			} as EmitDescendantsOptions),
+		).toThrow(ZodError);
+
+		// Invalid maxDepth (not integer)
+		expect(() =>
+			emitDescendants(world, root, 'action', { type: 'test', value: 1 }, getEventBus, {
+				maxDepth: 1.5,
+			} as EmitDescendantsOptions),
+		).toThrow(ZodError);
+	});
+
+	it('should handle deep hierarchies', () => {
+		const world = createWorld();
+		const entities: Entity[] = [];
+
+		// Create 10-level deep hierarchy
+		for (let i = 0; i < 10; i++) {
+			entities.push(addEntity(world));
+		}
+
+		for (let i = 0; i < 9; i++) {
+			appendChild(world, entities[i] as Entity, entities[i + 1] as Entity);
+		}
+
+		const eventBuses = new Map();
+		for (const entity of entities) {
+			eventBuses.set(entity, createEventBus<TestEvents>());
+		}
+
+		const handlers = entities.map(() => vi.fn());
+		for (let i = 0; i < entities.length; i++) {
+			const bus = eventBuses.get(entities[i]);
+			if (bus) {
+				bus.on('action', handlers[i] as (event: { type: string; value: number }) => void);
+			}
+		}
+
+		const getEventBus: GetEntityEventBus<TestEvents> = (_w: World, eid: Entity) =>
+			eventBuses.get(eid);
+
+		const result = emitDescendants(
+			world,
+			entities[0] as Entity,
+			'action',
+			{ type: 'test', value: 1 },
+			getEventBus,
+		);
+
+		// All 10 entities should receive the event
+		for (const handler of handlers) {
+			expect(handler).toHaveBeenCalledTimes(1);
+		}
+		expect(result.dispatchCount).toBe(10);
+		expect(result.maxDepth).toBe(9);
+	});
+});
+
+describe('createEntityEventBusStore', () => {
+	it('should get and set event buses', () => {
+		const world = createWorld();
+		const entity = addEntity(world);
+		const store = createEntityEventBusStore<TestEvents>();
+		const bus = createEventBus<TestEvents>();
+
+		expect(store.get(world, entity)).toBeUndefined();
+
+		store.set(world, entity, bus);
+		expect(store.get(world, entity)).toBe(bus);
+	});
+
+	it('should check if entity has event bus', () => {
+		const world = createWorld();
+		const entity = addEntity(world);
+		const store = createEntityEventBusStore<TestEvents>();
+
+		expect(store.has(world, entity)).toBe(false);
+
+		store.set(world, entity, createEventBus<TestEvents>());
+		expect(store.has(world, entity)).toBe(true);
+	});
+
+	it('should delete event bus', () => {
+		const world = createWorld();
+		const entity = addEntity(world);
+		const store = createEntityEventBusStore<TestEvents>();
+		const bus = createEventBus<TestEvents>();
+
+		store.set(world, entity, bus);
+		expect(store.has(world, entity)).toBe(true);
+
+		const deleted = store.delete(world, entity);
+		expect(deleted).toBe(true);
+		expect(store.has(world, entity)).toBe(false);
+
+		// Deleting again should return false
+		expect(store.delete(world, entity)).toBe(false);
+	});
+
+	it('should clear all event buses', () => {
+		const world = createWorld();
+		const entity1 = addEntity(world);
+		const entity2 = addEntity(world);
+		const store = createEntityEventBusStore<TestEvents>();
+
+		store.set(world, entity1, createEventBus<TestEvents>());
+		store.set(world, entity2, createEventBus<TestEvents>());
+
+		expect(store.has(world, entity1)).toBe(true);
+		expect(store.has(world, entity2)).toBe(true);
+
+		store.clear();
+
+		expect(store.has(world, entity1)).toBe(false);
+		expect(store.has(world, entity2)).toBe(false);
+	});
+
+	it('should work with emitDescendants', () => {
+		const world = createWorld();
+		const root = addEntity(world);
+		const child = addEntity(world);
+
+		appendChild(world, root, child);
+
+		const store = createEntityEventBusStore<TestEvents>();
+		const rootBus = createEventBus<TestEvents>();
+		const childBus = createEventBus<TestEvents>();
+
+		store.set(world, root, rootBus);
+		store.set(world, child, childBus);
+
+		const rootHandler = vi.fn();
+		const childHandler = vi.fn();
+		rootBus.on('action', rootHandler);
+		childBus.on('action', childHandler);
+
+		const result = emitDescendants(world, root, 'action', { type: 'test', value: 1 }, store.get);
+
+		expect(rootHandler).toHaveBeenCalledTimes(1);
+		expect(childHandler).toHaveBeenCalledTimes(1);
+		expect(result.dispatchCount).toBe(2);
+	});
+});

--- a/src/core/eventDescendants.ts
+++ b/src/core/eventDescendants.ts
@@ -1,0 +1,243 @@
+/**
+ * Event propagation to descendants (downward through hierarchy).
+ * Emits events to an entity and all its children recursively.
+ * @module core/eventDescendants
+ */
+
+import { z } from 'zod';
+import { Hierarchy, NULL_ENTITY } from '../components/hierarchy';
+import { hasComponent } from './ecs';
+import type { EventBus, EventMap } from './events';
+import type { Entity, World } from './types';
+
+/**
+ * Function type for getting an EventBus for a specific entity.
+ * Returns undefined if the entity has no event bus.
+ */
+export type GetEntityEventBus<T extends EventMap> = (
+	world: World,
+	eid: Entity,
+) => EventBus<T> | undefined;
+
+/**
+ * Result of emitting an event to descendants.
+ */
+export interface EmitDescendantsResult {
+	/** Number of entities the event was dispatched to */
+	dispatchCount: number;
+	/** Maximum depth reached during traversal */
+	maxDepth: number;
+	/** Whether a circular reference was detected */
+	circularReferenceDetected: boolean;
+}
+
+/**
+ * Zod schema for EmitDescendantsResult.
+ */
+export const EmitDescendantsResultSchema = z.object({
+	dispatchCount: z.number().int().nonnegative(),
+	maxDepth: z.number().int().nonnegative(),
+	circularReferenceDetected: z.boolean(),
+});
+
+/**
+ * Options for emitting events to descendants.
+ */
+export interface EmitDescendantsOptions {
+	/** Maximum depth to traverse (default: Infinity) */
+	maxDepth?: number;
+	/** Whether to include the root entity (default: true) */
+	includeRoot?: boolean;
+}
+
+/**
+ * Zod schema for EmitDescendantsOptions.
+ */
+export const EmitDescendantsOptionsSchema = z.object({
+	maxDepth: z.number().int().positive().optional(),
+	includeRoot: z.boolean().optional(),
+});
+
+/**
+ * Emits an event to an entity and all its descendants in the hierarchy.
+ * Traverses the entity tree depth-first, visiting each descendant entity.
+ * Safely handles circular references by tracking visited entities.
+ *
+ * @typeParam T - Event map type
+ * @typeParam K - Event name type
+ * @param world - The ECS world
+ * @param eid - The root entity to start emitting from
+ * @param eventName - The name of the event to emit
+ * @param eventData - The event data to pass to handlers
+ * @param getEventBus - Function to get the event bus for an entity
+ * @param options - Optional emission configuration
+ * @returns Result with dispatch count, max depth, and circular reference detection
+ *
+ * @example
+ * ```typescript
+ * import { emitDescendants, createEventBus } from 'blecsd';
+ *
+ * // Set up entity hierarchy
+ * const parent = addEntity(world);
+ * const child1 = addEntity(world);
+ * const child2 = addEntity(world);
+ * appendChild(world, parent, child1);
+ * appendChild(world, parent, child2);
+ *
+ * // Create event buses for entities
+ * const eventBuses = new Map();
+ * eventBuses.set(parent, createEventBus());
+ * eventBuses.set(child1, createEventBus());
+ * eventBuses.set(child2, createEventBus());
+ *
+ * const getEventBus = (world, eid) => eventBuses.get(eid);
+ *
+ * // Listen for events
+ * eventBuses.get(parent).on('action', (data) => console.log('Parent:', data));
+ * eventBuses.get(child1).on('action', (data) => console.log('Child1:', data));
+ * eventBuses.get(child2).on('action', (data) => console.log('Child2:', data));
+ *
+ * // Emit to all descendants
+ * const result = emitDescendants(
+ *   world,
+ *   parent,
+ *   'action',
+ *   { type: 'activate' },
+ *   getEventBus
+ * );
+ * // Logs: "Parent: { type: 'activate' }"
+ * //       "Child1: { type: 'activate' }"
+ *       "Child2: { type: 'activate' }"
+ * // result.dispatchCount === 3
+ * ```
+ */
+export function emitDescendants<T extends EventMap, K extends keyof T>(
+	world: World,
+	eid: Entity,
+	eventName: K,
+	eventData: T[K],
+	getEventBus: GetEntityEventBus<T>,
+	options?: EmitDescendantsOptions,
+): EmitDescendantsResult {
+	// Validate options
+	const validatedOptions = options
+		? EmitDescendantsOptionsSchema.parse(options)
+		: { includeRoot: true, maxDepth: Number.POSITIVE_INFINITY };
+
+	const maxDepth = validatedOptions.maxDepth ?? Number.POSITIVE_INFINITY;
+	const includeRoot = validatedOptions.includeRoot ?? true;
+
+	// Track visited entities to detect circular references
+	const visited = new Set<Entity>();
+	let dispatchCount = 0;
+	let maxDepthReached = 0;
+	let circularReferenceDetected = false;
+
+	/**
+	 * Recursively emit to entity and all descendants.
+	 * @internal
+	 */
+	function emitRecursive(currentEid: Entity, depth: number): void {
+		// Check depth limit
+		if (depth > maxDepth) {
+			return;
+		}
+
+		// Detect circular references
+		if (visited.has(currentEid)) {
+			circularReferenceDetected = true;
+			return;
+		}
+
+		visited.add(currentEid);
+		maxDepthReached = Math.max(maxDepthReached, depth);
+
+		// Emit to current entity (skip root if includeRoot is false)
+		if (depth > 0 || includeRoot) {
+			const eventBus = getEventBus(world, currentEid);
+			if (eventBus) {
+				eventBus.emit(eventName, eventData);
+				dispatchCount++;
+			}
+		}
+
+		// Check if entity has hierarchy component
+		if (!hasComponent(world, currentEid, Hierarchy)) {
+			return;
+		}
+
+		// Traverse children
+		let child = Hierarchy.firstChild[currentEid] as Entity;
+		while (child !== NULL_ENTITY) {
+			emitRecursive(child, depth + 1);
+			child = Hierarchy.nextSibling[child] as Entity;
+		}
+	}
+
+	// Start recursive emission
+	emitRecursive(eid, 0);
+
+	const result: EmitDescendantsResult = {
+		dispatchCount,
+		maxDepth: maxDepthReached,
+		circularReferenceDetected,
+	};
+
+	return EmitDescendantsResultSchema.parse(result);
+}
+
+/**
+ * Store for entity event buses.
+ * Maps entity IDs to their event buses.
+ */
+export interface EntityEventBusStore<T extends EventMap> {
+	/** Gets the event bus for an entity */
+	get(world: World, eid: Entity): EventBus<T> | undefined;
+	/** Sets the event bus for an entity */
+	set(world: World, eid: Entity, eventBus: EventBus<T>): void;
+	/** Checks if an entity has an event bus */
+	has(world: World, eid: Entity): boolean;
+	/** Removes the event bus for an entity */
+	delete(world: World, eid: Entity): boolean;
+	/** Clears all event buses */
+	clear(): void;
+}
+
+/**
+ * Creates a simple entity event bus store using a Map.
+ *
+ * @typeParam T - Event map type
+ * @returns A new EntityEventBusStore instance
+ *
+ * @example
+ * ```typescript
+ * import { createEntityEventBusStore, createEventBus } from 'blecsd';
+ *
+ * const store = createEntityEventBusStore();
+ * const eventBus = createEventBus();
+ *
+ * store.set(world, entity, eventBus);
+ * const retrieved = store.get(world, entity);
+ * ```
+ */
+export function createEntityEventBusStore<T extends EventMap>(): EntityEventBusStore<T> {
+	const buses = new Map<Entity, EventBus<T>>();
+
+	return {
+		get(_world: World, eid: Entity): EventBus<T> | undefined {
+			return buses.get(eid);
+		},
+		set(_world: World, eid: Entity, eventBus: EventBus<T>): void {
+			buses.set(eid, eventBus);
+		},
+		has(_world: World, eid: Entity): boolean {
+			return buses.has(eid);
+		},
+		delete(_world: World, eid: Entity): boolean {
+			return buses.delete(eid);
+		},
+		clear(): void {
+			buses.clear();
+		},
+	};
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -274,6 +274,19 @@ export {
 	createBubbleableEvent,
 	createEntityEventBusStore,
 } from './eventBubbling';
+// Event descendants
+export type {
+	EmitDescendantsOptions,
+	EmitDescendantsResult,
+	EntityEventBusStore,
+	GetEntityEventBus as GetEntityEventBusForDescendants,
+} from './eventDescendants';
+export {
+	createEntityEventBusStore as createEntityEventBusStoreForDescendants,
+	EmitDescendantsOptionsSchema,
+	EmitDescendantsResultSchema,
+	emitDescendants,
+} from './eventDescendants';
 // Event system
 export type { EventBus, EventHandler, EventMap, ScreenEventMap, UIEventMap } from './events';
 export { createEventBus } from './events';


### PR DESCRIPTION
## Summary
Implements recursive event emission down entity hierarchies, complementing the existing upward event bubbling system.

## Key Features
- Depth-first traversal of entity tree
- Optional `maxDepth` and `includeRoot` parameters
- Circular reference detection via visited Set
- Returns dispatch count, max depth, and circular reference flag
- `EntityEventBusStore` helper for managing entity event buses

## Implementation Details
- Uses hierarchy component's firstChild/nextSibling linked list structure
- Validates options with Zod schemas
- Pure functional design with explicit world parameter
- Comprehensive JSDoc with examples

## Testing
- 15 tests covering all features
- Tests for maxDepth limiting, includeRoot option, entities without buses
- Tests for deep hierarchies and different event types
- Tests for EntityEventBusStore helper

## Related
Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)