### PR TITLE
feat: add basic syntax highlighting for terminal code display

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -11,3 +11,16 @@ export {
 	renderMarkup,
 	stripMarkup,
 } from './markup';
+
+export type {
+	HighlightColors,
+	HighlightConfig,
+	SupportedLanguage,
+	// Note: TokenType not exported to avoid conflict with utils/syntaxHighlight
+} from './syntaxHighlight';
+export {
+	DEFAULT_COLORS,
+	HighlightConfigSchema,
+	highlightCode,
+	stripHighlight,
+} from './syntaxHighlight';

--- a/src/text/syntaxHighlight.test.ts
+++ b/src/text/syntaxHighlight.test.ts
@@ -1,0 +1,428 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DEFAULT_COLORS,
+	type HighlightConfig,
+	HighlightConfigSchema,
+	highlightCode,
+	stripHighlight,
+} from './syntaxHighlight';
+
+describe('syntaxHighlight', () => {
+	describe('HighlightConfigSchema', () => {
+		it('validates valid config', () => {
+			const config: HighlightConfig = {
+				colors: {
+					keyword: '\x1b[31m',
+					string: '\x1b[32m',
+				},
+				enabled: true,
+			};
+			expect(() => HighlightConfigSchema.parse(config)).not.toThrow();
+		});
+
+		it('validates empty config', () => {
+			expect(() => HighlightConfigSchema.parse({})).not.toThrow();
+		});
+
+		it('validates partial colors', () => {
+			const config = {
+				colors: {
+					keyword: '\x1b[31m',
+				},
+			};
+			expect(() => HighlightConfigSchema.parse(config)).not.toThrow();
+		});
+	});
+
+	describe('highlightCode - JavaScript', () => {
+		it('highlights keywords', () => {
+			const code = 'const x = 1;';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.keyword); // 'const'
+			expect(result).toContain(DEFAULT_COLORS.number); // '1'
+		});
+
+		it('highlights strings', () => {
+			const code = 'const str = "hello";';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.string);
+		});
+
+		it('highlights single-quoted strings', () => {
+			const code = "const str = 'hello';";
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.string);
+		});
+
+		it('highlights template strings', () => {
+			const code = 'const str = `hello`;';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.string);
+		});
+
+		it('highlights numbers', () => {
+			const code = 'const x = 123;';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.number);
+		});
+
+		it('highlights hex numbers', () => {
+			const code = 'const x = 0xff;';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.number);
+		});
+
+		it('highlights floating point numbers', () => {
+			const code = 'const x = 3.14;';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.number);
+		});
+
+		it('highlights single-line comments', () => {
+			const code = '// This is a comment';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.comment);
+		});
+
+		it('highlights multi-line comments', () => {
+			const code = '/* This is\na comment */';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.comment);
+		});
+
+		it('highlights function calls', () => {
+			const code = 'console.log("test");';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.function);
+		});
+
+		it('highlights constants', () => {
+			const code = 'const x = true;';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.constant); // 'true'
+		});
+
+		it('highlights null and undefined', () => {
+			const code = 'const x = null; const y = undefined;';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.constant);
+		});
+
+		it('highlights operators', () => {
+			const code = 'const x = 1 + 2;';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.operator);
+		});
+
+		it('highlights punctuation', () => {
+			const code = 'const obj = { x: 1 };';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.punctuation);
+		});
+
+		it('handles escaped strings', () => {
+			const code = 'const str = "hello\\"world";';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.string);
+		});
+
+		it('handles complete function', () => {
+			const code = `function greet(name) {
+  return "Hello, " + name;
+}`;
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.keyword); // 'function', 'return'
+			expect(result).toContain(DEFAULT_COLORS.string);
+			expect(result).toContain(DEFAULT_COLORS.operator);
+		});
+	});
+
+	describe('highlightCode - TypeScript', () => {
+		it('highlights TypeScript keywords', () => {
+			const code = 'interface User { name: string; }';
+			const result = highlightCode(code, 'typescript');
+			expect(result).toContain(DEFAULT_COLORS.keyword); // 'interface'
+		});
+
+		it('highlights type annotations', () => {
+			const code = 'const x: number = 1;';
+			const result = highlightCode(code, 'typescript');
+			expect(result).toContain(DEFAULT_COLORS.keyword); // 'const'
+			expect(result).toContain(DEFAULT_COLORS.number);
+		});
+
+		it('highlights TypeScript-specific keywords', () => {
+			const code = 'type MyType = string | number;';
+			const result = highlightCode(code, 'typescript');
+			expect(result).toContain(DEFAULT_COLORS.keyword); // 'type'
+		});
+	});
+
+	describe('highlightCode - JSON', () => {
+		it('highlights property keys', () => {
+			const code = '{"name": "value"}';
+			const result = highlightCode(code, 'json');
+			expect(result).toContain(DEFAULT_COLORS.property); // "name"
+		});
+
+		it('highlights string values', () => {
+			const code = '{"key": "value"}';
+			const result = highlightCode(code, 'json');
+			expect(result).toContain(DEFAULT_COLORS.string); // "value"
+		});
+
+		it('highlights numbers', () => {
+			const code = '{"count": 123}';
+			const result = highlightCode(code, 'json');
+			expect(result).toContain(DEFAULT_COLORS.number);
+		});
+
+		it('highlights negative numbers', () => {
+			const code = '{"temp": -5}';
+			const result = highlightCode(code, 'json');
+			expect(result).toContain(DEFAULT_COLORS.number);
+		});
+
+		it('highlights floating point numbers', () => {
+			const code = '{"pi": 3.14}';
+			const result = highlightCode(code, 'json');
+			expect(result).toContain(DEFAULT_COLORS.number);
+		});
+
+		it('highlights booleans', () => {
+			const code = '{"active": true}';
+			const result = highlightCode(code, 'json');
+			expect(result).toContain(DEFAULT_COLORS.constant); // 'true'
+		});
+
+		it('highlights null', () => {
+			const code = '{"data": null}';
+			const result = highlightCode(code, 'json');
+			expect(result).toContain(DEFAULT_COLORS.constant); // 'null'
+		});
+
+		it('highlights punctuation', () => {
+			const code = '{"a": [1, 2, 3]}';
+			const result = highlightCode(code, 'json');
+			expect(result).toContain(DEFAULT_COLORS.punctuation);
+		});
+
+		it('handles nested objects', () => {
+			const code = '{"user": {"name": "Alice", "age": 30}}';
+			const result = highlightCode(code, 'json');
+			expect(result).toContain(DEFAULT_COLORS.property);
+			expect(result).toContain(DEFAULT_COLORS.string);
+			expect(result).toContain(DEFAULT_COLORS.number);
+		});
+
+		it('handles arrays', () => {
+			const code = '{"items": [1, 2, 3]}';
+			const result = highlightCode(code, 'json');
+			expect(result).toContain(DEFAULT_COLORS.number);
+			expect(result).toContain(DEFAULT_COLORS.punctuation);
+		});
+
+		it('handles escaped strings', () => {
+			const code = '{"text": "hello\\"world"}';
+			const result = highlightCode(code, 'json');
+			expect(result).toContain(DEFAULT_COLORS.string);
+		});
+	});
+
+	describe('highlightCode - Bash', () => {
+		it('highlights bash keywords', () => {
+			const code = 'if [ -f file ]; then echo "exists"; fi';
+			const result = highlightCode(code, 'bash');
+			expect(result).toContain(DEFAULT_COLORS.keyword); // 'if', 'then', 'fi'
+		});
+
+		it('highlights strings', () => {
+			const code = 'echo "hello world"';
+			const result = highlightCode(code, 'bash');
+			expect(result).toContain(DEFAULT_COLORS.string);
+		});
+
+		it('highlights single-quoted strings', () => {
+			const code = "echo 'hello world'";
+			const result = highlightCode(code, 'bash');
+			expect(result).toContain(DEFAULT_COLORS.string);
+		});
+
+		it('highlights variables', () => {
+			const code = 'echo $USER';
+			const result = highlightCode(code, 'bash');
+			expect(result).toContain(DEFAULT_COLORS.variable);
+		});
+
+		it('highlights braced variables', () => {
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: Testing bash variable syntax
+			const code = 'echo ${USER}';
+			const result = highlightCode(code, 'bash');
+			expect(result).toContain(DEFAULT_COLORS.variable);
+		});
+
+		it('highlights comments', () => {
+			const code = '# This is a comment';
+			const result = highlightCode(code, 'bash');
+			expect(result).toContain(DEFAULT_COLORS.comment);
+		});
+
+		it('highlights numbers', () => {
+			const code = 'count=42';
+			const result = highlightCode(code, 'bash');
+			expect(result).toContain(DEFAULT_COLORS.number);
+		});
+
+		it('highlights operators', () => {
+			const code = 'cmd1 | cmd2';
+			const result = highlightCode(code, 'bash');
+			expect(result).toContain(DEFAULT_COLORS.operator);
+		});
+
+		it('highlights redirects', () => {
+			const code = 'echo "test" > file.txt';
+			const result = highlightCode(code, 'bash');
+			expect(result).toContain(DEFAULT_COLORS.operator); // '>'
+		});
+
+		it('handles loops', () => {
+			const code = 'for i in 1 2 3; do echo $i; done';
+			const result = highlightCode(code, 'bash');
+			expect(result).toContain(DEFAULT_COLORS.keyword); // 'for', 'in', 'do', 'done'
+			expect(result).toContain(DEFAULT_COLORS.variable); // '$i'
+		});
+
+		it('handles escaped strings', () => {
+			const code = 'echo "hello\\"world"';
+			const result = highlightCode(code, 'bash');
+			expect(result).toContain(DEFAULT_COLORS.string);
+		});
+	});
+
+	describe('highlightCode - language aliases', () => {
+		it('treats "shell" as bash', () => {
+			const code = 'echo $USER';
+			const shellResult = highlightCode(code, 'shell');
+			const bashResult = highlightCode(code, 'bash');
+			expect(stripHighlight(shellResult)).toBe(stripHighlight(bashResult));
+		});
+
+		it('treats "sh" as bash', () => {
+			const code = 'echo $USER';
+			const shResult = highlightCode(code, 'sh');
+			const bashResult = highlightCode(code, 'bash');
+			expect(stripHighlight(shResult)).toBe(stripHighlight(bashResult));
+		});
+	});
+
+	describe('highlightCode - configuration', () => {
+		it('uses custom colors', () => {
+			const code = 'const x = 1;';
+			const customColor = '\x1b[31m'; // Red
+			const result = highlightCode(code, 'javascript', {
+				colors: {
+					keyword: customColor,
+				},
+			});
+			expect(result).toContain(customColor);
+		});
+
+		it('merges custom colors with defaults', () => {
+			const code = 'const str = "hello";';
+			const customKeyword = '\x1b[31m';
+			const result = highlightCode(code, 'javascript', {
+				colors: {
+					keyword: customKeyword,
+				},
+			});
+			expect(result).toContain(customKeyword); // Custom keyword color
+			expect(result).toContain(DEFAULT_COLORS.string); // Default string color
+		});
+
+		it('disables highlighting when enabled=false', () => {
+			const code = 'const x = 1;';
+			const result = highlightCode(code, 'javascript', {
+				enabled: false,
+			});
+			expect(result).toBe(code);
+			expect(result).not.toContain('\x1b[');
+		});
+	});
+
+	describe('highlightCode - unsupported languages', () => {
+		it('returns code as-is for unsupported language', () => {
+			const code = 'some random code';
+			const result = highlightCode(code, 'unknown' as never);
+			expect(result).toBe(code);
+		});
+	});
+
+	describe('stripHighlight', () => {
+		it('removes ANSI color codes', () => {
+			const highlighted = '\x1b[31mred text\x1b[0m normal';
+			const result = stripHighlight(highlighted);
+			expect(result).toBe('red text normal');
+		});
+
+		it('removes multiple color codes', () => {
+			const highlighted = '\x1b[31mred\x1b[0m \x1b[32mgreen\x1b[0m \x1b[34mblue\x1b[0m';
+			const result = stripHighlight(highlighted);
+			expect(result).toBe('red green blue');
+		});
+
+		it('handles code without color codes', () => {
+			const code = 'plain text';
+			const result = stripHighlight(code);
+			expect(result).toBe(code);
+		});
+
+		it('removes 256-color codes', () => {
+			const highlighted = '\x1b[38;5;175mtext\x1b[0m';
+			const result = stripHighlight(highlighted);
+			expect(result).toBe('text');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('handles empty code', () => {
+			const result = highlightCode('', 'javascript');
+			expect(result).toBe('');
+		});
+
+		it('handles code with only whitespace', () => {
+			const code = '   \n\t';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toBe(code);
+		});
+
+		it('handles unclosed strings', () => {
+			const code = 'const str = "unclosed';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.string);
+		});
+
+		it('handles unclosed comments', () => {
+			const code = '/* unclosed comment';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.comment);
+		});
+
+		it('handles special characters in strings', () => {
+			const code = 'const str = "\\n\\t\\r";';
+			const result = highlightCode(code, 'javascript');
+			expect(result).toContain(DEFAULT_COLORS.string);
+		});
+
+		it('preserves whitespace', () => {
+			const code = 'const  x  =  1;';
+			const result = stripHighlight(highlightCode(code, 'javascript'));
+			expect(result).toBe(code);
+		});
+
+		it('preserves newlines', () => {
+			const code = 'const x = 1;\nconst y = 2;';
+			const result = stripHighlight(highlightCode(code, 'javascript'));
+			expect(result).toBe(code);
+		});
+	});
+});

