### PR TITLE
feat: add Canvas widget (#1070)

### DIFF
--- a/src/widgets/canvas.test.ts
+++ b/src/widgets/canvas.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Tests for Canvas widget.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { addEntity, createWorld } from '../core/ecs';
+import type { World } from '../core/types';
+import {
+	clearCanvas,
+	createCanvas,
+	drawCircle,
+	drawLine,
+	drawRect,
+	getCanvasContent,
+	isCanvas,
+	resetCanvasStore,
+	setPixel,
+} from './canvas';
+
+describe('Canvas widget', () => {
+	let world: World;
+
+	beforeEach(() => {
+		world = createWorld();
+		resetCanvasStore();
+	});
+
+	describe('createCanvas', () => {
+		it('should create a canvas widget', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid);
+
+			expect(canvas.entity).toBe(eid);
+			expect(canvas.world).toBe(world);
+			expect(isCanvas(eid)).toBe(true);
+		});
+
+		it('should accept width and height in dots', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 40,
+				height: 80,
+			});
+
+			expect(canvas.widthDots).toBe(40);
+			expect(canvas.heightDots).toBe(80);
+		});
+
+		it('should use default dimensions', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid);
+
+			expect(canvas.widthDots).toBe(40);
+			expect(canvas.heightDots).toBe(40);
+		});
+
+		it('should accept foreground color', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				fg: '#FFFFFF',
+			});
+
+			expect(isCanvas(canvas.entity)).toBe(true);
+		});
+
+		it('should accept background color', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				bg: '#000000',
+			});
+
+			expect(isCanvas(canvas.entity)).toBe(true);
+		});
+
+		it('should accept both colors', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				fg: '#00FF00',
+				bg: '#000000',
+			});
+
+			expect(isCanvas(canvas.entity)).toBe(true);
+		});
+
+		it('should accept numeric colors', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				fg: 0xffffff,
+				bg: 0x000000,
+			});
+
+			expect(isCanvas(canvas.entity)).toBe(true);
+		});
+	});
+
+	describe('setPixel', () => {
+		it('should set a single pixel', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 10,
+				height: 10,
+			});
+
+			setPixel(canvas, 5, 5, true);
+			const content = getCanvasContent(canvas);
+
+			// Should have non-empty braille characters
+			expect(content.length).toBeGreaterThan(0);
+			expect(content).not.toBe('     \n     \n     ');
+		});
+
+		it('should clear a pixel', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 10,
+				height: 10,
+			});
+
+			setPixel(canvas, 5, 5, true);
+			setPixel(canvas, 5, 5, false);
+			const content = getCanvasContent(canvas);
+
+			// Should be back to empty (all braille base characters)
+			expect(content).toContain('⠀'); // U+2800 braille base
+		});
+
+		it('should handle out-of-bounds coordinates gracefully', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 10,
+				height: 10,
+			});
+
+			expect(() => setPixel(canvas, -1, 5, true)).not.toThrow();
+			expect(() => setPixel(canvas, 5, -1, true)).not.toThrow();
+			expect(() => setPixel(canvas, 100, 5, true)).not.toThrow();
+			expect(() => setPixel(canvas, 5, 100, true)).not.toThrow();
+		});
+
+		it('should handle multiple pixels', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 10,
+				height: 10,
+			});
+
+			setPixel(canvas, 0, 0, true);
+			setPixel(canvas, 1, 0, true);
+			setPixel(canvas, 0, 1, true);
+			setPixel(canvas, 1, 1, true);
+
+			const content = getCanvasContent(canvas);
+			expect(content.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('drawLine', () => {
+		it('should draw a horizontal line', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 20,
+				height: 20,
+			});
+
+			drawLine(canvas, 0, 5, 19, 5);
+			const content = getCanvasContent(canvas);
+
+			expect(content.length).toBeGreaterThan(0);
+			expect(content).not.toBe('⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀');
+		});
+
+		it('should draw a vertical line', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 20,
+				height: 20,
+			});
+
+			drawLine(canvas, 10, 0, 10, 19);
+			const content = getCanvasContent(canvas);
+
+			expect(content.length).toBeGreaterThan(0);
+		});
+
+		it('should draw a diagonal line', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 20,
+				height: 20,
+			});
+
+			drawLine(canvas, 0, 0, 19, 19);
+			const content = getCanvasContent(canvas);
+
+			expect(content.length).toBeGreaterThan(0);
+		});
+
+		it('should draw line in any direction', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 20,
+				height: 20,
+			});
+
+			// Right to left
+			drawLine(canvas, 19, 5, 0, 5);
+			clearCanvas(canvas);
+
+			// Bottom to top
+			drawLine(canvas, 10, 19, 10, 0);
+			clearCanvas(canvas);
+
+			// Diagonal reverse
+			drawLine(canvas, 19, 19, 0, 0);
+
+			expect(getCanvasContent(canvas).length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('drawRect', () => {
+		it('should draw a rectangle outline', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 30,
+				height: 30,
+			});
+
+			drawRect(canvas, 5, 5, 10, 10, false);
+			const content = getCanvasContent(canvas);
+
+			expect(content.length).toBeGreaterThan(0);
+		});
+
+		it('should draw a filled rectangle', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 30,
+				height: 30,
+			});
+
+			drawRect(canvas, 5, 5, 10, 10, true);
+			const content = getCanvasContent(canvas);
+
+			expect(content.length).toBeGreaterThan(0);
+		});
+
+		it('should handle single-pixel rectangles', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 20,
+				height: 20,
+			});
+
+			expect(() => drawRect(canvas, 10, 10, 1, 1, false)).not.toThrow();
+		});
+
+		it('should handle large rectangles', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 40,
+				height: 40,
+			});
+
+			drawRect(canvas, 0, 0, 40, 40, false);
+			const content = getCanvasContent(canvas);
+
+			expect(content.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('drawCircle', () => {
+		it('should draw a circle outline', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 40,
+				height: 40,
+			});
+
+			drawCircle(canvas, 20, 20, 10, false);
+			const content = getCanvasContent(canvas);
+
+			expect(content.length).toBeGreaterThan(0);
+		});
+
+		it('should draw a filled circle', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 40,
+				height: 40,
+			});
+
+			drawCircle(canvas, 20, 20, 10, true);
+			const content = getCanvasContent(canvas);
+
+			expect(content.length).toBeGreaterThan(0);
+		});
+
+		it('should handle small circles', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 20,
+				height: 20,
+			});
+
+			drawCircle(canvas, 10, 10, 3, false);
+			const content = getCanvasContent(canvas);
+
+			expect(content.length).toBeGreaterThan(0);
+		});
+
+		it('should handle large circles', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 60,
+				height: 60,
+			});
+
+			drawCircle(canvas, 30, 30, 25, false);
+			const content = getCanvasContent(canvas);
+
+			expect(content.length).toBeGreaterThan(0);
+		});
+
+		it('should handle radius of zero', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 20,
+				height: 20,
+			});
+
+			expect(() => drawCircle(canvas, 10, 10, 0, false)).not.toThrow();
+		});
+	});
+
+	describe('clearCanvas', () => {
+		it('should clear all pixels', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 20,
+				height: 20,
+			});
+
+			// Draw some shapes
+			drawLine(canvas, 0, 0, 19, 19);
+			drawRect(canvas, 5, 5, 10, 10);
+			drawCircle(canvas, 10, 10, 5);
+
+			// Clear
+			clearCanvas(canvas);
+			const content = getCanvasContent(canvas);
+
+			// Should be all braille base characters (empty)
+			expect(content).toContain('⠀');
+		});
+
+		it('should allow drawing after clear', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 20,
+				height: 20,
+			});
+
+			drawLine(canvas, 0, 0, 19, 19);
+			clearCanvas(canvas);
+			drawLine(canvas, 0, 19, 19, 0);
+
+			const content = getCanvasContent(canvas);
+			expect(content.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('getCanvasContent', () => {
+		it('should return string content', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 20,
+				height: 20,
+			});
+
+			const content = getCanvasContent(canvas);
+
+			expect(typeof content).toBe('string');
+			expect(content.length).toBeGreaterThan(0);
+		});
+
+		it('should return braille characters', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 10,
+				height: 10,
+			});
+
+			const content = getCanvasContent(canvas);
+
+			// Should contain braille unicode characters (U+2800-U+28FF)
+			expect(content).toMatch(/[\u2800-\u28FF]/);
+		});
+
+		it('should include newlines for rows', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 10,
+				height: 20, // 5 character rows
+			});
+
+			const content = getCanvasContent(canvas);
+
+			// Should have newlines
+			expect(content).toContain('\n');
+		});
+	});
+
+	describe('isCanvas', () => {
+		it('should return true for canvas entities', () => {
+			const eid = addEntity(world);
+			createCanvas(world, eid);
+
+			expect(isCanvas(eid)).toBe(true);
+		});
+
+		it('should return false for non-canvas entities', () => {
+			const eid = addEntity(world);
+
+			expect(isCanvas(eid)).toBe(false);
+		});
+	});
+
+	describe('integration', () => {
+		it('should support complex drawings', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 60,
+				height: 80,
+				fg: '#00FF00',
+				bg: '#000000',
+			});
+
+			// Draw multiple shapes
+			drawCircle(canvas, 30, 40, 20, false);
+			drawCircle(canvas, 30, 40, 10, true);
+			drawRect(canvas, 20, 30, 20, 20, false);
+			drawLine(canvas, 0, 0, 59, 79);
+			drawLine(canvas, 59, 0, 0, 79);
+
+			const content = getCanvasContent(canvas);
+			expect(content.length).toBeGreaterThan(0);
+		});
+
+		it('should handle overlapping shapes', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 40,
+				height: 40,
+			});
+
+			// Draw overlapping circles
+			drawCircle(canvas, 15, 20, 10, true);
+			drawCircle(canvas, 25, 20, 10, true);
+
+			const content = getCanvasContent(canvas);
+			expect(content.length).toBeGreaterThan(0);
+		});
+
+		it('should handle full canvas clear and redraw', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 40,
+				height: 40,
+			});
+
+			// Draw something
+			drawRect(canvas, 10, 10, 20, 20, true);
+			const content1 = getCanvasContent(canvas);
+
+			// Clear
+			clearCanvas(canvas);
+			const content2 = getCanvasContent(canvas);
+
+			// Draw something else
+			drawCircle(canvas, 20, 20, 15, true);
+			const content3 = getCanvasContent(canvas);
+
+			expect(content1).not.toBe(content2);
+			expect(content2).not.toBe(content3);
+			expect(content1).not.toBe(content3);
+		});
+	});
+
+	describe('braille character rendering', () => {
+		it('should use correct braille base character', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 2,
+				height: 4,
+			});
+
+			const content = getCanvasContent(canvas);
+
+			// Empty canvas should be all U+2800 (braille blank)
+			expect(content).toBe('⠀');
+		});
+
+		it('should combine multiple dots in same character', () => {
+			const eid = addEntity(world);
+			const canvas = createCanvas(world, eid, {
+				width: 2,
+				height: 4,
+			});
+
+			// Set all 4 dots in one character (2x4 grid)
+			setPixel(canvas, 0, 0, true);
+			setPixel(canvas, 1, 0, true);
+			setPixel(canvas, 0, 1, true);
+			setPixel(canvas, 1, 1, true);
+
+			const content = getCanvasContent(canvas);
+
+			// Should have combined braille character (not base)
+			expect(content).not.toBe('⠀');
+			expect(content).toMatch(/[\u2801-\u28FF]/);
+		});
+	});
+});

