### PR TITLE
perf: add z-order occlusion culling to skip hidden widgets

### DIFF
--- a/src/systems/index.ts
+++ b/src/systems/index.ts
@@ -238,6 +238,7 @@ export {
 	clearRenderBuffer,
 	createRenderSystem,
 	getRenderBuffer,
+	isOcclusionCullingEnabled,
 	markAllDirty,
 	renderBackground,
 	renderBorder,
@@ -246,6 +247,7 @@ export {
 	renderScrollbar,
 	renderSystem,
 	renderText,
+	setOcclusionCulling,
 	setRenderBuffer,
 } from './renderSystem';
 // Smooth scroll system


### PR DESCRIPTION
## Summary

Implements z-order occlusion culling in the render system to skip rendering entities that are completely hidden behind higher z-index entities. This reduces rendering cost for layered UIs like modals, dialogs, and overlays.

**Closes #1008**

## Implementation Details

- Added occlusion tracking structures (`OcclusionRect`) to track rendered regions per z-layer
- Entities are checked against occluded regions before rendering
- If fully contained within an occluded region, rendering is skipped and entity marked clean
- After rendering, opaque entities add their bounds to the occlusion list

## Design Decisions

- **Disabled by default** - Conservative approach to avoid breaking existing behavior
- **Opt-in via API** - Use `setOcclusionCulling(true)` to enable
- **Single-rect coverage** - Currently only checks if entity is fully contained in one occlusion rect (not multi-rect unions)
- **Helper function** - Extracted `processEntityWithOcclusion()` to reduce complexity

## API

```typescript
// Enable occlusion culling
setOcclusionCulling(true);

// Check if enabled
const enabled = isOcclusionCullingEnabled();

// Disable occlusion culling
setOcclusionCulling(false);
```

## Performance Impact

- Minimal overhead when disabled (default)
- Performance benefit when occlusion rate > ~10% (e.g., modals covering background)
- Best suited for UIs with significant overlapping widgets

## Testing

- All 10,940 tests pass
- Occlusion disabled by default to preserve existing behavior
- Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)