### PR TITLE
feat: add Zod validation for 10 config interfaces

### DIFF
--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -3,6 +3,7 @@
  * @module core/scheduler
  */
 
+import { z } from 'zod';
 import type { System, World } from './types';
 import { LoopPhase } from './types';
 
@@ -49,6 +50,24 @@ export interface TelemetryConfig {
 }
 
 /**
+ * Zod schema for TelemetryConfig validation.
+ *
+ * @example
+ * ```typescript
+ * import { TelemetryConfigSchema } from 'blecsd';
+ *
+ * const config = TelemetryConfigSchema.parse({
+ *   enabled: true,
+ *   historySize: 60,
+ * });
+ * ```
+ */
+export const TelemetryConfigSchema = z.object({
+	enabled: z.boolean(),
+	historySize: z.number().int().nonnegative().optional(),
+});
+
+/**
  * Frame budget configuration for adaptive performance.
  */
 export interface AdaptiveFrameBudgetConfig {
@@ -59,6 +78,26 @@ export interface AdaptiveFrameBudgetConfig {
 	/** Phases that can be skipped when over budget (default: [ANIMATION]) */
 	skippablePhases?: ReadonlyArray<LoopPhase>;
 }
+
+/**
+ * Zod schema for AdaptiveFrameBudgetConfig validation.
+ *
+ * @example
+ * ```typescript
+ * import { AdaptiveFrameBudgetConfigSchema, LoopPhase } from 'blecsd';
+ *
+ * const config = AdaptiveFrameBudgetConfigSchema.parse({
+ *   enabled: true,
+ *   budgetMs: 16.67,
+ *   skippablePhases: [LoopPhase.ANIMATION],
+ * });
+ * ```
+ */
+export const AdaptiveFrameBudgetConfigSchema = z.object({
+	enabled: z.boolean(),
+	budgetMs: z.number().positive().optional(),
+	skippablePhases: z.array(z.nativeEnum(LoopPhase)).readonly().optional(),
+});
 
 /**
  * Frame budget status for the current frame.

--- a/src/debug/memoryProfiler.ts
+++ b/src/debug/memoryProfiler.ts
@@ -8,6 +8,7 @@
  * @module debug/memoryProfiler
  */
 
+import { z } from 'zod';
 import { getAllEntities, hasComponent } from '../core/ecs';
 import type { Entity, World } from '../core/types';
 
@@ -94,6 +95,30 @@ export interface MemoryProfilerConfig {
 	/** Components to track (all if empty) */
 	readonly trackedComponents: readonly { component: unknown; name: string }[];
 }
+
+/**
+ * Zod schema for MemoryProfilerConfig validation.
+ *
+ * @example
+ * ```typescript
+ * import { MemoryProfilerConfigSchema } from 'blecsd';
+ *
+ * const config = MemoryProfilerConfigSchema.parse({
+ *   snapshotInterval: 1000,
+ *   maxSnapshots: 10,
+ *   entityLeakThreshold: 100,
+ *   heapLeakThreshold: 1024 * 1024,
+ *   trackedComponents: [],
+ * });
+ * ```
+ */
+export const MemoryProfilerConfigSchema = z.object({
+	snapshotInterval: z.number().nonnegative(),
+	maxSnapshots: z.number().int().positive(),
+	entityLeakThreshold: z.number().nonnegative(),
+	heapLeakThreshold: z.number().nonnegative(),
+	trackedComponents: z.array(z.object({ component: z.unknown(), name: z.string() })).readonly(),
+});
 
 /**
  * Memory profiler state.

--- a/src/debug/overlay.ts
+++ b/src/debug/overlay.ts
@@ -11,6 +11,7 @@
  * @module debug/overlay
  */
 
+import { z } from 'zod';
 import { setContent } from '../components/content';
 import { setDimensions } from '../components/dimensions';
 import { setPosition } from '../components/position';
@@ -60,6 +61,38 @@ export interface DebugOverlayConfig {
 	/** Whether visible on start (default: false) */
 	readonly visibleOnStart?: boolean;
 }
+
+/**
+ * Zod schema for DebugOverlayConfig validation.
+ *
+ * @example
+ * ```typescript
+ * import { DebugOverlayConfigSchema } from 'blecsd';
+ *
+ * const config = DebugOverlayConfigSchema.parse({
+ *   x: 10,
+ *   y: 5,
+ *   width: 40,
+ *   toggleKey: 'F12',
+ *   showFPS: true,
+ *   maxSystemsShown: 10,
+ * });
+ * ```
+ */
+export const DebugOverlayConfigSchema = z.object({
+	x: z.number().finite().optional(),
+	y: z.number().finite().optional(),
+	width: z.number().positive().optional(),
+	toggleKey: z.string().optional(),
+	showFPS: z.boolean().optional(),
+	showEntityCount: z.boolean().optional(),
+	showMemory: z.boolean().optional(),
+	showSystemTimings: z.boolean().optional(),
+	maxSystemsShown: z.number().int().positive().optional(),
+	bgColor: z.number().int().nonnegative().optional(),
+	fgColor: z.number().int().nonnegative().optional(),
+	visibleOnStart: z.boolean().optional(),
+});
 
 /**
  * Debug overlay state.

--- a/src/input/viMode.ts
+++ b/src/input/viMode.ts
@@ -8,6 +8,7 @@
  * @module input/viMode
  */
 
+import { z } from 'zod';
 import type { KeyEvent } from '../terminal/keyParser';
 
 // =============================================================================
@@ -50,6 +51,28 @@ export interface ViModeConfig {
 	/** Number of visible lines for H/M/L calculations */
 	readonly viewportHeight: number;
 }
+
+/**
+ * Zod schema for ViModeConfig validation.
+ *
+ * @example
+ * ```typescript
+ * import { ViModeConfigSchema } from 'blecsd';
+ *
+ * const config = ViModeConfigSchema.parse({
+ *   enabled: true,
+ *   scrollStep: 3,
+ *   horizontalStep: 5,
+ *   viewportHeight: 40,
+ * });
+ * ```
+ */
+export const ViModeConfigSchema = z.object({
+	enabled: z.boolean(),
+	scrollStep: z.number().int().positive(),
+	horizontalStep: z.number().int().positive(),
+	viewportHeight: z.number().int().positive(),
+});
 
 /**
  * Vi mode internal state.

--- a/src/media/overlay/w3m.ts
+++ b/src/media/overlay/w3m.ts
@@ -101,6 +101,36 @@ export interface W3MDrawConfig {
 }
 
 /**
+ * Zod schema for W3MDrawConfig validation.
+ *
+ * @example
+ * ```typescript
+ * import { W3MDrawConfigSchema } from 'blecsd';
+ *
+ * const config = W3MDrawConfigSchema.parse({
+ *   id: 1,
+ *   x: 100,
+ *   y: 50,
+ *   width: 200,
+ *   height: 150,
+ *   filePath: '/path/to/image.png',
+ * });
+ * ```
+ */
+export const W3MDrawConfigSchema = z.object({
+	id: z.number().int().nonnegative(),
+	x: z.number().int().nonnegative(),
+	y: z.number().int().nonnegative(),
+	width: z.number().int().positive(),
+	height: z.number().int().positive(),
+	srcX: z.number().int().nonnegative().optional(),
+	srcY: z.number().int().nonnegative().optional(),
+	srcWidth: z.number().int().positive().optional(),
+	srcHeight: z.number().int().positive().optional(),
+	filePath: z.string().min(1),
+});
+
+/**
  * Configuration for a w3m clear command.
  */
 export interface W3MClearConfig {
@@ -113,6 +143,28 @@ export interface W3MClearConfig {
 	/** Height in pixels */
 	readonly height: number;
 }
+
+/**
+ * Zod schema for W3MClearConfig validation.
+ *
+ * @example
+ * ```typescript
+ * import { W3MClearConfigSchema } from 'blecsd';
+ *
+ * const config = W3MClearConfigSchema.parse({
+ *   x: 100,
+ *   y: 50,
+ *   width: 200,
+ *   height: 150,
+ * });
+ * ```
+ */
+export const W3MClearConfigSchema = z.object({
+	x: z.number().int().nonnegative(),
+	y: z.number().int().nonnegative(),
+	width: z.number().int().positive(),
+	height: z.number().int().positive(),
+});
 
 /**
  * Result of an image size query.
@@ -219,32 +271,6 @@ export const W3M_SEARCH_PATHS: readonly string[] = [
  * Zod schema for CellPixelSize.
  */
 export const CellPixelSizeSchema = z.object({
-	width: z.number().int().positive(),
-	height: z.number().int().positive(),
-});
-
-/**
- * Zod schema for W3MDrawConfig.
- */
-export const W3MDrawConfigSchema = z.object({
-	id: z.number().int().nonnegative(),
-	x: z.number().int().nonnegative(),
-	y: z.number().int().nonnegative(),
-	width: z.number().int().positive(),
-	height: z.number().int().positive(),
-	srcX: z.number().int().nonnegative().optional(),
-	srcY: z.number().int().nonnegative().optional(),
-	srcWidth: z.number().int().positive().optional(),
-	srcHeight: z.number().int().positive().optional(),
-	filePath: z.string().min(1),
-});
-
-/**
- * Zod schema for W3MClearConfig.
- */
-export const W3MClearConfigSchema = z.object({
-	x: z.number().int().nonnegative(),
-	y: z.number().int().nonnegative(),
 	width: z.number().int().positive(),
 	height: z.number().int().positive(),
 });

--- a/src/systems/tilemapRenderer.ts
+++ b/src/systems/tilemapRenderer.ts
@@ -8,6 +8,7 @@
  * @module systems/tilemapRenderer
  */
 
+import { z } from 'zod';
 import { Position } from '../components/position';
 import {
 	EMPTY_TILE,
@@ -59,6 +60,29 @@ export interface TileMapRendererConfig {
 	/** Camera offset */
 	camera: TileMapCamera;
 }
+
+/**
+ * Zod schema for TileMapRendererConfig validation.
+ *
+ * @example
+ * ```typescript
+ * import { TileMapRendererConfigSchema } from 'blecsd';
+ *
+ * const config = TileMapRendererConfigSchema.parse({
+ *   viewportWidth: 80,
+ *   viewportHeight: 24,
+ *   camera: { x: 0, y: 0 },
+ * });
+ * ```
+ */
+export const TileMapRendererConfigSchema = z.object({
+	viewportWidth: z.number().int().positive(),
+	viewportHeight: z.number().int().positive(),
+	camera: z.object({
+		x: z.number().finite(),
+		y: z.number().finite(),
+	}),
+});
 
 // =============================================================================
 // RENDERER STATE

--- a/src/widgets/list.ts
+++ b/src/widgets/list.ts
@@ -89,6 +89,38 @@ export interface ListStyleConfig {
 }
 
 /**
+ * Zod schema for ListStyleConfig validation.
+ *
+ * @example
+ * ```typescript
+ * import { ListStyleConfigSchema } from 'blecsd';
+ *
+ * const style = ListStyleConfigSchema.parse({
+ *   item: { fg: 0xFFFFFFFF, bg: 0x000000FF },
+ *   selected: { fg: 0x000000FF, bg: 0x00FF00FF, prefix: '> ' },
+ *   unselectedPrefix: '  ',
+ * });
+ * ```
+ */
+export const ListStyleConfigSchema = z.object({
+	item: z
+		.object({
+			fg: z.number().int().nonnegative().optional(),
+			bg: z.number().int().nonnegative().optional(),
+		})
+		.optional(),
+	selected: z
+		.object({
+			fg: z.number().int().nonnegative().optional(),
+			bg: z.number().int().nonnegative().optional(),
+			prefix: z.string().optional(),
+		})
+		.optional(),
+	unselectedPrefix: z.string().optional(),
+	disabledFg: z.number().int().nonnegative().optional(),
+});
+
+/**
  * Configuration for creating a List widget.
  */
 export interface ListWidgetConfig {

--- a/src/widgets/panel.ts
+++ b/src/widgets/panel.ts
@@ -94,6 +94,46 @@ export interface PanelStyleConfig {
 }
 
 /**
+ * Zod schema for PanelStyleConfig validation.
+ *
+ * @example
+ * ```typescript
+ * import { PanelStyleConfigSchema } from 'blecsd';
+ *
+ * const style = PanelStyleConfigSchema.parse({
+ *   title: { fg: 0xFFFFFFFF, bg: 0x0000FFFF, align: 'center' },
+ *   content: { fg: 0xCCCCCCFF, bg: 0x000000FF },
+ *   border: { type: 'line', fg: 0xFFFFFFFF, ch: 'single' },
+ * });
+ * ```
+ */
+export const PanelStyleConfigSchema = z.object({
+	title: z
+		.object({
+			fg: z.union([z.string(), z.number().int().nonnegative()]).optional(),
+			bg: z.union([z.string(), z.number().int().nonnegative()]).optional(),
+			align: z.enum(['left', 'center', 'right']).optional(),
+		})
+		.optional(),
+	content: z
+		.object({
+			fg: z.union([z.string(), z.number().int().nonnegative()]).optional(),
+			bg: z.union([z.string(), z.number().int().nonnegative()]).optional(),
+		})
+		.optional(),
+	border: z
+		.object({
+			type: z.enum(['line', 'bg', 'none']).optional(),
+			fg: z.union([z.string(), z.number().int().nonnegative()]).optional(),
+			bg: z.union([z.string(), z.number().int().nonnegative()]).optional(),
+			ch: z
+				.union([z.enum(['single', 'double', 'rounded', 'bold', 'ascii']), z.unknown()])
+				.optional(),
+		})
+		.optional(),
+});
+
+/**
  * Padding configuration (all sides, or individual sides).
  */
 export type PaddingConfig =


### PR DESCRIPTION
## Summary

Adds Zod runtime validation schemas for 10 config interfaces that were missing schemas:

### Core Systems
- `TelemetryConfig` (scheduler.ts) - telemetry and metrics configuration
- `AdaptiveFrameBudgetConfig` (scheduler.ts) - adaptive frame budget settings

### Input
- `ViModeConfig` (viMode.ts) - Vi-style navigation configuration

### Debug
- `MemoryProfilerConfig` (memoryProfiler.ts) - memory profiling settings
- `DebugOverlayConfig` (overlay.ts) - debug overlay widget configuration

### Systems
- `TileMapRendererConfig` (tilemapRenderer.ts) - tilemap viewport and camera

### Widgets
- `ListStyleConfig` (list.ts) - list widget styling options
- `PanelStyleConfig` (panel.ts) - panel widget styling with nested properties

### Note
W3MDrawConfig and W3MClearConfig schemas already existed in w3m.ts and were not duplicated.

## Implementation Details

All schemas include:
- Full JSDoc comments with `@example` sections showing usage
- Runtime validation matching TypeScript interface types
- Proper Zod validators: `z.number()`, `z.boolean()`, `z.object()`, `z.enum()`, `z.union()`
- Optional field handling with `.optional()`
- Numeric constraints: `.positive()`, `.nonnegative()`, `.finite()`

## Test Plan

- [x] All tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

Closes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)