--- a/src/widgets/canvas.ts
+++ b/src/widgets/canvas.ts
@@ -1,0 +1,568 @@
+/**
+ * Canvas Widget
+ *
+ * A widget for drawing custom shapes and pixels using Unicode braille characters.
+ * Each character represents a 2x4 grid of dots, providing 2x resolution compared
+ * to regular text characters.
+ *
+ * @module widgets/canvas
+ */
+
+import { z } from 'zod';
+import { appendChild } from '../components/hierarchy';
+import { setPosition } from '../components/position';
+import { markDirty, setStyle } from '../components/renderable';
+import { addEntity } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+import { parseColor } from '../utils/color';
+import { createBox } from './box';
+import { BRAILLE_BASE, BRAILLE_DOTS } from './chartUtils';
+import { createText, setTextContent } from './text';
+
+/** Default entity capacity for typed arrays */
+const DEFAULT_CAPACITY = 10000;
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+/**
+ * Canvas component marker for identifying canvas entities.
+ */
+export const Canvas = {
+	/** Tag indicating this is a canvas widget (1 = yes) */
+	isCanvas: new Uint8Array(DEFAULT_CAPACITY),
+};
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Canvas widget configuration.
+ *
+ * @example
+ * ```typescript
+ * import { createCanvas } from 'blecsd';
+ *
+ * const canvas = createCanvas(world, eid, {
+ *   width: 40,  // 40 braille dots wide (20 characters)
+ *   height: 80, // 80 braille dots high (20 character rows)
+ *   fg: '#FFFFFF',
+ *   bg: '#000000'
+ * });
+ *
+ * // Draw shapes
+ * setPixel(canvas, 10, 10, true);
+ * drawLine(canvas, 0, 0, 39, 79);
+ * drawRect(canvas, 10, 10, 20, 30);
+ * drawCircle(canvas, 20, 40, 15);
+ * ```
+ */
+export interface CanvasConfig {
+	/**
+	 * Canvas width in braille dots (2 dots per character width)
+	 * @default 40
+	 */
+	readonly width?: number;
+
+	/**
+	 * Canvas height in braille dots (4 dots per character height)
+	 * @default 40
+	 */
+	readonly height?: number;
+
+	/**
+	 * Foreground color for drawn pixels
+	 * @default undefined
+	 */
+	readonly fg?: string | number;
+
+	/**
+	 * Background color
+	 * @default undefined
+	 */
+	readonly bg?: string | number;
+
+	/**
+	 * Initial fill character
+	 * @default ' '
+	 */
+	readonly fillChar?: string;
+}
+
+/**
+ * Canvas widget interface.
+ */
+export interface CanvasWidget {
+	readonly entity: Entity;
+	readonly world: World;
+	readonly widthDots: number;
+	readonly heightDots: number;
+}
+
+// =============================================================================
+// SCHEMA
+// =============================================================================
+
+export const CanvasConfigSchema = z.object({
+	width: z.number().int().positive().optional().default(40),
+	height: z.number().int().positive().optional().default(40),
+	fg: z.union([z.string(), z.number()]).optional(),
+	bg: z.union([z.string(), z.number()]).optional(),
+	fillChar: z.string().length(1).optional().default(' '),
+});
+
+type ValidatedCanvasConfig = z.infer<typeof CanvasConfigSchema>;
+
+// =============================================================================
+// STATE
+// =============================================================================
+
+interface CanvasState {
+	world: World;
+	entity: Entity;
+	textEntity: Entity;
+	widthDots: number;
+	heightDots: number;
+	widthChars: number;
+	heightChars: number;
+	pixels: Uint8Array; // Braille dot state (8 dots per character)
+}
+
+const canvasStateMap = new Map<Entity, CanvasState>();
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+/**
+ * Converts dot coordinates to character coordinates and local dot position.
+ */
+function dotToChar(
+	x: number,
+	y: number,
+): { charX: number; charY: number; col: number; row: number } {
+	const charX = Math.floor(x / 2);
+	const charY = Math.floor(y / 4);
+	const col = x % 2;
+	const row = y % 4;
+	return { charX, charY, col, row };
+}
+
+/**
+ * Gets the index in the pixels array for a character position.
+ */
+function getCharIndex(state: CanvasState, charX: number, charY: number): number {
+	return charY * state.widthChars + charX;
+}
+
+/**
+ * Converts the pixel state to a renderable string.
+ */
+function renderCanvas(state: CanvasState): string {
+	const lines: string[] = [];
+
+	for (let y = 0; y < state.heightChars; y++) {
+		let line = '';
+		for (let x = 0; x < state.widthChars; x++) {
+			const idx = getCharIndex(state, x, y);
+			const bits = state.pixels[idx] ?? 0;
+			line += String.fromCharCode(BRAILLE_BASE | bits);
+		}
+		lines.push(line);
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Updates the canvas display.
+ */
+function updateCanvas(state: CanvasState): void {
+	const content = renderCanvas(state);
+	setTextContent(state.world, state.textEntity, content);
+	markDirty(state.world, state.entity);
+}
+
+// =============================================================================
+// DRAWING API
+// =============================================================================
+
+/**
+ * Sets or clears a single pixel (braille dot) on the canvas.
+ *
+ * @param canvas - The canvas widget
+ * @param x - X coordinate in braille dots
+ * @param y - Y coordinate in braille dots
+ * @param on - True to set the pixel, false to clear it (default: true)
+ *
+ * @example
+ * ```typescript
+ * setPixel(canvas, 10, 10, true);  // Set pixel
+ * setPixel(canvas, 10, 11, false); // Clear pixel
+ * ```
+ */
+export function setPixel(canvas: CanvasWidget, x: number, y: number, on = true): void {
+	const state = canvasStateMap.get(canvas.entity);
+	if (!state) return;
+
+	// Bounds check
+	if (x < 0 || x >= state.widthDots || y < 0 || y >= state.heightDots) {
+		return;
+	}
+
+	const { charX, charY, col, row } = dotToChar(x, y);
+	const idx = getCharIndex(state, charX, charY);
+
+	const rowDots = BRAILLE_DOTS[row];
+	if (!rowDots) return;
+	const dotBit = rowDots[col] ?? 0;
+
+	if (on) {
+		state.pixels[idx] = (state.pixels[idx] ?? 0) | dotBit;
+	} else {
+		state.pixels[idx] = (state.pixels[idx] ?? 0) & ~dotBit;
+	}
+
+	updateCanvas(state);
+}
+
+/**
+ * Draws a line between two points using Bresenham's algorithm.
+ *
+ * @param canvas - The canvas widget
+ * @param x1 - Start X coordinate
+ * @param y1 - Start Y coordinate
+ * @param x2 - End X coordinate
+ * @param y2 - End Y coordinate
+ *
+ * @example
+ * ```typescript
+ * drawLine(canvas, 0, 0, 39, 39); // Diagonal line
+ * ```
+ */
+export function drawLine(
+	canvas: CanvasWidget,
+	x1: number,
+	y1: number,
+	x2: number,
+	y2: number,
+): void {
+	const dx = Math.abs(x2 - x1);
+	const dy = Math.abs(y2 - y1);
+	const sx = x1 < x2 ? 1 : -1;
+	const sy = y1 < y2 ? 1 : -1;
+	let err = dx - dy;
+
+	let x = x1;
+	let y = y1;
+
+	while (true) {
+		setPixel(canvas, x, y, true);
+
+		if (x === x2 && y === y2) break;
+
+		const e2 = 2 * err;
+		if (e2 > -dy) {
+			err -= dy;
+			x += sx;
+		}
+		if (e2 < dx) {
+			err += dx;
+			y += sy;
+		}
+	}
+}
+
+/**
+ * Draws a rectangle on the canvas.
+ *
+ * @param canvas - The canvas widget
+ * @param x - Top-left X coordinate
+ * @param y - Top-left Y coordinate
+ * @param width - Rectangle width in dots
+ * @param height - Rectangle height in dots
+ * @param fill - If true, fill the rectangle; otherwise just draw outline (default: false)
+ *
+ * @example
+ * ```typescript
+ * drawRect(canvas, 10, 10, 20, 30);       // Outline
+ * drawRect(canvas, 10, 10, 20, 30, true); // Filled
+ * ```
+ */
+export function drawRect(
+	canvas: CanvasWidget,
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+	fill = false,
+): void {
+	if (fill) {
+		// Fill rectangle
+		for (let dy = 0; dy < height; dy++) {
+			for (let dx = 0; dx < width; dx++) {
+				setPixel(canvas, x + dx, y + dy, true);
+			}
+		}
+	} else {
+		// Draw outline
+		// Top and bottom edges
+		for (let dx = 0; dx < width; dx++) {
+			setPixel(canvas, x + dx, y, true);
+			setPixel(canvas, x + dx, y + height - 1, true);
+		}
+		// Left and right edges
+		for (let dy = 0; dy < height; dy++) {
+			setPixel(canvas, x, y + dy, true);
+			setPixel(canvas, x + width - 1, y + dy, true);
+		}
+	}
+}
+
+/**
+ * Draws a circle using the midpoint circle algorithm.
+ *
+ * @param canvas - The canvas widget
+ * @param cx - Center X coordinate
+ * @param cy - Center Y coordinate
+ * @param radius - Circle radius in dots
+ * @param fill - If true, fill the circle; otherwise just draw outline (default: false)
+ *
+ * @example
+ * ```typescript
+ * drawCircle(canvas, 20, 20, 10);       // Outline
+ * drawCircle(canvas, 20, 20, 10, true); // Filled
+ * ```
+ */
+export function drawCircle(
+	canvas: CanvasWidget,
+	cx: number,
+	cy: number,
+	radius: number,
+	fill = false,
+): void {
+	if (fill) {
+		// Filled circle - draw horizontal lines for each y
+		for (let y = -radius; y <= radius; y++) {
+			const width = Math.floor(Math.sqrt(radius * radius - y * y));
+			for (let x = -width; x <= width; x++) {
+				setPixel(canvas, cx + x, cy + y, true);
+			}
+		}
+	} else {
+		// Midpoint circle algorithm for outline
+		let x = radius;
+		let y = 0;
+		let err = 0;
+
+		while (x >= y) {
+			// Draw 8 octants
+			setPixel(canvas, cx + x, cy + y, true);
+			setPixel(canvas, cx + y, cy + x, true);
+			setPixel(canvas, cx - y, cy + x, true);
+			setPixel(canvas, cx - x, cy + y, true);
+			setPixel(canvas, cx - x, cy - y, true);
+			setPixel(canvas, cx - y, cy - x, true);
+			setPixel(canvas, cx + y, cy - x, true);
+			setPixel(canvas, cx + x, cy - y, true);
+
+			if (err <= 0) {
+				y += 1;
+				err += 2 * y + 1;
+			}
+			if (err > 0) {
+				x -= 1;
+				err -= 2 * x + 1;
+			}
+		}
+	}
+}
+
+/**
+ * Draws text on the canvas at the specified position.
+ * Note: This overlays regular text characters, not braille dots.
+ *
+ * @param canvas - The canvas widget
+ * @param _x - X position in characters (not dots)
+ * @param _y - Y position in characters (not dots)
+ * @param _text - Text to draw
+ *
+ * @example
+ * ```typescript
+ * drawText(canvas, 5, 5, 'Hello!');
+ * ```
+ */
+export function drawText(canvas: CanvasWidget, _x: number, _y: number, _text: string): void {
+	// Text drawing is more complex as it needs to overlay on braille
+	// For now, this is a placeholder that would need proper implementation
+	// involving mixing regular characters with braille
+	const state = canvasStateMap.get(canvas.entity);
+	if (!state) return;
+
+	// This is a simplified implementation - real implementation would need
+	// to handle text overlay properly
+	updateCanvas(state);
+}
+
+/**
+ * Clears all pixels on the canvas.
+ *
+ * @param canvas - The canvas widget
+ *
+ * @example
+ * ```typescript
+ * clearCanvas(canvas);
+ * ```
+ */
+export function clearCanvas(canvas: CanvasWidget): void {
+	const state = canvasStateMap.get(canvas.entity);
+	if (!state) return;
+
+	state.pixels.fill(0);
+	updateCanvas(state);
+}
+
+/**
+ * Gets the current canvas content as a string.
+ *
+ * @param canvas - The canvas widget
+ * @returns The rendered canvas content
+ *
+ * @example
+ * ```typescript
+ * const content = getCanvasContent(canvas);
+ * console.log(content);
+ * ```
+ */
+export function getCanvasContent(canvas: CanvasWidget): string {
+	const state = canvasStateMap.get(canvas.entity);
+	if (!state) return '';
+
+	return renderCanvas(state);
+}
+
+// =============================================================================
+// WIDGET FACTORY
+// =============================================================================
+
+/**
+ * Creates a Canvas widget for drawing custom shapes with braille dots.
+ *
+ * The canvas uses Unicode braille characters (U+2800-U+28FF) where each character
+ * represents a 2x4 grid of dots. This provides 2x resolution compared to regular
+ * text characters.
+ *
+ * @param world - The ECS world
+ * @param entity - The entity to attach the canvas to
+ * @param config - Canvas configuration
+ * @returns Canvas widget instance
+ *
+ * @example
+ * ```typescript
+ * import { createWorld, addEntity } from '../core/ecs';
+ * import { createCanvas, setPixel, drawLine, drawCircle } from 'blecsd';
+ *
+ * const world = createWorld();
+ * const eid = addEntity(world);
+ *
+ * // Create canvas (40 dots wide, 80 dots high = 20x20 characters)
+ * const canvas = createCanvas(world, eid, {
+ *   width: 40,
+ *   height: 80,
+ *   fg: '#00FF00',
+ *   bg: '#000000'
+ * });
+ *
+ * // Draw shapes
+ * setPixel(canvas, 10, 10, true);
+ * drawLine(canvas, 0, 0, 39, 79);
+ * drawRect(canvas, 10, 10, 20, 30);
+ * drawCircle(canvas, 20, 40, 15);
+ * drawCircle(canvas, 20, 40, 10, true); // Filled
+ *
+ * // Clear and redraw
+ * clearCanvas(canvas);
+ * drawCircle(canvas, 20, 40, 20);
+ * ```
+ */
+export function createCanvas(
+	world: World,
+	entity: Entity,
+	config: CanvasConfig = {},
+): CanvasWidget {
+	const validated = CanvasConfigSchema.parse(config) as ValidatedCanvasConfig;
+
+	// Calculate character dimensions (2 dots wide, 4 dots high per character)
+	const widthChars = Math.ceil(validated.width / 2);
+	const heightChars = Math.ceil(validated.height / 4);
+
+	// Mark as canvas
+	Canvas.isCanvas[entity] = 1;
+
+	// Create container
+	createBox(world, entity);
+	setPosition(world, entity, 0, 0);
+
+	// Apply colors
+	const fg = validated.fg ? parseColor(validated.fg) : undefined;
+	const bg = validated.bg ? parseColor(validated.bg) : undefined;
+	if (fg !== undefined || bg !== undefined) {
+		setStyle(world, entity, { fg, bg });
+	}
+
+	// Create text entity for rendering
+	const textEntity = addEntity(world);
+	createText(world, textEntity);
+	setPosition(world, textEntity, 0, 0);
+	appendChild(world, entity, textEntity);
+
+	// Initialize pixel state
+	const pixels = new Uint8Array(widthChars * heightChars);
+	pixels.fill(0);
+
+	// Initialize state
+	const state: CanvasState = {
+		world,
+		entity,
+		textEntity,
+		widthDots: validated.width,
+		heightDots: validated.height,
+		widthChars,
+		heightChars,
+		pixels,
+	};
+
+	canvasStateMap.set(entity, state);
+
+	// Initial render
+	updateCanvas(state);
+
+	// Return widget API
+	return {
+		entity,
+		world,
+		widthDots: validated.width,
+		heightDots: validated.height,
+	};
+}
+
+/**
+ * Checks if an entity is a canvas widget.
+ *
+ * @param entity - The entity to check
+ * @returns True if the entity is a canvas
+ */
+export function isCanvas(entity: Entity): boolean {
+	return Canvas.isCanvas[entity] === 1;
+}
+
+/**
+ * Resets the canvas store (for testing).
+ * @internal
+ */
+export function resetCanvasStore(): void {
+	canvasStateMap.clear();
+	Canvas.isCanvas.fill(0);
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -87,6 +87,22 @@ export {
 	isButtonWidget,
 	resetButtonWidgetStore,
 } from './button';
+// Canvas widget
+export type { CanvasConfig, CanvasWidget } from './canvas';
+export {
+	Canvas,
+	CanvasConfigSchema,
+	clearCanvas,
+	createCanvas,
+	drawCircle,
+	drawLine,
+	drawRect,
+	drawText,
+	getCanvasContent,
+	isCanvas,
+	resetCanvasStore,
+	setPixel,
+} from './canvas';
 // Chart utilities
 export {
 	BRAILLE_BASE,


### PR DESCRIPTION
Closes #1070

## Summary

Implements Canvas widget for drawing custom shapes using Unicode braille characters (U+2800-U+28FF). Each braille character represents a 2x4 grid of dots, providing 2x resolution compared to regular text characters.

## Features

- **Drawing API**: setPixel(), drawLine(), drawRect(), drawCircle(), clearCanvas(), getCanvasContent()
- **Algorithms**: Bresenham's line algorithm, midpoint circle algorithm
- **Configuration**: Width/height in braille dots, foreground/background colors
- **Validation**: Zod schema for configuration
- **Tests**: 36 comprehensive tests covering all drawing operations

## API

```typescript
import { createCanvas, setPixel, drawLine, drawRect, drawCircle } from 'blecsd';

const canvas = createCanvas(world, eid, {
  width: 40,   // 40 braille dots wide (20 characters)
  height: 80,  // 80 braille dots high (20 character rows)
  fg: '#00FF00',
  bg: '#000000'
});

// Draw shapes
setPixel(canvas, 10, 10, true);
drawLine(canvas, 0, 0, 39, 79);
drawRect(canvas, 10, 10, 20, 30);
drawCircle(canvas, 20, 40, 15);
```

## Testing

- ✅ All 11,806 tests passing (36 new canvas tests)
- ✅ Lint clean (28 acceptable complexity warnings)
- ✅ Type check passes
- ✅ Build succeeds