### PR TITLE
chore: fix bundle size monitoring script name

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "prepublishOnly": "pnpm run build:publish",
     "build:publish": "tsup --no-sourcemap --minify",
     "size": "size-limit",
-    "size:check": "size-limit --check",
+    "size:why": "size-limit --why",
     "verify-pack": "./scripts/verify-pack.sh",
     "doccheck": "tsx scripts/doccheck.ts"
   },


### PR DESCRIPTION
## Summary

Fixes bundle size monitoring script to use correct size-limit CLI flags.

Closes #1043

## Changes

Updated `size:check` script to `size:why` to match size-limit's actual CLI.

**Problem**: The `--check` flag doesn't exist in size-limit CLI.

**Solution**: 
- Default `size-limit` command already checks limits and exits with error if exceeded
- Changed `size:check` → `size:why` to use the `--why` flag for bundle analysis

## Bundle Size Status

size-limit is already configured and actively monitoring 3 key bundles:

| Bundle | Current Size | Limit | Headroom |
|--------|-------------|-------|----------|
| **dist/index.js** | 244.69 KB | 500 KB | ✅ 51% under |
| **dist/core/index.js** | 86.58 KB | 100 KB | ✅ 13% under |
| **dist/components/index.js** | 89.8 KB | 200 KB | ✅ 55% under |

All bundles are well under their limits with healthy headroom for growth.

## Scripts Available

```bash
pnpm size        # Check bundle sizes against limits (fails if over)
pnpm size:why    # Analyze what's in each bundle (--why flag)
```

## Configuration

Bundle limits are defined in `package.json` under the `size-limit` array:

```json
{
  "size-limit": [
    {
      "path": "dist/index.js",
      "limit": "500 KB",
      "ignore": ["fs", "path", "os", ...]  // Node.js built-ins
    },
    ...
  ]
}
```

The `ignore` list excludes Node.js built-in modules from bundle size calculations since they don't contribute to actual download size.

## Validation

```bash
✅ pnpm test        # 11,162 tests passed
✅ pnpm lint        # 13 warnings (pre-existing)
✅ pnpm typecheck   # success
✅ pnpm build       # success
✅ pnpm size        # all bundles under limits
```

## How It Works

- **CI Integration**: Run `pnpm size` in CI to enforce bundle size limits
- **Local Development**: Use `pnpm size:why` to analyze what's contributing to bundle size
- **Automatic Failure**: If any bundle exceeds its limit, `pnpm size` exits with error code

🤖 Generated with [Claude Code](https://claude.com/claude-code)