### PR TITLE
refactor: eliminate remaining 'this' keyword usage

### DIFF
--- a/src/terminal/process.test.ts
+++ b/src/terminal/process.test.ts
@@ -54,9 +54,9 @@ function createMockInput(): NodeJS.ReadStream & {
 		_rawMode: false,
 		isRaw: false,
 		setRawMode(mode: boolean) {
-			this._rawMode = mode;
-			this.isRaw = mode;
-			return this;
+			mock._rawMode = mode;
+			mock.isRaw = mode;
+			return mock;
 		},
 		on: vi.fn().mockReturnThis(),
 		once: vi.fn().mockReturnThis(),

--- a/src/terminal/suspend.test.ts
+++ b/src/terminal/suspend.test.ts
@@ -44,17 +44,17 @@ function createMockInput(): NodeJS.ReadStream & {
 		_paused: false,
 		isRaw: true,
 		setRawMode(mode: boolean) {
-			this._rawMode = mode;
-			this.isRaw = mode;
-			return this;
+			mock._rawMode = mode;
+			mock.isRaw = mode;
+			return mock;
 		},
 		pause() {
-			this._paused = true;
-			return this;
+			mock._paused = true;
+			return mock;
 		},
 		resume() {
-			this._paused = false;
-			return this;
+			mock._paused = false;
+			return mock;
 		},
 		on: vi.fn().mockReturnThis(),
 		once: vi.fn().mockReturnThis(),


### PR DESCRIPTION
Eliminates the final remaining \`this\` keyword usage from the codebase by fixing test mock objects in the terminal directory.

## Changes

### src/terminal/suspend.test.ts
- Replaced `this._rawMode`, `this.isRaw`, `this._paused` with `mock.*` closure references
- Methods now return `mock` instead of `this` for chaining

### src/terminal/process.test.ts
- Replaced `this._rawMode`, `this.isRaw` with `mock.*` closure references
- Methods now return `mock` instead of `this` for chaining

## Status

**All \`this\` keyword usage has been eliminated from the entire codebase.** The only remaining occurrences of "this" are in code comments (e.g., "before calling this" or "guards against this").

## Validation
- ✅ Tests: 10,840 passed
- ✅ Lint: Passing (pre-existing warnings only)
- ✅ Typecheck: Passing
- ✅ Build: Successful

## Issue
Closes #1096