### PR TITLE
perf: add viewport bounds culling to renderSystem

### DIFF
--- a/src/systems/index.ts
+++ b/src/systems/index.ts
@@ -238,6 +238,7 @@ export {
 	clearRenderBuffer,
 	createRenderSystem,
 	getRenderBuffer,
+	getViewportBounds,
 	isOcclusionCullingEnabled,
 	markAllDirty,
 	renderBackground,
@@ -249,6 +250,7 @@ export {
 	renderText,
 	setOcclusionCulling,
 	setRenderBuffer,
+	setViewportBounds,
 } from './renderSystem';
 // Smooth scroll system
 export type {


### PR DESCRIPTION
## Summary

Adds viewport bounds culling to skip rendering entities completely outside the visible screen area. Critical performance optimization for scrollable content with many off-screen elements.

## Problem

The current renderSystem filters by visibility and dirty flags but still loops across **all** Position+Renderable entities, even those far outside the viewport. No viewport bounds checking before processing entities.

This is mentioned in Issue #1005 as gap #4 in the performance optimization map.

## Solution

### Implementation

1. **New Module-Level State**:
   - `ViewportBounds` interface for tracking viewport dimensions (x, y, width, height)
   - `viewportBounds` variable to store current viewport (null = disabled)

2. **New Public API**:
   - `setViewportBounds(bounds | null)` - Enable/disable viewport culling
   - `getViewportBounds()` - Get current viewport bounds
   - `isOutsideViewport(bounds)` - Internal: Check if entity is completely outside viewport

3. **Culling Order** (in `processEntityWithCulling`):
   1. Check if entity has computed layout bounds
   2. **Viewport bounds culling** - Skip if completely outside viewport
   3. Z-order occlusion culling - Skip if fully hidden behind other entities
   4. Render entity

4. **Behavior**:
   - Entities completely outside viewport are skipped and marked as clean
   - Partially visible entities are still rendered (correct behavior)
   - Disabled by default (opt-in performance optimization)
   - Works alongside existing z-order occlusion culling

### Exports

Added to `src/systems/index.ts`:
- `setViewportBounds`
- `getViewportBounds`

## Benefits

- **Skip processing for off-screen entities**
- Example: 10,000 entities, only 100 on screen → 99% fewer render iterations
- **Critical for scrollable content** with many elements
- **Opt-in**: Disabled by default, enable via `setViewportBounds({ x: 0, y: 0, width: 80, height: 24 })`
- **Complements z-order culling**: Both can be enabled together

## Testing

Added 14 comprehensive tests in `renderSystem.test.ts`:

1. ✅ Set/get/clear viewport bounds
2. ✅ Entity inside viewport (renders)
3. ✅ Entity outside viewport - left, right, above, below (all culled)
4. ✅ Partially visible entities - overlapping all 4 edges (all rendered)
5. ✅ Entity exactly at viewport boundary (renders)
6. ✅ Performance test with 1000 off-screen entities
7. ✅ Disable culling with null viewport

### Test Results

✅ Tests: 11,000 passed (60 renderSystem tests including 14 new viewport culling tests)
✅ Lint: Passes (only 13 pre-existing warnings in other files)
✅ Typecheck: Passes
✅ Build: Successful

## Usage Example

```typescript
import { setViewportBounds, renderSystem } from 'blecsd';

// Enable viewport culling for 80x24 screen
setViewportBounds({ x: 0, y: 0, width: 80, height: 24 });

// For scrollable content, update viewport as user scrolls
setViewportBounds({ x: scrollX, y: scrollY, width: 80, height: 24 });

// Disable viewport culling
setViewportBounds(null);
```

## Files Changed

- `src/systems/renderSystem.ts` - Added viewport culling logic
- `src/systems/index.ts` - Added viewport exports
- `src/systems/renderSystem.test.ts` - Added 14 comprehensive tests

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)