--- a/src/text/syntaxHighlight.ts
+++ b/src/text/syntaxHighlight.ts
@@ -1,0 +1,791 @@
+/**
+ * Syntax highlighting for terminal code display
+ *
+ * Provides basic syntax highlighting using ANSI color codes for common languages.
+ * Supports JavaScript/TypeScript, JSON, and Bash.
+ *
+ * @module text/syntaxHighlight
+ */
+
+import { z } from 'zod';
+
+// =============================================================================
+// TYPES & SCHEMAS
+// =============================================================================
+
+/**
+ * Supported programming languages for syntax highlighting.
+ */
+export type SupportedLanguage = 'javascript' | 'typescript' | 'json' | 'bash' | 'shell' | 'sh';
+
+/**
+ * Token types for syntax highlighting.
+ */
+export type TokenType =
+	| 'keyword'
+	| 'string'
+	| 'number'
+	| 'comment'
+	| 'operator'
+	| 'punctuation'
+	| 'identifier'
+	| 'function'
+	| 'constant'
+	| 'property'
+	| 'variable';
+
+/**
+ * Color configuration for syntax highlighting.
+ */
+export interface HighlightColors {
+	/** Color for keywords (if, const, function, etc.) */
+	readonly keyword: string;
+	/** Color for string literals */
+	readonly string: string;
+	/** Color for numeric literals */
+	readonly number: string;
+	/** Color for comments */
+	readonly comment: string;
+	/** Color for operators (+, -, *, etc.) */
+	readonly operator: string;
+	/** Color for punctuation ({}, [], (), etc.) */
+	readonly punctuation: string;
+	/** Color for identifiers */
+	readonly identifier: string;
+	/** Color for function names */
+	readonly function: string;
+	/** Color for constants (true, false, null, etc.) */
+	readonly constant: string;
+	/** Color for object properties */
+	readonly property: string;
+	/** Color for variables */
+	readonly variable: string;
+}
+
+/**
+ * Syntax highlighting configuration.
+ */
+export interface HighlightConfig {
+	/** Color scheme for token types */
+	readonly colors?: Partial<HighlightColors>;
+	/** Whether to enable syntax highlighting (default: true) */
+	readonly enabled?: boolean;
+}
+
+/**
+ * Zod schema for highlight configuration.
+ */
+export const HighlightConfigSchema = z.object({
+	colors: z
+		.object({
+			keyword: z.string().optional(),
+			string: z.string().optional(),
+			number: z.string().optional(),
+			comment: z.string().optional(),
+			operator: z.string().optional(),
+			punctuation: z.string().optional(),
+			identifier: z.string().optional(),
+			function: z.string().optional(),
+			constant: z.string().optional(),
+			property: z.string().optional(),
+			variable: z.string().optional(),
+		})
+		.optional(),
+	enabled: z.boolean().optional(),
+});
+
+// =============================================================================
+// DEFAULT COLORS
+// =============================================================================
+
+/**
+ * Default color scheme (inspired by popular themes).
+ * Uses ANSI 256-color codes for better terminal compatibility.
+ */
+export const DEFAULT_COLORS: HighlightColors = {
+	keyword: '\x1b[38;5;175m', // Purple
+	string: '\x1b[38;5;150m', // Green
+	number: '\x1b[38;5;180m', // Orange
+	comment: '\x1b[38;5;245m', // Gray
+	operator: '\x1b[38;5;180m', // Orange
+	punctuation: '\x1b[38;5;248m', // Light gray
+	identifier: '\x1b[38;5;255m', // White
+	function: '\x1b[38;5;117m', // Light blue
+	constant: '\x1b[38;5;209m', // Light red
+	property: '\x1b[38;5;117m', // Light blue
+	variable: '\x1b[38;5;255m', // White
+};
+
+const RESET = '\x1b[0m';
+
+// =============================================================================
+// TOKEN PATTERNS
+// =============================================================================
+
+/**
+ * JavaScript/TypeScript keywords.
+ */
+const JS_KEYWORDS = new Set([
+	'async',
+	'await',
+	'break',
+	'case',
+	'catch',
+	'class',
+	'const',
+	'continue',
+	'debugger',
+	'default',
+	'delete',
+	'do',
+	'else',
+	'export',
+	'extends',
+	'finally',
+	'for',
+	'function',
+	'if',
+	'import',
+	'in',
+	'instanceof',
+	'let',
+	'new',
+	'return',
+	'static',
+	'super',
+	'switch',
+	'this',
+	'throw',
+	'try',
+	'typeof',
+	'var',
+	'void',
+	'while',
+	'with',
+	'yield',
+	// TypeScript
+	'interface',
+	'type',
+	'enum',
+	'namespace',
+	'module',
+	'declare',
+	'abstract',
+	'implements',
+	'private',
+	'protected',
+	'public',
+	'readonly',
+	'as',
+	'from',
+	'of',
+]);
+
+/**
+ * JavaScript/TypeScript constants.
+ */
+const JS_CONSTANTS = new Set(['true', 'false', 'null', 'undefined', 'NaN', 'Infinity']);
+
+/**
+ * Bash keywords.
+ */
+const BASH_KEYWORDS = new Set([
+	'if',
+	'then',
+	'else',
+	'elif',
+	'fi',
+	'case',
+	'esac',
+	'for',
+	'while',
+	'until',
+	'do',
+	'done',
+	'in',
+	'function',
+	'time',
+	'return',
+	'exit',
+	'break',
+	'continue',
+	'local',
+	'readonly',
+	'export',
+	'declare',
+	'typeset',
+	'eval',
+	'exec',
+	'source',
+	'alias',
+	'unalias',
+]);
+
+// =============================================================================
+// HIGHLIGHTING FUNCTIONS
+// =============================================================================
+
+/**
+ * Highlights a single-line comment in JavaScript/TypeScript.
+ */
+function highlightJSLineComment(
+	code: string,
+	start: number,
+	colors: HighlightColors,
+): [string, number] {
+	const end = code.indexOf('\n', start);
+	const comment = end === -1 ? code.slice(start) : code.slice(start, end);
+	return [colors.comment + comment + RESET, start + comment.length];
+}
+
+/**
+ * Highlights a multi-line comment in JavaScript/TypeScript.
+ */
+function highlightJSMultiLineComment(
+	code: string,
+	start: number,
+	colors: HighlightColors,
+): [string, number] {
+	const end = code.indexOf('*/', start + 2);
+	const comment = end === -1 ? code.slice(start) : code.slice(start, end + 2);
+	return [colors.comment + comment + RESET, start + comment.length];
+}
+
+/**
+ * Highlights a string literal in JavaScript/TypeScript.
+ */
+function highlightJSString(
+	code: string,
+	start: number,
+	quote: string,
+	colors: HighlightColors,
+): [string, number] {
+	let j = start + 1;
+	let escaped = false;
+
+	while (j < code.length) {
+		if (escaped) {
+			escaped = false;
+			j++;
+			continue;
+		}
+		if (code[j] === '\\') {
+			escaped = true;
+			j++;
+			continue;
+		}
+		if (code[j] === quote) {
+			j++;
+			break;
+		}
+		j++;
+	}
+
+	return [colors.string + code.slice(start, j) + RESET, j];
+}
+
+/**
+ * Highlights a number in JavaScript/TypeScript.
+ */
+function highlightJSNumber(code: string, start: number, colors: HighlightColors): [string, number] {
+	let j = start;
+	// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+	while (j < code.length && /[\d.xXeEabcdefABCDEF_]/.test(code[j]!)) {
+		j++;
+	}
+	return [colors.number + code.slice(start, j) + RESET, j];
+}
+
+/**
+ * Highlights an identifier, keyword, or constant in JavaScript/TypeScript.
+ */
+function highlightJSWord(code: string, start: number, colors: HighlightColors): [string, number] {
+	let j = start;
+	// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+	while (j < code.length && /[a-zA-Z0-9_$]/.test(code[j]!)) {
+		j++;
+	}
+	const word = code.slice(start, j);
+
+	let colored: string;
+	if (JS_KEYWORDS.has(word)) {
+		colored = colors.keyword + word + RESET;
+	} else if (JS_CONSTANTS.has(word)) {
+		colored = colors.constant + word + RESET;
+	} else if (j < code.length && code[j] === '(') {
+		colored = colors.function + word + RESET;
+	} else {
+		colored = colors.identifier + word + RESET;
+	}
+
+	return [colored, j];
+}
+
+/**
+ * Highlights an operator in JavaScript/TypeScript.
+ */
+function highlightJSOperator(
+	code: string,
+	start: number,
+	colors: HighlightColors,
+): [string, number] {
+	let j = start + 1;
+	// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+	while (j < code.length && /[+\-*/%&|^~<>=!]/.test(code[j]!)) {
+		j++;
+	}
+	return [colors.operator + code.slice(start, j) + RESET, j];
+}
+
+/**
+ * Highlights JavaScript/TypeScript code.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Token parsing requires sequential checks
+function highlightJavaScript(code: string, colors: HighlightColors): string {
+	let result = '';
+	let i = 0;
+
+	while (i < code.length) {
+		// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+		const char = code[i]!;
+
+		// Comments
+		if (char === '/' && i + 1 < code.length) {
+			if (code[i + 1] === '/') {
+				const [colored, newPos] = highlightJSLineComment(code, i, colors);
+				result += colored;
+				i = newPos;
+				continue;
+			}
+			if (code[i + 1] === '*') {
+				const [colored, newPos] = highlightJSMultiLineComment(code, i, colors);
+				result += colored;
+				i = newPos;
+				continue;
+			}
+		}
+
+		// Strings
+		if (char === '"' || char === "'" || char === '`') {
+			const [colored, newPos] = highlightJSString(code, i, char, colors);
+			result += colored;
+			i = newPos;
+			continue;
+		}
+
+		// Numbers
+		if (/\d/.test(char)) {
+			const [colored, newPos] = highlightJSNumber(code, i, colors);
+			result += colored;
+			i = newPos;
+			continue;
+		}
+
+		// Keywords, identifiers, and constants
+		if (/[a-zA-Z_$]/.test(char)) {
+			const [colored, newPos] = highlightJSWord(code, i, colors);
+			result += colored;
+			i = newPos;
+			continue;
+		}
+
+		// Operators
+		if (/[+\-*/%&|^~<>=!]/.test(char)) {
+			const [colored, newPos] = highlightJSOperator(code, i, colors);
+			result += colored;
+			i = newPos;
+			continue;
+		}
+
+		// Punctuation
+		if (/[{}[\]();:,.]/.test(char)) {
+			result += colors.punctuation + char + RESET;
+			i++;
+			continue;
+		}
+
+		// Whitespace and other characters
+		result += char;
+		i++;
+	}
+
+	return result;
+}
+
+/**
+ * Highlights a string in JSON (property key or value).
+ */
+function highlightJSONString(
+	code: string,
+	start: number,
+	colors: HighlightColors,
+): [string, number] {
+	let j = start + 1;
+	let escaped = false;
+
+	while (j < code.length) {
+		if (escaped) {
+			escaped = false;
+			j++;
+			continue;
+		}
+		if (code[j] === '\\') {
+			escaped = true;
+			j++;
+			continue;
+		}
+		if (code[j] === '"') {
+			j++;
+			break;
+		}
+		j++;
+	}
+
+	const string = code.slice(start, j);
+	// Check if this is a property key (followed by :)
+	let k = j;
+	// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+	while (k < code.length && /\s/.test(code[k]!)) k++;
+	const isProperty = k < code.length && code[k] === ':';
+	const colored = isProperty ? colors.property + string + RESET : colors.string + string + RESET;
+
+	return [colored, j];
+}
+
+/**
+ * Highlights JSON code.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Token parsing requires sequential checks
+function highlightJSON(code: string, colors: HighlightColors): string {
+	let result = '';
+	let i = 0;
+
+	while (i < code.length) {
+		// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+		const char = code[i]!;
+
+		// Strings (keys and values)
+		if (char === '"') {
+			const [colored, newPos] = highlightJSONString(code, i, colors);
+			result += colored;
+			i = newPos;
+			continue;
+		}
+
+		// Numbers
+		if (/[\d-]/.test(char)) {
+			let j = i;
+			if (char === '-') j++;
+			// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+			while (j < code.length && /[\d.eE+-]/.test(code[j]!)) {
+				j++;
+			}
+			// Verify it's actually a number
+			if (j > i && (j === i + 1 ? char !== '-' : true)) {
+				const number = code.slice(i, j);
+				result += colors.number + number + RESET;
+				i = j;
+				continue;
+			}
+		}
+
+		// Constants (true, false, null)
+		if (/[a-z]/.test(char)) {
+			let j = i;
+			// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+			while (j < code.length && /[a-z]/.test(code[j]!)) {
+				j++;
+			}
+			const word = code.slice(i, j);
+			if (word === 'true' || word === 'false' || word === 'null') {
+				result += colors.constant + word + RESET;
+				i = j;
+				continue;
+			}
+		}
+
+		// Punctuation
+		if (/[{}[\]:,]/.test(char)) {
+			result += colors.punctuation + char + RESET;
+			i++;
+			continue;
+		}
+
+		// Whitespace and other characters
+		result += char;
+		i++;
+	}
+
+	return result;
+}
+
+/**
+ * Highlights a string in Bash.
+ */
+function highlightBashString(
+	code: string,
+	start: number,
+	quote: string,
+	colors: HighlightColors,
+): [string, number] {
+	let j = start + 1;
+	let escaped = false;
+
+	while (j < code.length) {
+		if (escaped) {
+			escaped = false;
+			j++;
+			continue;
+		}
+		if (code[j] === '\\') {
+			escaped = true;
+			j++;
+			continue;
+		}
+		if (code[j] === quote) {
+			j++;
+			break;
+		}
+		j++;
+	}
+
+	return [colors.string + code.slice(start, j) + RESET, j];
+}
+
+/**
+ * Highlights a variable in Bash.
+ */
+function highlightBashVariable(
+	code: string,
+	start: number,
+	colors: HighlightColors,
+): [string, number] | null {
+	let j = start + 1;
+	if (j < code.length && code[j] === '{') {
+		// ${VAR} form
+		const end = code.indexOf('}', j);
+		if (end !== -1) {
+			return [colors.variable + code.slice(start, end + 1) + RESET, end + 1];
+		}
+	} else {
+		// $VAR form
+		// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+		while (j < code.length && /[a-zA-Z0-9_]/.test(code[j]!)) {
+			j++;
+		}
+		if (j > start + 1) {
+			return [colors.variable + code.slice(start, j) + RESET, j];
+		}
+	}
+	return null;
+}
+
+/**
+ * Highlights Bash/shell script code.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Token parsing requires sequential checks
+function highlightBash(code: string, colors: HighlightColors): string {
+	let result = '';
+	let i = 0;
+
+	while (i < code.length) {
+		// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+		const char = code[i]!;
+
+		// Comments
+		if (char === '#') {
+			const end = code.indexOf('\n', i);
+			const comment = end === -1 ? code.slice(i) : code.slice(i, end);
+			result += colors.comment + comment + RESET;
+			i += comment.length;
+			continue;
+		}
+
+		// Strings (single and double quoted)
+		if (char === '"' || char === "'") {
+			const [colored, newPos] = highlightBashString(code, i, char, colors);
+			result += colored;
+			i = newPos;
+			continue;
+		}
+
+		// Variables ($VAR, ${VAR})
+		if (char === '$') {
+			const varResult = highlightBashVariable(code, i, colors);
+			if (varResult) {
+				const [colored, newPos] = varResult;
+				result += colored;
+				i = newPos;
+				continue;
+			}
+		}
+
+		// Numbers
+		if (/\d/.test(char)) {
+			let j = i;
+			// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+			while (j < code.length && /\d/.test(code[j]!)) {
+				j++;
+			}
+			const number = code.slice(i, j);
+			result += colors.number + number + RESET;
+			i = j;
+			continue;
+		}
+
+		// Keywords and commands
+		if (/[a-zA-Z_]/.test(char)) {
+			let j = i;
+			// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+			while (j < code.length && /[a-zA-Z0-9_-]/.test(code[j]!)) {
+				j++;
+			}
+			const word = code.slice(i, j);
+
+			if (BASH_KEYWORDS.has(word)) {
+				result += colors.keyword + word + RESET;
+			} else {
+				result += colors.identifier + word + RESET;
+			}
+			i = j;
+			continue;
+		}
+
+		// Operators and redirects
+		if (/[|&;<>]/.test(char)) {
+			let j = i + 1;
+			// biome-ignore lint/style/noNonNullAssertion: Guarded by length check
+			while (j < code.length && /[|&;<>]/.test(code[j]!)) {
+				j++;
+			}
+			const op = code.slice(i, j);
+			result += colors.operator + op + RESET;
+			i = j;
+			continue;
+		}
+
+		// Punctuation
+		if (/[{}[\]();]/.test(char)) {
+			result += colors.punctuation + char + RESET;
+			i++;
+			continue;
+		}
+
+		// Whitespace and other characters
+		result += char;
+		i++;
+	}
+
+	return result;
+}
+
+// =============================================================================
+// PUBLIC API
+// =============================================================================
+
+/**
+ * Highlights code with syntax coloring for terminal display.
+ *
+ * @param code - The source code to highlight
+ * @param language - The programming language (javascript, typescript, json, bash, shell, sh)
+ * @param config - Optional configuration for colors and settings
+ * @returns The highlighted code with ANSI color codes
+ *
+ * @example
+ * ```typescript
+ * import { highlightCode } from 'blecsd';
+ *
+ * // Highlight JavaScript code
+ * const jsCode = `
+ * function greet(name) {
+ *   return \`Hello, \${name}!\`;
+ * }
+ * `;
+ * const highlighted = highlightCode(jsCode, 'javascript');
+ * console.log(highlighted);
+ *
+ * // Highlight with custom colors
+ * const customHighlighted = highlightCode(jsCode, 'javascript', {
+ *   colors: {
+ *     keyword: '\x1b[31m', // Red keywords
+ *     string: '\x1b[32m',  // Green strings
+ *   }
+ * });
+ *
+ * // Highlight JSON
+ * const jsonCode = '{"name": "blECSd", "version": "0.2.0"}';
+ * const jsonHighlighted = highlightCode(jsonCode, 'json');
+ *
+ * // Highlight Bash
+ * const bashCode = 'echo "Hello, $USER!"';
+ * const bashHighlighted = highlightCode(bashCode, 'bash');
+ * ```
+ */
+export function highlightCode(
+	code: string,
+	language: SupportedLanguage,
+	config: HighlightConfig = {},
+): string {
+	// Validate config
+	const validatedConfig = HighlightConfigSchema.parse(config);
+
+	// If disabled, return code as-is
+	if (validatedConfig.enabled === false) {
+		return code;
+	}
+
+	// Merge colors with defaults (filter out undefined values)
+	const customColors = validatedConfig.colors ?? {};
+	const colors: HighlightColors = {
+		keyword: customColors.keyword ?? DEFAULT_COLORS.keyword,
+		string: customColors.string ?? DEFAULT_COLORS.string,
+		number: customColors.number ?? DEFAULT_COLORS.number,
+		comment: customColors.comment ?? DEFAULT_COLORS.comment,
+		operator: customColors.operator ?? DEFAULT_COLORS.operator,
+		punctuation: customColors.punctuation ?? DEFAULT_COLORS.punctuation,
+		identifier: customColors.identifier ?? DEFAULT_COLORS.identifier,
+		function: customColors.function ?? DEFAULT_COLORS.function,
+		constant: customColors.constant ?? DEFAULT_COLORS.constant,
+		property: customColors.property ?? DEFAULT_COLORS.property,
+		variable: customColors.variable ?? DEFAULT_COLORS.variable,
+	};
+
+	// Normalize language
+	const lang = language.toLowerCase();
+
+	// Apply highlighting based on language
+	switch (lang) {
+		case 'javascript':
+		case 'typescript':
+			return highlightJavaScript(code, colors);
+		case 'json':
+			return highlightJSON(code, colors);
+		case 'bash':
+		case 'shell':
+		case 'sh':
+			return highlightBash(code, colors);
+		default:
+			// Unsupported language, return as-is
+			return code;
+	}
+}
+
+/**
+ * Strips ANSI color codes from highlighted code.
+ *
+ * @param code - The code with ANSI color codes
+ * @returns The code without color codes
+ *
+ * @example
+ * ```typescript
+ * import { highlightCode, stripHighlight } from 'blecsd';
+ *
+ * const highlighted = highlightCode('const x = 1;', 'javascript');
+ * const plain = stripHighlight(highlighted);
+ * console.log(plain); // 'const x = 1;'
+ * ```
+ */
+export function stripHighlight(code: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: Need to match ANSI escape codes
+	return code.replace(/\x1b\[[0-9;]*m/g, '');
+}


### PR DESCRIPTION
## Summary

Implements basic syntax highlighting for terminal code display with support for JS/TS, JSON, and Bash.

## Changes

- Added `highlightCode(code, language, config)` function with full JSDoc
- Supports: `javascript`, `typescript`, `json`, `bash`, `shell`, `sh`
- Token types: keyword, string, number, comment, operator, punctuation, identifier, function, constant, property, variable
- Configurable colors via Zod-validated `HighlightConfig`
- Helper function `stripHighlight()` to remove ANSI codes
- 61 comprehensive tests covering all languages and edge cases

## Test Results

- ✅ All 61 tests passing
- ✅ Lint clean (no new warnings)
- ✅ Type check passing
- ✅ Build successful

Closes #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)