### PR TITLE
feat: terminal UX widgets - search, multi-select, searchable list

### DIFF
--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -487,6 +487,22 @@ export {
 	openModal,
 	resetModalStore,
 } from './modal';
+// MultiSelect widget
+export type {
+	MultiSelectConfig,
+	MultiSelectItem,
+	MultiSelectWidget,
+	SelectionChangeCallback,
+} from './multiSelect';
+export {
+	createMultiSelect,
+	getSelectedItems,
+	isMultiSelect,
+	MultiSelect,
+	MultiSelectConfigSchema,
+	onSelectionChange,
+	resetMultiSelectStore,
+} from './multiSelect';
 // Panel widget
 export type {
 	PanelAction,
@@ -619,6 +635,41 @@ export {
 // ScrollableText widget
 export type { ScrollableTextConfig, ScrollableTextWidget } from './scrollableText';
 export { createScrollableText, isScrollableText } from './scrollableText';
+// SearchableList widget
+export type {
+	SearchableListCallback,
+	SearchableListConfig,
+	SearchableListItem,
+	SearchableListWidget,
+} from './searchableList';
+export {
+	createSearchableList,
+	getSearchableFilteredItems,
+	isSearchableList,
+	resetSearchableListStore,
+	SearchableList,
+	SearchableListConfigSchema,
+	setSearchableFilter,
+} from './searchableList';
+// SearchOverlay widget
+export type {
+	SearchableContent,
+	SearchMode,
+	SearchOverlayConfig,
+	SearchOverlayMatch,
+	SearchOverlayMatchCallback,
+	SearchOverlayWidget,
+} from './searchOverlay';
+export {
+	attachSearchOverlay,
+	createSearchOverlay,
+	getSearchOverlayColors,
+	getSearchOverlayTarget,
+	isSearchOverlay,
+	resetSearchOverlayStore,
+	SearchOverlay,
+	SearchOverlayConfigSchema,
+} from './searchOverlay';
 // Sparkline widget
 export type { SparklineConfig, SparklineWidget } from './sparkline';
 export {

--- a/src/widgets/multiSelect.test.ts
+++ b/src/widgets/multiSelect.test.ts
@@ -1,0 +1,601 @@
+/**
+ * MultiSelect Widget Tests
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addEntity, createWorld } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+import {
+	createMultiSelect,
+	getSelectedItems,
+	isMultiSelect,
+	type MultiSelectWidget,
+	onSelectionChange,
+	resetMultiSelectStore,
+} from './multiSelect';
+
+describe('MultiSelect Widget', () => {
+	let world: World;
+	let eid: Entity;
+	let ms: MultiSelectWidget;
+
+	const items = ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry'];
+
+	beforeEach(() => {
+		resetMultiSelectStore();
+		world = createWorld() as World;
+		eid = addEntity(world) as Entity;
+	});
+
+	describe('createMultiSelect', () => {
+		it('should create a multi-select widget', () => {
+			ms = createMultiSelect(world, { items });
+
+			expect(ms.eid).toBeDefined();
+			expect(isMultiSelect(world, ms.eid)).toBe(true);
+		});
+
+		it('should initialize with default values', () => {
+			ms = createMultiSelect(world);
+
+			expect(ms.getItems()).toEqual([]);
+			expect(ms.getSelectedCount()).toBe(0);
+			expect(ms.getCursorIndex()).toBe(-1);
+		});
+
+		it('should initialize with provided items', () => {
+			ms = createMultiSelect(world, { items });
+
+			const allItems = ms.getItems();
+			expect(allItems).toHaveLength(5);
+			expect(allItems[0]?.text).toBe('Apple');
+			expect(allItems[4]?.text).toBe('Elderberry');
+		});
+
+		it('should initialize with pre-selected items', () => {
+			ms = createMultiSelect(world, { items, selected: [0, 2] });
+
+			expect(ms.getSelectedCount()).toBe(2);
+			expect(ms.isSelected(0)).toBe(true);
+			expect(ms.isSelected(1)).toBe(false);
+			expect(ms.isSelected(2)).toBe(true);
+		});
+
+		it('should accept MultiSelectItem objects', () => {
+			ms = createMultiSelect(world, {
+				items: [
+					{ text: 'A', value: 'val-a' },
+					{ text: 'B', value: 'val-b', disabled: true },
+				],
+			});
+
+			const allItems = ms.getItems();
+			expect(allItems).toHaveLength(2);
+			expect(allItems[0]?.value).toBe('val-a');
+			expect(allItems[1]?.disabled).toBe(true);
+		});
+
+		it('should not pre-select disabled items', () => {
+			ms = createMultiSelect(world, {
+				items: [{ text: 'A' }, { text: 'B', disabled: true }],
+				selected: [0, 1],
+			});
+
+			expect(ms.getSelectedCount()).toBe(1);
+			expect(ms.isSelected(0)).toBe(true);
+			expect(ms.isSelected(1)).toBe(false);
+		});
+	});
+
+	describe('visibility', () => {
+		beforeEach(() => {
+			ms = createMultiSelect(world, { items });
+		});
+
+		it('should show the widget', () => {
+			const result = ms.hide().show();
+			expect(result).toBe(ms);
+		});
+
+		it('should hide the widget', () => {
+			const result = ms.show().hide();
+			expect(result).toBe(ms);
+		});
+	});
+
+	describe('focus', () => {
+		beforeEach(() => {
+			ms = createMultiSelect(world, { items });
+		});
+
+		it('should focus the widget', () => {
+			const result = ms.focus();
+			expect(result).toBe(ms);
+			expect(ms.isFocused()).toBe(true);
+		});
+
+		it('should blur the widget', () => {
+			ms.focus();
+			const result = ms.blur();
+			expect(result).toBe(ms);
+			expect(ms.isFocused()).toBe(false);
+		});
+	});
+
+	describe('cursor navigation', () => {
+		beforeEach(() => {
+			ms = createMultiSelect(world, { items });
+		});
+
+		it('should start at index 0', () => {
+			expect(ms.getCursorIndex()).toBe(0);
+		});
+
+		it('should move cursor down', () => {
+			ms.cursorDown();
+			expect(ms.getCursorIndex()).toBe(1);
+		});
+
+		it('should move cursor up', () => {
+			ms.cursorDown().cursorDown();
+			ms.cursorUp();
+			expect(ms.getCursorIndex()).toBe(1);
+		});
+
+		it('should not go below 0', () => {
+			ms.cursorUp();
+			expect(ms.getCursorIndex()).toBe(0);
+		});
+
+		it('should not go past last item', () => {
+			for (let i = 0; i < 10; i++) {
+				ms.cursorDown();
+			}
+			expect(ms.getCursorIndex()).toBe(4);
+		});
+
+		it('should jump to first item', () => {
+			ms.cursorDown().cursorDown();
+			ms.cursorFirst();
+			expect(ms.getCursorIndex()).toBe(0);
+		});
+
+		it('should jump to last item', () => {
+			ms.cursorLast();
+			expect(ms.getCursorIndex()).toBe(4);
+		});
+
+		it('should select by index', () => {
+			ms.select(3);
+			expect(ms.getCursorIndex()).toBe(3);
+		});
+
+		it('should page up and down', () => {
+			ms = createMultiSelect(world, {
+				items: Array.from({ length: 20 }, (_, i) => `Item ${i}`),
+				height: 5,
+			});
+
+			ms.pageDown();
+			expect(ms.getCursorIndex()).toBeGreaterThan(0);
+
+			ms.pageUp();
+			expect(ms.getCursorIndex()).toBe(0);
+		});
+	});
+
+	describe('selection', () => {
+		beforeEach(() => {
+			ms = createMultiSelect(world, { items });
+		});
+
+		it('should toggle current item', () => {
+			ms.select(0);
+			ms.toggleCurrent();
+			expect(ms.isSelected(0)).toBe(true);
+
+			ms.toggleCurrent();
+			expect(ms.isSelected(0)).toBe(false);
+		});
+
+		it('should toggle specific item by index', () => {
+			ms.toggleItem(2);
+			expect(ms.isSelected(2)).toBe(true);
+
+			ms.toggleItem(2);
+			expect(ms.isSelected(2)).toBe(false);
+		});
+
+		it('should not toggle disabled items', () => {
+			ms = createMultiSelect(world, {
+				items: [{ text: 'A' }, { text: 'B', disabled: true }],
+			});
+
+			ms.select(1).toggleCurrent();
+			expect(ms.isSelected(1)).toBe(false);
+		});
+
+		it('should select all items', () => {
+			ms.selectAll();
+			expect(ms.getSelectedCount()).toBe(5);
+		});
+
+		it('should not select disabled items when selecting all', () => {
+			ms = createMultiSelect(world, {
+				items: [{ text: 'A' }, { text: 'B', disabled: true }, { text: 'C' }],
+			});
+
+			ms.selectAll();
+			expect(ms.getSelectedCount()).toBe(2);
+			expect(ms.isSelected(1)).toBe(false);
+		});
+
+		it('should deselect all items', () => {
+			ms.selectAll();
+			ms.deselectAll();
+			expect(ms.getSelectedCount()).toBe(0);
+		});
+
+		it('should get selected indices sorted', () => {
+			ms.toggleItem(3);
+			ms.toggleItem(1);
+			ms.toggleItem(4);
+
+			const indices = ms.getSelectedIndices();
+			expect(indices).toEqual([1, 3, 4]);
+		});
+
+		it('should get selected items', () => {
+			ms.toggleItem(0);
+			ms.toggleItem(2);
+
+			const selectedItems = ms.getSelectedItems();
+			expect(selectedItems).toHaveLength(2);
+			expect(selectedItems[0]?.text).toBe('Apple');
+			expect(selectedItems[1]?.text).toBe('Cherry');
+		});
+
+		it('should report selection status', () => {
+			expect(ms.getSelectionStatus()).toBe('None selected');
+
+			ms.toggleItem(0);
+			expect(ms.getSelectionStatus()).toBe('1 selected');
+
+			ms.toggleItem(1);
+			expect(ms.getSelectionStatus()).toBe('2 selected');
+		});
+	});
+
+	describe('range selection', () => {
+		beforeEach(() => {
+			ms = createMultiSelect(world, { items });
+		});
+
+		it('should range select from anchor to target', () => {
+			ms.select(1); // Sets anchor at 1
+			ms.rangeSelectTo(3);
+
+			expect(ms.isSelected(1)).toBe(true);
+			expect(ms.isSelected(2)).toBe(true);
+			expect(ms.isSelected(3)).toBe(true);
+			expect(ms.isSelected(0)).toBe(false);
+			expect(ms.isSelected(4)).toBe(false);
+		});
+
+		it('should range select backward', () => {
+			ms.select(3); // Sets anchor at 3
+			ms.rangeSelectTo(1);
+
+			expect(ms.isSelected(1)).toBe(true);
+			expect(ms.isSelected(2)).toBe(true);
+			expect(ms.isSelected(3)).toBe(true);
+		});
+
+		it('should skip disabled items in range', () => {
+			ms = createMultiSelect(world, {
+				items: [{ text: 'A' }, { text: 'B', disabled: true }, { text: 'C' }, { text: 'D' }],
+			});
+
+			ms.select(0);
+			ms.rangeSelectTo(3);
+
+			expect(ms.isSelected(0)).toBe(true);
+			expect(ms.isSelected(1)).toBe(false); // disabled
+			expect(ms.isSelected(2)).toBe(true);
+			expect(ms.isSelected(3)).toBe(true);
+		});
+	});
+
+	describe('filter-as-you-type', () => {
+		beforeEach(() => {
+			ms = createMultiSelect(world, { items, filterable: true });
+		});
+
+		it('should filter items', () => {
+			ms.setFilter('ber');
+
+			const visible = ms.getVisibleItems();
+			expect(visible.length).toBeGreaterThanOrEqual(1);
+			expect(visible.some((i) => i.text === 'Elderberry')).toBe(true);
+		});
+
+		it('should filter case-insensitively', () => {
+			ms.setFilter('APPLE');
+
+			const visible = ms.getVisibleItems();
+			expect(visible).toHaveLength(1);
+			expect(visible[0]?.text).toBe('Apple');
+		});
+
+		it('should clear filter', () => {
+			ms.setFilter('xyz');
+			ms.clearFilter();
+
+			const visible = ms.getVisibleItems();
+			expect(visible).toHaveLength(5);
+		});
+
+		it('should get filter query', () => {
+			ms.setFilter('test');
+			expect(ms.getFilter()).toBe('test');
+		});
+
+		it('should preserve selections across filter changes', () => {
+			ms.toggleItem(0); // Select Apple
+			ms.toggleItem(2); // Select Cherry
+
+			ms.setFilter('Ch'); // Only Cherry visible
+			expect(ms.getSelectedCount()).toBe(2); // Both still selected
+
+			ms.clearFilter();
+			expect(ms.isSelected(0)).toBe(true);
+			expect(ms.isSelected(2)).toBe(true);
+		});
+
+		it('should clamp cursor on filter', () => {
+			ms.select(4); // Last item
+			ms.setFilter('Apple'); // Only 1 item visible
+			expect(ms.getCursorIndex()).toBe(0);
+		});
+	});
+
+	describe('render lines', () => {
+		beforeEach(() => {
+			ms = createMultiSelect(world, { items: ['A', 'B', 'C'], width: 20 });
+		});
+
+		it('should render lines with checkboxes', () => {
+			const lines = ms.getRenderLines();
+			expect(lines).toHaveLength(3);
+			expect(lines[0]).toContain('[ ]');
+			expect(lines[0]).toContain('A');
+		});
+
+		it('should show checked items', () => {
+			ms.toggleItem(1);
+			const lines = ms.getRenderLines();
+			expect(lines[1]).toContain('[x]');
+		});
+
+		it('should show cursor indicator', () => {
+			ms.select(0);
+			const lines = ms.getRenderLines();
+			expect(lines[0]).toMatch(/^>/);
+			expect(lines[1]).toMatch(/^ /);
+		});
+
+		it('should truncate long text', () => {
+			ms = createMultiSelect(world, {
+				items: ['This is a very long item name that should be truncated'],
+				width: 20,
+			});
+
+			const lines = ms.getRenderLines();
+			expect(lines[0]).toBeDefined();
+			expect((lines[0] as string).length).toBeLessThanOrEqual(20);
+		});
+	});
+
+	describe('events', () => {
+		beforeEach(() => {
+			ms = createMultiSelect(world, { items });
+		});
+
+		it('should fire selection change callback', () => {
+			const callback = vi.fn();
+			ms.onSelectionChange(callback);
+
+			ms.toggleItem(0);
+			expect(callback).toHaveBeenCalledWith([0], expect.any(Array));
+		});
+
+		it('should fire on select all', () => {
+			const callback = vi.fn();
+			ms.onSelectionChange(callback);
+
+			ms.selectAll();
+			expect(callback).toHaveBeenCalled();
+			const [indices] = callback.mock.calls[0] as [number[], unknown];
+			expect(indices).toHaveLength(5);
+		});
+
+		it('should fire on deselect all', () => {
+			ms.selectAll();
+			const callback = vi.fn();
+			ms.onSelectionChange(callback);
+
+			ms.deselectAll();
+			expect(callback).toHaveBeenCalledWith([], []);
+		});
+
+		it('should unsubscribe callback', () => {
+			const callback = vi.fn();
+			const unsub = ms.onSelectionChange(callback);
+
+			unsub();
+			ms.toggleItem(0);
+			expect(callback).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('key handling', () => {
+		beforeEach(() => {
+			ms = createMultiSelect(world, { items });
+		});
+
+		it('should handle down arrow', () => {
+			ms.handleKey('down');
+			expect(ms.getCursorIndex()).toBe(1);
+		});
+
+		it('should handle up arrow', () => {
+			ms.handleKey('down');
+			ms.handleKey('up');
+			expect(ms.getCursorIndex()).toBe(0);
+		});
+
+		it('should handle j/k vim keys', () => {
+			ms.handleKey('j');
+			expect(ms.getCursorIndex()).toBe(1);
+			ms.handleKey('k');
+			expect(ms.getCursorIndex()).toBe(0);
+		});
+
+		it('should handle space to toggle', () => {
+			ms.handleKey(' ');
+			expect(ms.isSelected(0)).toBe(true);
+		});
+
+		it('should handle Ctrl+A to select all', () => {
+			ms.handleKey('a', true);
+			expect(ms.getSelectedCount()).toBe(5);
+		});
+
+		it('should handle Ctrl+A to deselect all when all selected', () => {
+			ms.selectAll();
+			ms.handleKey('a', true);
+			expect(ms.getSelectedCount()).toBe(0);
+		});
+
+		it('should handle Shift+Down for range select', () => {
+			ms.handleKey('down', false, true);
+			expect(ms.isSelected(0)).toBe(true);
+			expect(ms.isSelected(1)).toBe(true);
+		});
+
+		it('should handle Shift+Up for range select', () => {
+			ms.select(2);
+			ms.handleKey('up', false, true);
+			expect(ms.isSelected(1)).toBe(true);
+			expect(ms.isSelected(2)).toBe(true);
+		});
+
+		it('should handle home/end keys', () => {
+			ms.handleKey('end');
+			expect(ms.getCursorIndex()).toBe(4);
+			ms.handleKey('home');
+			expect(ms.getCursorIndex()).toBe(0);
+		});
+
+		it('should handle g/G vim keys', () => {
+			ms.handleKey('G');
+			expect(ms.getCursorIndex()).toBe(4);
+			ms.handleKey('g');
+			expect(ms.getCursorIndex()).toBe(0);
+		});
+
+		it('should handle escape to clear filter first', () => {
+			ms.setFilter('test');
+			ms.handleKey('escape');
+			expect(ms.getFilter()).toBe('');
+			expect(ms.isFocused()).toBe(false); // Not blurred yet
+
+			ms.focus();
+			ms.handleKey('escape');
+			expect(ms.isFocused()).toBe(false);
+		});
+
+		it('should handle typing for filter', () => {
+			ms.handleKey('a');
+			expect(ms.getFilter()).toBe('a');
+		});
+
+		it('should handle backspace for filter', () => {
+			ms.setFilter('abc');
+			ms.handleKey('backspace');
+			expect(ms.getFilter()).toBe('ab');
+		});
+
+		it('should return false for unhandled keys', () => {
+			const result = ms.handleKey('f5');
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('standalone API functions', () => {
+		it('should get selected items via getSelectedItems', () => {
+			ms = createMultiSelect(world, { items });
+			ms.toggleItem(0);
+			ms.toggleItem(2);
+
+			const selected = getSelectedItems(world, ms.eid);
+			expect(selected).toHaveLength(2);
+			expect(selected[0]?.text).toBe('Apple');
+		});
+
+		it('should return empty for non-existent entity', () => {
+			const selected = getSelectedItems(world, eid);
+			expect(selected).toEqual([]);
+		});
+
+		it('should register via onSelectionChange', () => {
+			ms = createMultiSelect(world, { items });
+			const callback = vi.fn();
+
+			onSelectionChange(world, ms.eid, callback);
+			ms.toggleItem(0);
+			expect(callback).toHaveBeenCalled();
+		});
+
+		it('should return no-op unsub for non-existent entity', () => {
+			const unsub = onSelectionChange(world, eid, vi.fn());
+			expect(() => unsub()).not.toThrow();
+		});
+	});
+
+	describe('item management', () => {
+		beforeEach(() => {
+			ms = createMultiSelect(world, { items });
+		});
+
+		it('should set new items', () => {
+			ms.setItems(['X', 'Y', 'Z']);
+			expect(ms.getItems()).toHaveLength(3);
+			expect(ms.getItems()[0]?.text).toBe('X');
+		});
+
+		it('should clear out-of-bounds selections on item change', () => {
+			ms.toggleItem(4); // Select last item
+			ms.setItems(['A', 'B']); // Now only 2 items
+			expect(ms.isSelected(4)).toBe(false);
+		});
+
+		it('should clamp cursor on item change', () => {
+			ms.select(4);
+			ms.setItems(['A', 'B']);
+			expect(ms.getCursorIndex()).toBeLessThanOrEqual(1);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('should destroy the widget', () => {
+			ms = createMultiSelect(world, { items });
+			const msEid = ms.eid;
+
+			expect(isMultiSelect(world, msEid)).toBe(true);
+
+			ms.destroy();
+			expect(isMultiSelect(world, msEid)).toBe(false);
+		});
+	});
+});

--- a/src/widgets/multiSelect.ts
+++ b/src/widgets/multiSelect.ts
@@ -1,0 +1,983 @@
+/**
+ * Multi-Select Widget
+ *
+ * A standalone multi-select dropdown/list with checkbox display,
+ * filter-as-you-type, range selection, and keyboard-only navigation.
+ *
+ * @module widgets/multiSelect
+ *
+ * @example
+ * ```typescript
+ * import { createMultiSelect, getSelectedItems, onSelectionChange } from 'blecsd';
+ *
+ * const world = createWorld();
+ * const ms = createMultiSelect(world, {
+ *   items: ['Apple', 'Banana', 'Cherry', 'Date'],
+ *   width: 30,
+ *   height: 10,
+ * });
+ *
+ * // Toggle items
+ * ms.focus().select(0).toggleCurrent();
+ *
+ * // Get selected
+ * const selected = getSelectedItems(world, ms.eid);
+ * console.log(selected); // ['Apple']
+ *
+ * // Listen for changes
+ * onSelectionChange(world, ms.eid, (items) => {
+ *   console.log('Selected:', items);
+ * });
+ * ```
+ */
+
+import { z } from 'zod';
+import { addEntity, removeEntity } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/** Default widget dimensions */
+const DEFAULT_WIDTH = 30;
+const DEFAULT_HEIGHT = 10;
+
+/** Default entity capacity for typed arrays */
+const DEFAULT_CAPACITY = 10000;
+
+/** Checkbox display characters */
+const CHECKBOX_CHECKED = '[x]';
+const CHECKBOX_UNCHECKED = '[ ]';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * A multi-select item with display text and optional value.
+ *
+ * @example
+ * ```typescript
+ * const item: MultiSelectItem = {
+ *   text: 'Option A',
+ *   value: 'a',
+ *   disabled: false,
+ * };
+ * ```
+ */
+export interface MultiSelectItem {
+	/** Display text */
+	readonly text: string;
+	/** Optional value (defaults to text) */
+	readonly value?: string | undefined;
+	/** Whether the item is disabled and cannot be selected */
+	readonly disabled?: boolean | undefined;
+}
+
+/**
+ * Configuration for creating a MultiSelect widget.
+ *
+ * @example
+ * ```typescript
+ * const config: MultiSelectConfig = {
+ *   items: ['Apple', 'Banana', 'Cherry'],
+ *   width: 30,
+ *   height: 10,
+ *   selected: [0, 2],
+ * };
+ * ```
+ */
+export interface MultiSelectConfig {
+	/** X position @default 0 */
+	readonly x?: number;
+	/** Y position @default 0 */
+	readonly y?: number;
+	/** Width in columns @default 30 */
+	readonly width?: number;
+	/** Height in rows @default 10 */
+	readonly height?: number;
+	/** Items as strings or MultiSelectItem objects */
+	readonly items?: readonly (string | MultiSelectItem)[];
+	/** Initially selected indices @default [] */
+	readonly selected?: readonly number[];
+	/** Foreground color for normal items */
+	readonly fg?: number;
+	/** Background color for normal items */
+	readonly bg?: number;
+	/** Foreground color for the highlighted/cursor item */
+	readonly cursorFg?: number;
+	/** Background color for the highlighted/cursor item */
+	readonly cursorBg?: number;
+	/** Foreground color for selected items */
+	readonly selectedFg?: number;
+	/** Background color for selected items */
+	readonly selectedBg?: number;
+	/** Foreground color for disabled items */
+	readonly disabledFg?: number;
+	/** Whether to enable filter-as-you-type @default true */
+	readonly filterable?: boolean;
+}
+
+/**
+ * Callback fired when the selection changes.
+ */
+export type SelectionChangeCallback = (
+	selectedIndices: readonly number[],
+	selectedItems: readonly MultiSelectItem[],
+) => void;
+
+/**
+ * MultiSelect widget interface providing chainable methods.
+ */
+export interface MultiSelectWidget {
+	/** The underlying entity ID */
+	readonly eid: Entity;
+
+	// Visibility
+	/** Shows the widget */
+	show(): MultiSelectWidget;
+	/** Hides the widget */
+	hide(): MultiSelectWidget;
+
+	// Focus
+	/** Focuses the widget */
+	focus(): MultiSelectWidget;
+	/** Blurs the widget */
+	blur(): MultiSelectWidget;
+	/** Returns whether the widget is focused */
+	isFocused(): boolean;
+
+	// Cursor
+	/** Moves cursor to a specific index */
+	select(index: number): MultiSelectWidget;
+	/** Gets the current cursor index */
+	getCursorIndex(): number;
+	/** Moves cursor up */
+	cursorUp(): MultiSelectWidget;
+	/** Moves cursor down */
+	cursorDown(): MultiSelectWidget;
+	/** Moves to first item */
+	cursorFirst(): MultiSelectWidget;
+	/** Moves to last item */
+	cursorLast(): MultiSelectWidget;
+	/** Scrolls up by page */
+	pageUp(): MultiSelectWidget;
+	/** Scrolls down by page */
+	pageDown(): MultiSelectWidget;
+
+	// Selection
+	/** Toggles the selection of the current item */
+	toggleCurrent(): MultiSelectWidget;
+	/** Toggles the selection of a specific item by index */
+	toggleItem(index: number): MultiSelectWidget;
+	/** Selects all items */
+	selectAll(): MultiSelectWidget;
+	/** Deselects all items */
+	deselectAll(): MultiSelectWidget;
+	/** Range select from anchor to current cursor (Shift+Arrow behavior) */
+	rangeSelectTo(index: number): MultiSelectWidget;
+	/** Gets all selected indices (sorted) */
+	getSelectedIndices(): readonly number[];
+	/** Gets all selected items */
+	getSelectedItems(): readonly MultiSelectItem[];
+	/** Gets the count of selected items */
+	getSelectedCount(): number;
+	/** Gets a formatted status string like "3 selected" */
+	getSelectionStatus(): string;
+	/** Checks if a specific index is selected */
+	isSelected(index: number): boolean;
+
+	// Items
+	/** Sets the items */
+	setItems(items: readonly (string | MultiSelectItem)[]): MultiSelectWidget;
+	/** Gets all items */
+	getItems(): readonly MultiSelectItem[];
+	/** Gets visible items (after filtering) */
+	getVisibleItems(): readonly MultiSelectItem[];
+
+	// Filter
+	/** Sets the filter query (filter-as-you-type) */
+	setFilter(query: string): MultiSelectWidget;
+	/** Gets the current filter query */
+	getFilter(): string;
+	/** Clears the filter */
+	clearFilter(): MultiSelectWidget;
+
+	// Rendering helpers
+	/** Gets the rendered lines for display (with checkboxes) */
+	getRenderLines(): readonly string[];
+
+	// Events
+	/** Registers a callback for selection changes */
+	onSelectionChange(callback: SelectionChangeCallback): () => void;
+
+	// Key handling
+	/** Handles a key press, returns true if consumed */
+	handleKey(key: string, ctrl?: boolean, shift?: boolean): boolean;
+
+	// Lifecycle
+	/** Destroys the widget */
+	destroy(): void;
+}
+
+// =============================================================================
+// SCHEMAS
+// =============================================================================
+
+/**
+ * Zod schema for MultiSelectConfig validation.
+ */
+export const MultiSelectConfigSchema = z.object({
+	x: z.number().int().default(0),
+	y: z.number().int().default(0),
+	width: z.number().int().positive().default(DEFAULT_WIDTH),
+	height: z.number().int().positive().default(DEFAULT_HEIGHT),
+	items: z
+		.array(
+			z.union([
+				z.string(),
+				z.object({
+					text: z.string(),
+					value: z.string().optional(),
+					disabled: z.boolean().optional(),
+				}),
+			]),
+		)
+		.default([]),
+	selected: z.array(z.number().int().nonnegative()).default([]),
+	fg: z.number().int().nonnegative().optional(),
+	bg: z.number().int().nonnegative().optional(),
+	cursorFg: z.number().int().nonnegative().optional(),
+	cursorBg: z.number().int().nonnegative().optional(),
+	selectedFg: z.number().int().nonnegative().optional(),
+	selectedBg: z.number().int().nonnegative().optional(),
+	disabledFg: z.number().int().nonnegative().optional(),
+	filterable: z.boolean().default(true),
+});
+
+// =============================================================================
+// COMPONENT TAG
+// =============================================================================
+
+/**
+ * MultiSelect component marker for identifying multi-select entities.
+ *
+ * @example
+ * ```typescript
+ * import { MultiSelect } from 'blecsd';
+ *
+ * if (MultiSelect.isMultiSelect[eid] === 1) {
+ *   // Entity is a multi-select widget
+ * }
+ * ```
+ */
+export const MultiSelect = {
+	/** Tag indicating this is a multi-select widget (1 = yes) */
+	isMultiSelect: new Uint8Array(DEFAULT_CAPACITY),
+	/** Whether the widget is visible (0 = hidden, 1 = visible) */
+	visible: new Uint8Array(DEFAULT_CAPACITY),
+	/** Whether the widget is focused (0 = no, 1 = yes) */
+	focused: new Uint8Array(DEFAULT_CAPACITY),
+};
+
+// =============================================================================
+// INTERNAL STATE
+// =============================================================================
+
+interface MultiSelectState {
+	items: MultiSelectItem[];
+	selected: Set<number>;
+	cursorIndex: number;
+	rangeAnchor: number;
+	filterQuery: string;
+	filteredIndices: number[];
+	filterable: boolean;
+	firstVisible: number;
+	visibleCount: number;
+	width: number;
+	fg: number;
+	bg: number;
+	cursorFg: number;
+	cursorBg: number;
+	selectedFg: number;
+	selectedBg: number;
+	disabledFg: number;
+	selectionCallbacks: SelectionChangeCallback[];
+}
+
+const stateMap = new Map<Entity, MultiSelectState>();
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+/**
+ * Handles navigation keys for multi-select.
+ */
+function handleMultiSelectNav(
+	widget: MultiSelectWidget,
+	state: MultiSelectState,
+	key: string,
+	shift: boolean,
+): boolean {
+	if (key === 'up' || key === 'k') {
+		if (shift) {
+			widget.rangeSelectTo(Math.max(0, state.cursorIndex - 1));
+		} else {
+			widget.cursorUp();
+			state.rangeAnchor = state.cursorIndex;
+		}
+		return true;
+	}
+
+	if (key === 'down' || key === 'j') {
+		if (shift) {
+			widget.rangeSelectTo(Math.min(state.filteredIndices.length - 1, state.cursorIndex + 1));
+		} else {
+			widget.cursorDown();
+			state.rangeAnchor = state.cursorIndex;
+		}
+		return true;
+	}
+
+	if (key === 'home' || key === 'g') {
+		widget.cursorFirst();
+		return true;
+	}
+	if (key === 'end' || key === 'G') {
+		widget.cursorLast();
+		return true;
+	}
+	if (key === 'pageup') {
+		widget.pageUp();
+		return true;
+	}
+	if (key === 'pagedown') {
+		widget.pageDown();
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Handles filter input keys for multi-select.
+ */
+function handleMultiSelectFilter(
+	widget: MultiSelectWidget,
+	state: MultiSelectState,
+	key: string,
+	ctrl: boolean,
+): boolean {
+	if (state.filterable && key.length === 1 && !ctrl) {
+		state.filterQuery += key;
+		recalculateFilter(state);
+		return true;
+	}
+
+	if (state.filterable && key === 'backspace') {
+		if (state.filterQuery.length > 0) {
+			state.filterQuery = state.filterQuery.slice(0, -1);
+			recalculateFilter(state);
+		}
+		return true;
+	}
+
+	if (key === 'escape') {
+		if (state.filterQuery.length > 0) {
+			state.filterQuery = '';
+			recalculateFilter(state);
+		} else {
+			widget.blur();
+		}
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Handles key input for the multi-select widget.
+ */
+function handleMultiSelectKey(
+	widget: MultiSelectWidget,
+	state: MultiSelectState,
+	key: string,
+	ctrl: boolean,
+	shift: boolean,
+): boolean {
+	if (ctrl && key === 'a') {
+		if (state.selected.size === state.items.length) {
+			widget.deselectAll();
+		} else {
+			widget.selectAll();
+		}
+		return true;
+	}
+
+	if (handleMultiSelectNav(widget, state, key, shift)) {
+		return true;
+	}
+
+	if (key === ' ') {
+		widget.toggleCurrent();
+		return true;
+	}
+
+	return handleMultiSelectFilter(widget, state, key, ctrl);
+}
+
+/**
+ * Normalizes items from string or MultiSelectItem to MultiSelectItem.
+ */
+function normalizeItems(items: readonly (string | MultiSelectItem)[]): MultiSelectItem[] {
+	return items.map((item) => {
+		if (typeof item === 'string') {
+			return { text: item, value: item };
+		}
+		return { ...item, value: item.value ?? item.text };
+	});
+}
+
+/**
+ * Recalculates filtered indices based on current filter query.
+ */
+function recalculateFilter(state: MultiSelectState): void {
+	if (state.filterQuery.length === 0) {
+		state.filteredIndices = state.items.map((_, i) => i);
+		return;
+	}
+
+	const lowerQuery = state.filterQuery.toLowerCase();
+	state.filteredIndices = [];
+	for (let i = 0; i < state.items.length; i++) {
+		const item = state.items[i];
+		if (item?.text.toLowerCase().includes(lowerQuery)) {
+			state.filteredIndices.push(i);
+		}
+	}
+
+	// Clamp cursor
+	if (state.filteredIndices.length === 0) {
+		state.cursorIndex = -1;
+	} else if (state.cursorIndex >= state.filteredIndices.length) {
+		state.cursorIndex = state.filteredIndices.length - 1;
+	} else if (state.cursorIndex < 0) {
+		state.cursorIndex = 0;
+	}
+	state.firstVisible = 0;
+}
+
+/**
+ * Fires selection change callbacks.
+ */
+function fireSelectionCallbacks(state: MultiSelectState): void {
+	const indices = Array.from(state.selected).sort((a, b) => a - b);
+	const items = indices
+		.map((i) => state.items[i])
+		.filter((item): item is MultiSelectItem => item !== undefined);
+
+	for (const cb of state.selectionCallbacks) {
+		cb(indices, items);
+	}
+}
+
+/**
+ * Gets the actual item index from the filtered view index.
+ */
+function getActualIndex(state: MultiSelectState, filteredIdx: number): number {
+	const idx = state.filteredIndices[filteredIdx];
+	return idx ?? -1;
+}
+
+/**
+ * Ensures the cursor is visible in the viewport.
+ */
+function ensureCursorVisible(state: MultiSelectState): void {
+	if (state.cursorIndex < state.firstVisible) {
+		state.firstVisible = state.cursorIndex;
+	} else if (state.cursorIndex >= state.firstVisible + state.visibleCount) {
+		state.firstVisible = state.cursorIndex - state.visibleCount + 1;
+	}
+}
+
+// =============================================================================
+// FACTORY
+// =============================================================================
+
+/**
+ * Creates a MultiSelect widget.
+ *
+ * @param world - The ECS world
+ * @param config - Widget configuration
+ * @returns The MultiSelectWidget instance
+ *
+ * @example
+ * ```typescript
+ * import { createWorld } from 'blecsd';
+ * import { createMultiSelect } from 'blecsd';
+ *
+ * const world = createWorld();
+ * const ms = createMultiSelect(world, {
+ *   items: ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry'],
+ *   width: 30,
+ *   height: 8,
+ *   selected: [0, 2],
+ * });
+ *
+ * ms.focus();
+ * console.log(ms.getSelectionStatus()); // "2 selected"
+ *
+ * ms.handleKey(' '); // Toggle current
+ * ms.handleKey('down'); // Move cursor
+ * ```
+ */
+export function createMultiSelect(world: World, config: MultiSelectConfig = {}): MultiSelectWidget {
+	const validated = MultiSelectConfigSchema.parse(config);
+	const eid = addEntity(world);
+
+	// Mark as multi-select
+	MultiSelect.isMultiSelect[eid] = 1;
+	MultiSelect.visible[eid] = 1;
+	MultiSelect.focused[eid] = 0;
+
+	const items = normalizeItems(validated.items);
+
+	// Initialize selected set
+	const selected = new Set<number>();
+	for (const idx of validated.selected) {
+		if (idx >= 0 && idx < items.length) {
+			const item = items[idx];
+			if (item && !item.disabled) {
+				selected.add(idx);
+			}
+		}
+	}
+
+	// Determine visible count (account for filter input line if filterable)
+	const filterLineHeight = validated.filterable ? 1 : 0;
+	const visibleCount = Math.max(1, validated.height - filterLineHeight);
+
+	const state: MultiSelectState = {
+		items,
+		selected,
+		cursorIndex: items.length > 0 ? 0 : -1,
+		rangeAnchor: 0,
+		filterQuery: '',
+		filteredIndices: items.map((_, i) => i),
+		filterable: validated.filterable,
+		firstVisible: 0,
+		visibleCount,
+		width: validated.width,
+		fg: validated.fg ?? 0xffffffff,
+		bg: validated.bg ?? 0x000000ff,
+		cursorFg: validated.cursorFg ?? 0x000000ff,
+		cursorBg: validated.cursorBg ?? 0x0088ffff,
+		selectedFg: validated.selectedFg ?? 0x00ff00ff,
+		selectedBg: validated.selectedBg ?? 0x000000ff,
+		disabledFg: validated.disabledFg ?? 0x888888ff,
+		selectionCallbacks: [],
+	};
+
+	stateMap.set(eid, state);
+
+	const widget: MultiSelectWidget = {
+		eid,
+
+		// Visibility
+		show(): MultiSelectWidget {
+			MultiSelect.visible[eid] = 1;
+			return widget;
+		},
+
+		hide(): MultiSelectWidget {
+			MultiSelect.visible[eid] = 0;
+			return widget;
+		},
+
+		// Focus
+		focus(): MultiSelectWidget {
+			MultiSelect.focused[eid] = 1;
+			return widget;
+		},
+
+		blur(): MultiSelectWidget {
+			MultiSelect.focused[eid] = 0;
+			return widget;
+		},
+
+		isFocused(): boolean {
+			return MultiSelect.focused[eid] === 1;
+		},
+
+		// Cursor
+		select(index: number): MultiSelectWidget {
+			if (index >= 0 && index < state.filteredIndices.length) {
+				state.cursorIndex = index;
+				state.rangeAnchor = index;
+				ensureCursorVisible(state);
+			}
+			return widget;
+		},
+
+		getCursorIndex(): number {
+			return state.cursorIndex;
+		},
+
+		cursorUp(): MultiSelectWidget {
+			if (state.cursorIndex > 0) {
+				state.cursorIndex--;
+				ensureCursorVisible(state);
+			}
+			return widget;
+		},
+
+		cursorDown(): MultiSelectWidget {
+			if (state.cursorIndex < state.filteredIndices.length - 1) {
+				state.cursorIndex++;
+				ensureCursorVisible(state);
+			}
+			return widget;
+		},
+
+		cursorFirst(): MultiSelectWidget {
+			if (state.filteredIndices.length > 0) {
+				state.cursorIndex = 0;
+				state.firstVisible = 0;
+			}
+			return widget;
+		},
+
+		cursorLast(): MultiSelectWidget {
+			if (state.filteredIndices.length > 0) {
+				state.cursorIndex = state.filteredIndices.length - 1;
+				ensureCursorVisible(state);
+			}
+			return widget;
+		},
+
+		pageUp(): MultiSelectWidget {
+			state.cursorIndex = Math.max(0, state.cursorIndex - state.visibleCount);
+			ensureCursorVisible(state);
+			return widget;
+		},
+
+		pageDown(): MultiSelectWidget {
+			state.cursorIndex = Math.min(
+				state.filteredIndices.length - 1,
+				state.cursorIndex + state.visibleCount,
+			);
+			ensureCursorVisible(state);
+			return widget;
+		},
+
+		// Selection
+		toggleCurrent(): MultiSelectWidget {
+			if (state.cursorIndex < 0 || state.cursorIndex >= state.filteredIndices.length) {
+				return widget;
+			}
+
+			const actualIdx = getActualIndex(state, state.cursorIndex);
+			if (actualIdx < 0) {
+				return widget;
+			}
+
+			const item = state.items[actualIdx];
+			if (item?.disabled) {
+				return widget;
+			}
+
+			if (state.selected.has(actualIdx)) {
+				state.selected.delete(actualIdx);
+			} else {
+				state.selected.add(actualIdx);
+			}
+
+			state.rangeAnchor = state.cursorIndex;
+			fireSelectionCallbacks(state);
+			return widget;
+		},
+
+		toggleItem(index: number): MultiSelectWidget {
+			if (index < 0 || index >= state.items.length) {
+				return widget;
+			}
+
+			const item = state.items[index];
+			if (item?.disabled) {
+				return widget;
+			}
+
+			if (state.selected.has(index)) {
+				state.selected.delete(index);
+			} else {
+				state.selected.add(index);
+			}
+
+			fireSelectionCallbacks(state);
+			return widget;
+		},
+
+		selectAll(): MultiSelectWidget {
+			for (let i = 0; i < state.items.length; i++) {
+				const item = state.items[i];
+				if (item && !item.disabled) {
+					state.selected.add(i);
+				}
+			}
+			fireSelectionCallbacks(state);
+			return widget;
+		},
+
+		deselectAll(): MultiSelectWidget {
+			state.selected.clear();
+			fireSelectionCallbacks(state);
+			return widget;
+		},
+
+		rangeSelectTo(index: number): MultiSelectWidget {
+			if (index < 0 || index >= state.filteredIndices.length) {
+				return widget;
+			}
+
+			const start = Math.min(state.rangeAnchor, index);
+			const end = Math.max(state.rangeAnchor, index);
+
+			for (let i = start; i <= end; i++) {
+				const actualIdx = getActualIndex(state, i);
+				if (actualIdx >= 0) {
+					const item = state.items[actualIdx];
+					if (item && !item.disabled) {
+						state.selected.add(actualIdx);
+					}
+				}
+			}
+
+			state.cursorIndex = index;
+			ensureCursorVisible(state);
+			fireSelectionCallbacks(state);
+			return widget;
+		},
+
+		getSelectedIndices(): readonly number[] {
+			return Array.from(state.selected).sort((a, b) => a - b);
+		},
+
+		getSelectedItems(): readonly MultiSelectItem[] {
+			return Array.from(state.selected)
+				.sort((a, b) => a - b)
+				.map((i) => state.items[i])
+				.filter((item): item is MultiSelectItem => item !== undefined);
+		},
+
+		getSelectedCount(): number {
+			return state.selected.size;
+		},
+
+		getSelectionStatus(): string {
+			const count = state.selected.size;
+			if (count === 0) {
+				return 'None selected';
+			}
+			return `${count} selected`;
+		},
+
+		isSelected(index: number): boolean {
+			return state.selected.has(index);
+		},
+
+		// Items
+		setItems(newItems: readonly (string | MultiSelectItem)[]): MultiSelectWidget {
+			state.items = normalizeItems(newItems);
+			// Remove selections that are out of bounds
+			for (const idx of state.selected) {
+				if (idx >= state.items.length) {
+					state.selected.delete(idx);
+				}
+			}
+			recalculateFilter(state);
+			if (state.cursorIndex >= state.filteredIndices.length) {
+				state.cursorIndex = Math.max(0, state.filteredIndices.length - 1);
+			}
+			return widget;
+		},
+
+		getItems(): readonly MultiSelectItem[] {
+			return state.items;
+		},
+
+		getVisibleItems(): readonly MultiSelectItem[] {
+			return state.filteredIndices
+				.map((i) => state.items[i])
+				.filter((item): item is MultiSelectItem => item !== undefined);
+		},
+
+		// Filter
+		setFilter(query: string): MultiSelectWidget {
+			state.filterQuery = query;
+			recalculateFilter(state);
+			return widget;
+		},
+
+		getFilter(): string {
+			return state.filterQuery;
+		},
+
+		clearFilter(): MultiSelectWidget {
+			state.filterQuery = '';
+			recalculateFilter(state);
+			return widget;
+		},
+
+		// Rendering helpers
+		getRenderLines(): readonly string[] {
+			const lines: string[] = [];
+			const startIdx = state.firstVisible;
+			const endIdx = Math.min(startIdx + state.visibleCount, state.filteredIndices.length);
+
+			for (let i = startIdx; i < endIdx; i++) {
+				const actualIdx = getActualIndex(state, i);
+				if (actualIdx < 0) {
+					continue;
+				}
+				const item = state.items[actualIdx];
+				if (!item) {
+					continue;
+				}
+
+				const checkbox = state.selected.has(actualIdx) ? CHECKBOX_CHECKED : CHECKBOX_UNCHECKED;
+				const cursor = i === state.cursorIndex ? '>' : ' ';
+				const text = item.text;
+				const maxTextWidth = Math.max(0, state.width - 6); // cursor + space + checkbox + space
+				const truncated = text.length > maxTextWidth ? `${text.slice(0, maxTextWidth - 1)}~` : text;
+
+				lines.push(`${cursor} ${checkbox} ${truncated}`);
+			}
+
+			return lines;
+		},
+
+		// Events
+		onSelectionChange(callback: SelectionChangeCallback): () => void {
+			state.selectionCallbacks.push(callback);
+			return () => {
+				const idx = state.selectionCallbacks.indexOf(callback);
+				if (idx !== -1) {
+					state.selectionCallbacks.splice(idx, 1);
+				}
+			};
+		},
+
+		// Key handling
+		handleKey(key: string, ctrl = false, shift = false): boolean {
+			return handleMultiSelectKey(widget, state, key, ctrl, shift);
+		},
+
+		// Lifecycle
+		destroy(): void {
+			MultiSelect.isMultiSelect[eid] = 0;
+			MultiSelect.visible[eid] = 0;
+			MultiSelect.focused[eid] = 0;
+			stateMap.delete(eid);
+			removeEntity(world, eid);
+		},
+	};
+
+	return widget;
+}
+
+// =============================================================================
+// STANDALONE API FUNCTIONS
+// =============================================================================
+
+/**
+ * Gets the selected items from a MultiSelect entity.
+ *
+ * @param _world - The ECS world
+ * @param eid - The multi-select entity ID
+ * @returns Array of selected items, or empty array if not a multi-select
+ *
+ * @example
+ * ```typescript
+ * import { getSelectedItems } from 'blecsd';
+ *
+ * const items = getSelectedItems(world, multiSelectEid);
+ * console.log(items.map(i => i.text));
+ * ```
+ */
+export function getSelectedItems(_world: World, eid: Entity): readonly MultiSelectItem[] {
+	const state = stateMap.get(eid);
+	if (!state) {
+		return [];
+	}
+	return Array.from(state.selected)
+		.sort((a, b) => a - b)
+		.map((i) => state.items[i])
+		.filter((item): item is MultiSelectItem => item !== undefined);
+}
+
+/**
+ * Registers a callback for when the selection changes on a MultiSelect entity.
+ *
+ * @param _world - The ECS world
+ * @param eid - The multi-select entity ID
+ * @param callback - The callback to fire on selection change
+ * @returns Unsubscribe function
+ *
+ * @example
+ * ```typescript
+ * import { onSelectionChange } from 'blecsd';
+ *
+ * const unsub = onSelectionChange(world, msEid, (indices, items) => {
+ *   console.log(`${items.length} items selected`);
+ * });
+ *
+ * // Later: unsub();
+ * ```
+ */
+export function onSelectionChange(
+	_world: World,
+	eid: Entity,
+	callback: SelectionChangeCallback,
+): () => void {
+	const state = stateMap.get(eid);
+	if (!state) {
+		return () => {};
+	}
+
+	state.selectionCallbacks.push(callback);
+	return () => {
+		const idx = state.selectionCallbacks.indexOf(callback);
+		if (idx !== -1) {
+			state.selectionCallbacks.splice(idx, 1);
+		}
+	};
+}
+
+// =============================================================================
+// UTILITY FUNCTIONS
+// =============================================================================
+
+/**
+ * Checks if an entity is a MultiSelect widget.
+ *
+ * @param _world - The ECS world (unused, for API consistency)
+ * @param eid - The entity ID
+ * @returns true if the entity is a multi-select widget
+ */
+export function isMultiSelect(_world: World, eid: Entity): boolean {
+	return MultiSelect.isMultiSelect[eid] === 1;
+}
+
+/**
+ * Resets the MultiSelect component store. Useful for testing.
+ *
+ * @internal
+ */
+export function resetMultiSelectStore(): void {
+	MultiSelect.isMultiSelect.fill(0);
+	MultiSelect.visible.fill(0);
+	MultiSelect.focused.fill(0);
+	stateMap.clear();
+}

--- a/src/widgets/searchOverlay.test.ts
+++ b/src/widgets/searchOverlay.test.ts
@@ -1,0 +1,588 @@
+/**
+ * SearchOverlay Widget Tests
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addEntity, createWorld } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+import {
+	attachSearchOverlay,
+	createSearchOverlay,
+	getSearchOverlayColors,
+	getSearchOverlayTarget,
+	isSearchOverlay,
+	resetSearchOverlayStore,
+	type SearchableContent,
+	type SearchOverlayWidget,
+} from './searchOverlay';
+
+describe('SearchOverlay Widget', () => {
+	let world: World;
+	let eid: Entity;
+	let overlay: SearchOverlayWidget;
+
+	const sampleContent: SearchableContent = {
+		getLineCount: () => 5,
+		getLine: (index: number) => {
+			const lines = [
+				'Hello world',
+				'foo bar baz',
+				'Hello again',
+				'testing 123',
+				'Hello world again',
+			];
+			return lines[index];
+		},
+	};
+
+	beforeEach(() => {
+		resetSearchOverlayStore();
+		world = createWorld() as World;
+		eid = addEntity(world) as Entity;
+	});
+
+	describe('createSearchOverlay', () => {
+		it('should create a search overlay widget', () => {
+			overlay = createSearchOverlay(world);
+
+			expect(overlay.eid).toBeDefined();
+			expect(isSearchOverlay(world, overlay.eid)).toBe(true);
+		});
+
+		it('should start hidden', () => {
+			overlay = createSearchOverlay(world);
+
+			expect(overlay.isVisible()).toBe(false);
+		});
+
+		it('should initialize with default values', () => {
+			overlay = createSearchOverlay(world);
+
+			expect(overlay.getQuery()).toBe('');
+			expect(overlay.getMode()).toBe('plain');
+			expect(overlay.isCaseSensitive()).toBe(false);
+			expect(overlay.getMatchCount()).toBe(0);
+			expect(overlay.getCurrentMatchIndex()).toBe(-1);
+		});
+
+		it('should accept custom configuration', () => {
+			overlay = createSearchOverlay(world, {
+				mode: 'regex',
+				caseSensitive: true,
+				width: 60,
+			});
+
+			expect(overlay.getMode()).toBe('regex');
+			expect(overlay.isCaseSensitive()).toBe(true);
+		});
+	});
+
+	describe('visibility', () => {
+		beforeEach(() => {
+			overlay = createSearchOverlay(world);
+		});
+
+		it('should show the overlay', () => {
+			const result = overlay.show();
+			expect(result).toBe(overlay);
+			expect(overlay.isVisible()).toBe(true);
+		});
+
+		it('should hide the overlay', () => {
+			overlay.show();
+			const result = overlay.hide();
+			expect(result).toBe(overlay);
+			expect(overlay.isVisible()).toBe(false);
+		});
+
+		it('should clear query when hidden', () => {
+			overlay.show().setQuery('test');
+			overlay.hide();
+			expect(overlay.getQuery()).toBe('');
+		});
+
+		it('should fire close callbacks when hidden', () => {
+			const callback = vi.fn();
+			overlay.onClose(callback);
+			overlay.show();
+			overlay.hide();
+			expect(callback).toHaveBeenCalled();
+		});
+	});
+
+	describe('search query', () => {
+		beforeEach(() => {
+			overlay = createSearchOverlay(world);
+			overlay.attachContent(sampleContent).show();
+		});
+
+		it('should set query', () => {
+			const result = overlay.setQuery('Hello');
+			expect(result).toBe(overlay);
+			expect(overlay.getQuery()).toBe('Hello');
+		});
+
+		it('should append character', () => {
+			overlay.appendChar('H').appendChar('e');
+			expect(overlay.getQuery()).toBe('He');
+		});
+
+		it('should backspace', () => {
+			overlay.setQuery('Hello');
+			overlay.backspace();
+			expect(overlay.getQuery()).toBe('Hell');
+		});
+
+		it('should not backspace past empty', () => {
+			overlay.backspace();
+			expect(overlay.getQuery()).toBe('');
+		});
+
+		it('should clear query', () => {
+			overlay.setQuery('test');
+			overlay.clearQuery();
+			expect(overlay.getQuery()).toBe('');
+		});
+	});
+
+	describe('plain text search', () => {
+		beforeEach(() => {
+			overlay = createSearchOverlay(world, { mode: 'plain' });
+			overlay.attachContent(sampleContent).show();
+		});
+
+		it('should find matches case-insensitively by default', () => {
+			overlay.setQuery('hello');
+			expect(overlay.getMatchCount()).toBe(3);
+		});
+
+		it('should find matches case-sensitively when enabled', () => {
+			overlay.setCaseSensitive(true).setQuery('Hello');
+			expect(overlay.getMatchCount()).toBe(3);
+		});
+
+		it('should not find non-existent text', () => {
+			overlay.setQuery('nonexistent');
+			expect(overlay.getMatchCount()).toBe(0);
+		});
+
+		it('should return correct match positions', () => {
+			overlay.setQuery('Hello');
+			const matches = overlay.getMatches();
+			expect(matches[0]).toEqual({ lineIndex: 0, charOffset: 0, length: 5 });
+			expect(matches[1]).toEqual({ lineIndex: 2, charOffset: 0, length: 5 });
+			expect(matches[2]).toEqual({ lineIndex: 4, charOffset: 0, length: 5 });
+		});
+
+		it('should clear matches when query is empty', () => {
+			overlay.setQuery('Hello');
+			expect(overlay.getMatchCount()).toBe(3);
+			overlay.clearQuery();
+			expect(overlay.getMatchCount()).toBe(0);
+		});
+
+		it('should escape regex characters in plain mode', () => {
+			const specialContent: SearchableContent = {
+				getLineCount: () => 2,
+				getLine: (i) => ['test.file', 'testXfile'][i],
+			};
+			overlay.attachContent(specialContent);
+			overlay.setQuery('test.file');
+			expect(overlay.getMatchCount()).toBe(1);
+		});
+	});
+
+	describe('regex search', () => {
+		beforeEach(() => {
+			overlay = createSearchOverlay(world, { mode: 'regex' });
+			overlay.attachContent(sampleContent).show();
+		});
+
+		it('should support regex patterns', () => {
+			overlay.setQuery('Hello.*$');
+			expect(overlay.getMatchCount()).toBe(3);
+		});
+
+		it('should handle invalid regex gracefully', () => {
+			overlay.setQuery('[invalid');
+			expect(overlay.getMatchCount()).toBe(0);
+		});
+
+		it('should match digit patterns', () => {
+			overlay.setQuery('\\d+');
+			expect(overlay.getMatchCount()).toBe(1);
+			expect(overlay.getMatches()[0]?.lineIndex).toBe(3);
+		});
+	});
+
+	describe('match navigation', () => {
+		beforeEach(() => {
+			overlay = createSearchOverlay(world);
+			overlay.attachContent(sampleContent).show();
+			overlay.setQuery('Hello');
+		});
+
+		it('should start at first match', () => {
+			expect(overlay.getCurrentMatchIndex()).toBe(0);
+		});
+
+		it('should navigate to next match', () => {
+			overlay.nextMatch();
+			expect(overlay.getCurrentMatchIndex()).toBe(1);
+		});
+
+		it('should wrap around to first match', () => {
+			overlay.nextMatch(); // 1
+			overlay.nextMatch(); // 2
+			overlay.nextMatch(); // wraps to 0
+			expect(overlay.getCurrentMatchIndex()).toBe(0);
+		});
+
+		it('should navigate to previous match', () => {
+			overlay.nextMatch(); // 1
+			overlay.prevMatch();
+			expect(overlay.getCurrentMatchIndex()).toBe(0);
+		});
+
+		it('should wrap around to last match going backward', () => {
+			overlay.prevMatch(); // wraps to 2
+			expect(overlay.getCurrentMatchIndex()).toBe(2);
+		});
+
+		it('should not navigate when no matches', () => {
+			overlay.setQuery('nonexistent');
+			overlay.nextMatch();
+			expect(overlay.getCurrentMatchIndex()).toBe(-1);
+		});
+	});
+
+	describe('match status', () => {
+		beforeEach(() => {
+			overlay = createSearchOverlay(world);
+			overlay.attachContent(sampleContent).show();
+		});
+
+		it('should return empty string when no query', () => {
+			expect(overlay.getMatchStatus()).toBe('');
+		});
+
+		it('should return "No matches" when query has no matches', () => {
+			overlay.setQuery('zzzzz');
+			expect(overlay.getMatchStatus()).toBe('No matches');
+		});
+
+		it('should return "1 of N" format', () => {
+			overlay.setQuery('Hello');
+			expect(overlay.getMatchStatus()).toBe('1 of 3');
+		});
+
+		it('should update status on navigation', () => {
+			overlay.setQuery('Hello');
+			overlay.nextMatch();
+			expect(overlay.getMatchStatus()).toBe('2 of 3');
+		});
+	});
+
+	describe('search mode', () => {
+		beforeEach(() => {
+			overlay = createSearchOverlay(world);
+		});
+
+		it('should toggle mode between plain and regex', () => {
+			expect(overlay.getMode()).toBe('plain');
+			overlay.toggleMode();
+			expect(overlay.getMode()).toBe('regex');
+			overlay.toggleMode();
+			expect(overlay.getMode()).toBe('plain');
+		});
+
+		it('should set mode directly', () => {
+			overlay.setMode('regex');
+			expect(overlay.getMode()).toBe('regex');
+		});
+
+		it('should re-search when mode changes', () => {
+			overlay.attachContent(sampleContent).show();
+			overlay.setQuery('\\d+');
+
+			// In plain mode, looks for literal "\d+"
+			expect(overlay.getMatchCount()).toBe(0);
+
+			// Switch to regex
+			overlay.setMode('regex');
+			expect(overlay.getMatchCount()).toBe(1);
+		});
+	});
+
+	describe('content attachment', () => {
+		beforeEach(() => {
+			overlay = createSearchOverlay(world);
+		});
+
+		it('should attach content', () => {
+			const result = overlay.attachContent(sampleContent);
+			expect(result).toBe(overlay);
+		});
+
+		it('should search attached content', () => {
+			overlay.attachContent(sampleContent).show();
+			overlay.setQuery('foo');
+			expect(overlay.getMatchCount()).toBe(1);
+		});
+
+		it('should detach content', () => {
+			overlay.attachContent(sampleContent).show();
+			overlay.setQuery('foo');
+			overlay.detachContent();
+			expect(overlay.getMatchCount()).toBe(0);
+		});
+
+		it('should clear matches on detach', () => {
+			overlay.attachContent(sampleContent).show();
+			overlay.setQuery('Hello');
+			overlay.detachContent();
+			expect(overlay.getCurrentMatchIndex()).toBe(-1);
+		});
+	});
+
+	describe('events', () => {
+		beforeEach(() => {
+			overlay = createSearchOverlay(world);
+			overlay.attachContent(sampleContent).show();
+		});
+
+		it('should fire match change callback on query change', () => {
+			const callback = vi.fn();
+			overlay.onMatchChange(callback);
+
+			overlay.setQuery('Hello');
+			expect(callback).toHaveBeenCalledWith(expect.any(Array), 0);
+		});
+
+		it('should fire match change callback on navigation', () => {
+			const callback = vi.fn();
+			overlay.setQuery('Hello');
+			overlay.onMatchChange(callback);
+
+			overlay.nextMatch();
+			expect(callback).toHaveBeenCalledWith(expect.any(Array), 1);
+		});
+
+		it('should unsubscribe match change callback', () => {
+			const callback = vi.fn();
+			const unsub = overlay.onMatchChange(callback);
+
+			unsub();
+			overlay.setQuery('Hello');
+			expect(callback).not.toHaveBeenCalled();
+		});
+
+		it('should fire close callback', () => {
+			const callback = vi.fn();
+			overlay.onClose(callback);
+
+			overlay.hide();
+			expect(callback).toHaveBeenCalled();
+		});
+
+		it('should unsubscribe close callback', () => {
+			const callback = vi.fn();
+			const unsub = overlay.onClose(callback);
+
+			unsub();
+			overlay.hide();
+			expect(callback).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('key handling', () => {
+		beforeEach(() => {
+			overlay = createSearchOverlay(world);
+			overlay.attachContent(sampleContent);
+		});
+
+		it('should open on Ctrl+F', () => {
+			const handled = overlay.handleKey('f', true);
+			expect(handled).toBe(true);
+			expect(overlay.isVisible()).toBe(true);
+		});
+
+		it('should not handle Ctrl+F when already visible', () => {
+			overlay.show();
+			// When visible, Ctrl+F is not consumed (key is 'f' without ctrl check)
+			const handled = overlay.handleKey('f', true);
+			// It should still return false for 'f' with ctrl when overlay is visible
+			// because 'f' with ctrl is not a regular character
+			expect(handled).toBe(false);
+		});
+
+		it('should close on Escape', () => {
+			overlay.show();
+			const handled = overlay.handleKey('escape');
+			expect(handled).toBe(true);
+			expect(overlay.isVisible()).toBe(false);
+		});
+
+		it('should append characters', () => {
+			overlay.show();
+			overlay.handleKey('h');
+			overlay.handleKey('i');
+			expect(overlay.getQuery()).toBe('hi');
+		});
+
+		it('should handle backspace', () => {
+			overlay.show();
+			overlay.setQuery('test');
+			overlay.handleKey('backspace');
+			expect(overlay.getQuery()).toBe('tes');
+		});
+
+		it('should navigate forward on Enter', () => {
+			overlay.show();
+			overlay.setQuery('Hello');
+			overlay.handleKey('enter');
+			expect(overlay.getCurrentMatchIndex()).toBe(1);
+		});
+
+		it('should navigate backward on Shift+Enter', () => {
+			overlay.show();
+			overlay.setQuery('Hello');
+			overlay.handleKey('enter', false, true);
+			expect(overlay.getCurrentMatchIndex()).toBe(2);
+		});
+
+		it('should toggle regex mode on Ctrl+R', () => {
+			overlay.show();
+			overlay.handleKey('r', true);
+			expect(overlay.getMode()).toBe('regex');
+		});
+
+		it('should toggle case sensitivity on Ctrl+I', () => {
+			overlay.show();
+			overlay.handleKey('i', true);
+			expect(overlay.isCaseSensitive()).toBe(true);
+		});
+
+		it('should not handle keys when hidden (except Ctrl+F)', () => {
+			const handled = overlay.handleKey('a');
+			expect(handled).toBe(false);
+		});
+	});
+
+	describe('attachSearchOverlay', () => {
+		it('should attach overlay to target entity', () => {
+			overlay = createSearchOverlay(world);
+			const targetEid = addEntity(world) as Entity;
+
+			attachSearchOverlay(world, overlay, targetEid, sampleContent);
+
+			expect(getSearchOverlayTarget(overlay.eid)).toBe(targetEid);
+		});
+
+		it('should search through attached content', () => {
+			overlay = createSearchOverlay(world);
+			const targetEid = addEntity(world) as Entity;
+
+			attachSearchOverlay(world, overlay, targetEid, sampleContent);
+			overlay.show().setQuery('Hello');
+
+			expect(overlay.getMatchCount()).toBe(3);
+		});
+	});
+
+	describe('utility functions', () => {
+		it('should check if entity is search overlay', () => {
+			overlay = createSearchOverlay(world);
+			expect(isSearchOverlay(world, overlay.eid)).toBe(true);
+			expect(isSearchOverlay(world, eid)).toBe(false);
+		});
+
+		it('should get target entity', () => {
+			overlay = createSearchOverlay(world);
+			expect(getSearchOverlayTarget(overlay.eid)).toBeNull();
+		});
+
+		it('should get colors', () => {
+			overlay = createSearchOverlay(world, {
+				matchFg: 0x111111ff,
+				matchBg: 0x222222ff,
+			});
+
+			const colors = getSearchOverlayColors(overlay.eid);
+			expect(colors).toBeDefined();
+			expect(colors?.matchFg).toBe(0x111111ff);
+			expect(colors?.matchBg).toBe(0x222222ff);
+		});
+
+		it('should return null colors for non-overlay entity', () => {
+			const colors = getSearchOverlayColors(eid);
+			expect(colors).toBeNull();
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('should destroy the widget', () => {
+			overlay = createSearchOverlay(world);
+			const overlayEid = overlay.eid;
+
+			expect(isSearchOverlay(world, overlayEid)).toBe(true);
+
+			overlay.destroy();
+			expect(isSearchOverlay(world, overlayEid)).toBe(false);
+		});
+
+		it('should fire close callbacks on destroy if visible', () => {
+			overlay = createSearchOverlay(world);
+			const callback = vi.fn();
+			overlay.onClose(callback);
+			overlay.show();
+			overlay.destroy();
+			expect(callback).toHaveBeenCalled();
+		});
+	});
+
+	describe('edge cases', () => {
+		beforeEach(() => {
+			overlay = createSearchOverlay(world);
+		});
+
+		it('should handle empty content', () => {
+			const emptyContent: SearchableContent = {
+				getLineCount: () => 0,
+				getLine: () => undefined,
+			};
+			overlay.attachContent(emptyContent).show();
+			overlay.setQuery('test');
+			expect(overlay.getMatchCount()).toBe(0);
+		});
+
+		it('should handle content with undefined lines', () => {
+			const sparseContent: SearchableContent = {
+				getLineCount: () => 3,
+				getLine: (i) => (i === 1 ? 'match' : undefined),
+			};
+			overlay.attachContent(sparseContent).show();
+			overlay.setQuery('match');
+			expect(overlay.getMatchCount()).toBe(1);
+		});
+
+		it('should handle multiple matches on same line', () => {
+			const content: SearchableContent = {
+				getLineCount: () => 1,
+				getLine: () => 'aaa',
+			};
+			overlay.attachContent(content).show();
+			overlay.setQuery('a');
+			expect(overlay.getMatchCount()).toBe(3);
+		});
+
+		it('should handle case-sensitive search', () => {
+			overlay.attachContent(sampleContent).show();
+			overlay.setCaseSensitive(true).setQuery('hello');
+			expect(overlay.getMatchCount()).toBe(0);
+
+			overlay.setQuery('Hello');
+			expect(overlay.getMatchCount()).toBe(3);
+		});
+	});
+});

--- a/src/widgets/searchOverlay.ts
+++ b/src/widgets/searchOverlay.ts
@@ -1,0 +1,817 @@
+/**
+ * Search Overlay Widget
+ *
+ * A floating search bar that can be attached to any scrollable content widget.
+ * Supports regex and plain text search modes, match highlighting, and
+ * navigation between matches with Enter/Shift+Enter.
+ *
+ * @module widgets/searchOverlay
+ *
+ * @example
+ * ```typescript
+ * import { createSearchOverlay, attachSearchOverlay } from 'blecsd';
+ *
+ * const overlay = createSearchOverlay(world, {
+ *   width: 40,
+ *   mode: 'plain',
+ * });
+ *
+ * // Attach to a scrollable widget
+ * attachSearchOverlay(world, overlay, targetWidgetEid);
+ *
+ * // Open with Ctrl+F
+ * overlay.show();
+ *
+ * // Navigate matches
+ * overlay.nextMatch();
+ * overlay.prevMatch();
+ * ```
+ */
+
+import { z } from 'zod';
+import { addEntity, removeEntity } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/** Default width for the search overlay */
+const DEFAULT_SEARCH_WIDTH = 40;
+
+/** Default entity capacity for typed arrays */
+const DEFAULT_CAPACITY = 10000;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Search mode for the overlay.
+ */
+export type SearchMode = 'plain' | 'regex';
+
+/**
+ * A single match found in content by the search overlay.
+ */
+export interface SearchOverlayMatch {
+	/** Line index where the match was found */
+	readonly lineIndex: number;
+	/** Character offset within the line */
+	readonly charOffset: number;
+	/** Length of the matched text */
+	readonly length: number;
+}
+
+/**
+ * Configuration for creating a SearchOverlay widget.
+ *
+ * @example
+ * ```typescript
+ * const config: SearchOverlayConfig = {
+ *   width: 40,
+ *   mode: 'plain',
+ *   caseSensitive: false,
+ * };
+ * ```
+ */
+export interface SearchOverlayConfig {
+	/** Width of the search bar in columns @default 40 */
+	readonly width?: number;
+	/** Search mode: 'plain' for substring, 'regex' for regular expression @default 'plain' */
+	readonly mode?: SearchMode;
+	/** Whether search is case-sensitive @default false */
+	readonly caseSensitive?: boolean;
+	/** Foreground color for the search bar @default 0xFFFFFFFF */
+	readonly fg?: number;
+	/** Background color for the search bar @default 0x333333FF */
+	readonly bg?: number;
+	/** Foreground color for highlighted matches @default 0x000000FF */
+	readonly matchFg?: number;
+	/** Background color for highlighted matches @default 0xFFFF00FF */
+	readonly matchBg?: number;
+	/** Foreground color for the current match @default 0x000000FF */
+	readonly currentMatchFg?: number;
+	/** Background color for the current match @default 0xFF8800FF */
+	readonly currentMatchBg?: number;
+}
+
+/**
+ * Content provider interface for searchable widgets.
+ * Any widget that wants to support search overlay must provide
+ * a way to retrieve its content lines.
+ */
+export interface SearchableContent {
+	/** Returns the total number of lines */
+	getLineCount(): number;
+	/** Returns the text content at a given line index */
+	getLine(index: number): string | undefined;
+}
+
+/**
+ * Callback fired when the match set or current match changes.
+ */
+export type SearchOverlayMatchCallback = (
+	matches: readonly SearchOverlayMatch[],
+	currentIndex: number,
+) => void;
+
+/**
+ * SearchOverlay widget interface providing chainable methods.
+ */
+export interface SearchOverlayWidget {
+	/** The underlying entity ID */
+	readonly eid: Entity;
+
+	// Visibility
+	/** Shows the search overlay */
+	show(): SearchOverlayWidget;
+	/** Hides the search overlay and clears state */
+	hide(): SearchOverlayWidget;
+	/** Returns whether the overlay is currently visible */
+	isVisible(): boolean;
+
+	// Search query
+	/** Sets the search query text */
+	setQuery(query: string): SearchOverlayWidget;
+	/** Gets the current search query */
+	getQuery(): string;
+	/** Appends a character to the query */
+	appendChar(char: string): SearchOverlayWidget;
+	/** Removes the last character from the query */
+	backspace(): SearchOverlayWidget;
+	/** Clears the query */
+	clearQuery(): SearchOverlayWidget;
+
+	// Search mode
+	/** Sets the search mode (plain or regex) */
+	setMode(mode: SearchMode): SearchOverlayWidget;
+	/** Gets the current search mode */
+	getMode(): SearchMode;
+	/** Toggles between plain and regex mode */
+	toggleMode(): SearchOverlayWidget;
+	/** Sets case sensitivity */
+	setCaseSensitive(sensitive: boolean): SearchOverlayWidget;
+	/** Gets case sensitivity setting */
+	isCaseSensitive(): boolean;
+
+	// Match navigation
+	/** Moves to the next match */
+	nextMatch(): SearchOverlayWidget;
+	/** Moves to the previous match */
+	prevMatch(): SearchOverlayWidget;
+	/** Gets all current matches */
+	getMatches(): readonly SearchOverlayMatch[];
+	/** Gets the current match index (0-based, -1 if no matches) */
+	getCurrentMatchIndex(): number;
+	/** Gets the total number of matches */
+	getMatchCount(): number;
+	/** Gets a formatted status string like "3 of 47" */
+	getMatchStatus(): string;
+
+	// Content attachment
+	/** Attaches to a content provider for searching */
+	attachContent(content: SearchableContent): SearchOverlayWidget;
+	/** Detaches from the current content provider */
+	detachContent(): SearchOverlayWidget;
+
+	// Events
+	/** Registers a callback for match changes */
+	onMatchChange(callback: SearchOverlayMatchCallback): () => void;
+	/** Registers a callback for when the overlay is closed */
+	onClose(callback: () => void): () => void;
+
+	// Key handling
+	/** Handles a key press, returns true if consumed */
+	handleKey(key: string, ctrl?: boolean, shift?: boolean): boolean;
+
+	// Lifecycle
+	/** Destroys the widget */
+	destroy(): void;
+}
+
+// =============================================================================
+// SCHEMAS
+// =============================================================================
+
+/**
+ * Zod schema for SearchOverlayConfig validation.
+ *
+ * @example
+ * ```typescript
+ * import { SearchOverlayConfigSchema } from 'blecsd';
+ *
+ * const config = SearchOverlayConfigSchema.parse({
+ *   width: 50,
+ *   mode: 'regex',
+ *   caseSensitive: true,
+ * });
+ * ```
+ */
+export const SearchOverlayConfigSchema = z.object({
+	width: z.number().int().positive().default(DEFAULT_SEARCH_WIDTH),
+	mode: z.enum(['plain', 'regex']).default('plain'),
+	caseSensitive: z.boolean().default(false),
+	fg: z.number().int().nonnegative().optional(),
+	bg: z.number().int().nonnegative().optional(),
+	matchFg: z.number().int().nonnegative().optional(),
+	matchBg: z.number().int().nonnegative().optional(),
+	currentMatchFg: z.number().int().nonnegative().optional(),
+	currentMatchBg: z.number().int().nonnegative().optional(),
+});
+
+// =============================================================================
+// COMPONENT TAG
+// =============================================================================
+
+/**
+ * SearchOverlay component marker for identifying search overlay entities.
+ *
+ * @example
+ * ```typescript
+ * import { SearchOverlay } from 'blecsd';
+ *
+ * if (SearchOverlay.isSearchOverlay[eid] === 1) {
+ *   // Entity is a search overlay
+ * }
+ * ```
+ */
+export const SearchOverlay = {
+	/** Tag indicating this is a search overlay widget (1 = yes) */
+	isSearchOverlay: new Uint8Array(DEFAULT_CAPACITY),
+	/** Whether the overlay is currently visible (0 = hidden, 1 = visible) */
+	visible: new Uint8Array(DEFAULT_CAPACITY),
+};
+
+// =============================================================================
+// INTERNAL STATE
+// =============================================================================
+
+interface SearchOverlayState {
+	query: string;
+	mode: SearchMode;
+	caseSensitive: boolean;
+	matches: SearchOverlayMatch[];
+	currentMatchIndex: number;
+	content: SearchableContent | null;
+	targetEid: Entity | null;
+	width: number;
+	fg: number;
+	bg: number;
+	matchFg: number;
+	matchBg: number;
+	currentMatchFg: number;
+	currentMatchBg: number;
+	matchCallbacks: SearchOverlayMatchCallback[];
+	closeCallbacks: Array<() => void>;
+}
+
+const stateMap = new Map<Entity, SearchOverlayState>();
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+/**
+ * Handles control-key shortcuts when the overlay is visible.
+ */
+function handleCtrlKey(
+	widget: SearchOverlayWidget,
+	state: SearchOverlayState,
+	key: string,
+): boolean {
+	if (key === 'r') {
+		widget.toggleMode();
+		return true;
+	}
+	if (key === 'i') {
+		widget.setCaseSensitive(!state.caseSensitive);
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Handles key input for the search overlay.
+ */
+function handleSearchOverlayKey(
+	widget: SearchOverlayWidget,
+	state: SearchOverlayState,
+	key: string,
+	ctrl: boolean,
+	shift: boolean,
+): boolean {
+	if (!widget.isVisible()) {
+		if (ctrl && key === 'f') {
+			widget.show();
+			return true;
+		}
+		return false;
+	}
+
+	if (key === 'escape') {
+		widget.hide();
+		return true;
+	}
+
+	if (key === 'enter' || key === 'return') {
+		if (shift) {
+			widget.prevMatch();
+		} else {
+			widget.nextMatch();
+		}
+		return true;
+	}
+
+	if (ctrl) {
+		return handleCtrlKey(widget, state, key);
+	}
+
+	if (key === 'backspace') {
+		widget.backspace();
+		return true;
+	}
+
+	if (key.length === 1) {
+		widget.appendChar(key);
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Creates a search RegExp from the current state.
+ * Returns null if the query produces an invalid regex.
+ */
+function createSearchPattern(state: SearchOverlayState): RegExp | null {
+	const flags = state.caseSensitive ? 'g' : 'gi';
+	try {
+		const source = state.mode === 'regex' ? state.query : escapeRegExp(state.query);
+		return new RegExp(source, flags);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Finds all matches of a pattern within a single line.
+ */
+function findMatchesInLine(pattern: RegExp, line: string, lineIndex: number): SearchOverlayMatch[] {
+	const matches: SearchOverlayMatch[] = [];
+	pattern.lastIndex = 0;
+	let result: RegExpExecArray | null = pattern.exec(line);
+
+	while (result !== null) {
+		matches.push({
+			lineIndex,
+			charOffset: result.index,
+			length: result[0].length,
+		});
+
+		if (result[0].length === 0) {
+			pattern.lastIndex++;
+		}
+		result = pattern.exec(line);
+	}
+
+	return matches;
+}
+
+/**
+ * Performs the search across attached content and returns all matches.
+ */
+function performSearch(state: SearchOverlayState): SearchOverlayMatch[] {
+	if (!state.content || state.query.length === 0) {
+		return [];
+	}
+
+	const pattern = createSearchPattern(state);
+	if (!pattern) {
+		return [];
+	}
+
+	const matches: SearchOverlayMatch[] = [];
+	const lineCount = state.content.getLineCount();
+
+	for (let lineIndex = 0; lineIndex < lineCount; lineIndex++) {
+		const line = state.content.getLine(lineIndex);
+		if (!line) {
+			continue;
+		}
+
+		const lineMatches = findMatchesInLine(pattern, line, lineIndex);
+		for (const m of lineMatches) {
+			matches.push(m);
+		}
+	}
+
+	return matches;
+}
+
+/**
+ * Escapes special regex characters in a string for plain text search.
+ */
+function escapeRegExp(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Updates matches and notifies callbacks.
+ */
+function updateMatches(state: SearchOverlayState): void {
+	state.matches = performSearch(state);
+
+	// Clamp current index
+	if (state.matches.length === 0) {
+		state.currentMatchIndex = -1;
+	} else if (state.currentMatchIndex >= state.matches.length) {
+		state.currentMatchIndex = 0;
+	} else if (state.currentMatchIndex < 0) {
+		state.currentMatchIndex = 0;
+	}
+
+	// Fire callbacks
+	for (const cb of state.matchCallbacks) {
+		cb(state.matches, state.currentMatchIndex);
+	}
+}
+
+// =============================================================================
+// FACTORY
+// =============================================================================
+
+/**
+ * Creates a SearchOverlay widget.
+ *
+ * The overlay starts hidden. Call `show()` to display it.
+ *
+ * @param world - The ECS world
+ * @param config - Widget configuration
+ * @returns The SearchOverlayWidget instance
+ *
+ * @example
+ * ```typescript
+ * import { createWorld, addEntity } from 'blecsd';
+ * import { createSearchOverlay } from 'blecsd';
+ *
+ * const world = createWorld();
+ * const overlay = createSearchOverlay(world, {
+ *   width: 40,
+ *   mode: 'plain',
+ * });
+ *
+ * overlay.show();
+ * overlay.setQuery('hello');
+ * console.log(overlay.getMatchStatus()); // "3 of 47"
+ * overlay.nextMatch();
+ * ```
+ */
+export function createSearchOverlay(
+	world: World,
+	config: SearchOverlayConfig = {},
+): SearchOverlayWidget {
+	const validated = SearchOverlayConfigSchema.parse(config);
+	const eid = addEntity(world);
+
+	// Mark as search overlay
+	SearchOverlay.isSearchOverlay[eid] = 1;
+	SearchOverlay.visible[eid] = 0;
+
+	// Create internal state
+	const state: SearchOverlayState = {
+		query: '',
+		mode: validated.mode,
+		caseSensitive: validated.caseSensitive,
+		matches: [],
+		currentMatchIndex: -1,
+		content: null,
+		targetEid: null,
+		width: validated.width,
+		fg: validated.fg ?? 0xffffffff,
+		bg: validated.bg ?? 0x333333ff,
+		matchFg: validated.matchFg ?? 0x000000ff,
+		matchBg: validated.matchBg ?? 0xffff00ff,
+		currentMatchFg: validated.currentMatchFg ?? 0x000000ff,
+		currentMatchBg: validated.currentMatchBg ?? 0xff8800ff,
+		matchCallbacks: [],
+		closeCallbacks: [],
+	};
+
+	stateMap.set(eid, state);
+
+	const widget: SearchOverlayWidget = {
+		eid,
+
+		// Visibility
+		show(): SearchOverlayWidget {
+			SearchOverlay.visible[eid] = 1;
+			// Re-run search when shown
+			updateMatches(state);
+			return widget;
+		},
+
+		hide(): SearchOverlayWidget {
+			SearchOverlay.visible[eid] = 0;
+			state.query = '';
+			state.matches = [];
+			state.currentMatchIndex = -1;
+
+			for (const cb of state.closeCallbacks) {
+				cb();
+			}
+
+			return widget;
+		},
+
+		isVisible(): boolean {
+			return SearchOverlay.visible[eid] === 1;
+		},
+
+		// Search query
+		setQuery(query: string): SearchOverlayWidget {
+			state.query = query;
+			updateMatches(state);
+			return widget;
+		},
+
+		getQuery(): string {
+			return state.query;
+		},
+
+		appendChar(char: string): SearchOverlayWidget {
+			state.query += char;
+			updateMatches(state);
+			return widget;
+		},
+
+		backspace(): SearchOverlayWidget {
+			if (state.query.length > 0) {
+				state.query = state.query.slice(0, -1);
+				updateMatches(state);
+			}
+			return widget;
+		},
+
+		clearQuery(): SearchOverlayWidget {
+			state.query = '';
+			updateMatches(state);
+			return widget;
+		},
+
+		// Search mode
+		setMode(mode: SearchMode): SearchOverlayWidget {
+			state.mode = mode;
+			updateMatches(state);
+			return widget;
+		},
+
+		getMode(): SearchMode {
+			return state.mode;
+		},
+
+		toggleMode(): SearchOverlayWidget {
+			state.mode = state.mode === 'plain' ? 'regex' : 'plain';
+			updateMatches(state);
+			return widget;
+		},
+
+		setCaseSensitive(sensitive: boolean): SearchOverlayWidget {
+			state.caseSensitive = sensitive;
+			updateMatches(state);
+			return widget;
+		},
+
+		isCaseSensitive(): boolean {
+			return state.caseSensitive;
+		},
+
+		// Match navigation
+		nextMatch(): SearchOverlayWidget {
+			if (state.matches.length === 0) {
+				return widget;
+			}
+
+			state.currentMatchIndex = (state.currentMatchIndex + 1) % state.matches.length;
+
+			for (const cb of state.matchCallbacks) {
+				cb(state.matches, state.currentMatchIndex);
+			}
+
+			return widget;
+		},
+
+		prevMatch(): SearchOverlayWidget {
+			if (state.matches.length === 0) {
+				return widget;
+			}
+
+			state.currentMatchIndex =
+				state.currentMatchIndex <= 0 ? state.matches.length - 1 : state.currentMatchIndex - 1;
+
+			for (const cb of state.matchCallbacks) {
+				cb(state.matches, state.currentMatchIndex);
+			}
+
+			return widget;
+		},
+
+		getMatches(): readonly SearchOverlayMatch[] {
+			return state.matches;
+		},
+
+		getCurrentMatchIndex(): number {
+			return state.currentMatchIndex;
+		},
+
+		getMatchCount(): number {
+			return state.matches.length;
+		},
+
+		getMatchStatus(): string {
+			if (state.matches.length === 0) {
+				if (state.query.length > 0) {
+					return 'No matches';
+				}
+				return '';
+			}
+			return `${state.currentMatchIndex + 1} of ${state.matches.length}`;
+		},
+
+		// Content attachment
+		attachContent(content: SearchableContent): SearchOverlayWidget {
+			state.content = content;
+			if (state.query.length > 0) {
+				updateMatches(state);
+			}
+			return widget;
+		},
+
+		detachContent(): SearchOverlayWidget {
+			state.content = null;
+			state.matches = [];
+			state.currentMatchIndex = -1;
+			return widget;
+		},
+
+		// Events
+		onMatchChange(callback: SearchOverlayMatchCallback): () => void {
+			state.matchCallbacks.push(callback);
+			return () => {
+				const idx = state.matchCallbacks.indexOf(callback);
+				if (idx !== -1) {
+					state.matchCallbacks.splice(idx, 1);
+				}
+			};
+		},
+
+		onClose(callback: () => void): () => void {
+			state.closeCallbacks.push(callback);
+			return () => {
+				const idx = state.closeCallbacks.indexOf(callback);
+				if (idx !== -1) {
+					state.closeCallbacks.splice(idx, 1);
+				}
+			};
+		},
+
+		// Key handling
+		handleKey(key: string, ctrl = false, shift = false): boolean {
+			return handleSearchOverlayKey(widget, state, key, ctrl, shift);
+		},
+
+		// Lifecycle
+		destroy(): void {
+			if (SearchOverlay.visible[eid] === 1) {
+				widget.hide();
+			}
+
+			SearchOverlay.isSearchOverlay[eid] = 0;
+			SearchOverlay.visible[eid] = 0;
+			stateMap.delete(eid);
+			removeEntity(world, eid);
+		},
+	};
+
+	return widget;
+}
+
+// =============================================================================
+// CONVENIENCE FUNCTIONS
+// =============================================================================
+
+/**
+ * Attaches a search overlay to a target widget that provides searchable content.
+ *
+ * The target must expose content through the SearchableContent interface.
+ * For VirtualizedList widgets, this wraps their getLine/getLineCount methods.
+ *
+ * @param _world - The ECS world
+ * @param overlay - The search overlay widget
+ * @param targetEid - The entity ID of the target widget
+ * @param content - The searchable content provider
+ * @returns The search overlay widget for chaining
+ *
+ * @example
+ * ```typescript
+ * import { createSearchOverlay, attachSearchOverlay } from 'blecsd';
+ *
+ * const overlay = createSearchOverlay(world);
+ * const vlist = createVirtualizedList(world, { width: 80, height: 24 });
+ *
+ * attachSearchOverlay(world, overlay, vlist.eid, {
+ *   getLineCount: () => vlist.getLineCount(),
+ *   getLine: (i) => vlist.getLine(i),
+ * });
+ * ```
+ */
+export function attachSearchOverlay(
+	_world: World,
+	overlay: SearchOverlayWidget,
+	targetEid: Entity,
+	content: SearchableContent,
+): SearchOverlayWidget {
+	const state = stateMap.get(overlay.eid);
+	if (state) {
+		state.targetEid = targetEid;
+	}
+	return overlay.attachContent(content);
+}
+
+/**
+ * Checks if an entity is a SearchOverlay widget.
+ *
+ * @param _world - The ECS world (unused, for API consistency)
+ * @param eid - The entity ID
+ * @returns true if the entity is a search overlay widget
+ *
+ * @example
+ * ```typescript
+ * import { isSearchOverlay } from 'blecsd';
+ *
+ * if (isSearchOverlay(world, entity)) {
+ *   // Handle search overlay
+ * }
+ * ```
+ */
+export function isSearchOverlay(_world: World, eid: Entity): boolean {
+	return SearchOverlay.isSearchOverlay[eid] === 1;
+}
+
+/**
+ * Gets the target entity ID that a search overlay is attached to.
+ *
+ * @param eid - The search overlay entity ID
+ * @returns The target entity ID or null if not attached
+ */
+export function getSearchOverlayTarget(eid: Entity): Entity | null {
+	const state = stateMap.get(eid);
+	return state?.targetEid ?? null;
+}
+
+/**
+ * Gets the match highlight colors for rendering.
+ *
+ * @param eid - The search overlay entity ID
+ * @returns Object with match and current match colors, or null if not a search overlay
+ *
+ * @example
+ * ```typescript
+ * const colors = getSearchOverlayColors(overlayEid);
+ * if (colors) {
+ *   // Use colors.matchFg, colors.matchBg for highlighting
+ * }
+ * ```
+ */
+export function getSearchOverlayColors(eid: Entity): {
+	fg: number;
+	bg: number;
+	matchFg: number;
+	matchBg: number;
+	currentMatchFg: number;
+	currentMatchBg: number;
+} | null {
+	const state = stateMap.get(eid);
+	if (!state) {
+		return null;
+	}
+	return {
+		fg: state.fg,
+		bg: state.bg,
+		matchFg: state.matchFg,
+		matchBg: state.matchBg,
+		currentMatchFg: state.currentMatchFg,
+		currentMatchBg: state.currentMatchBg,
+	};
+}
+
+/**
+ * Resets the SearchOverlay component store. Useful for testing.
+ *
+ * @internal
+ */
+export function resetSearchOverlayStore(): void {
+	SearchOverlay.isSearchOverlay.fill(0);
+	SearchOverlay.visible.fill(0);
+	stateMap.clear();
+}

--- a/src/widgets/searchableList.test.ts
+++ b/src/widgets/searchableList.test.ts
@@ -1,0 +1,461 @@
+/**
+ * SearchableList Widget Tests
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addEntity, createWorld } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+import {
+	createSearchableList,
+	getSearchableFilteredItems,
+	isSearchableList,
+	resetSearchableListStore,
+	type SearchableListWidget,
+	setSearchableFilter,
+} from './searchableList';
+
+describe('SearchableList Widget', () => {
+	let world: World;
+	let eid: Entity;
+	let list: SearchableListWidget;
+
+	const items = ['Apple', 'Apricot', 'Banana', 'Blueberry', 'Cherry'];
+
+	beforeEach(() => {
+		resetSearchableListStore();
+		world = createWorld() as World;
+		eid = addEntity(world) as Entity;
+	});
+
+	describe('createSearchableList', () => {
+		it('should create a searchable list widget', () => {
+			list = createSearchableList(world, { items });
+
+			expect(list.eid).toBeDefined();
+			expect(isSearchableList(world, list.eid)).toBe(true);
+		});
+
+		it('should initialize with default values', () => {
+			list = createSearchableList(world);
+
+			expect(list.getItems()).toEqual([]);
+			expect(list.getFilter()).toBe('');
+			expect(list.isSearchEnabled()).toBe(true);
+		});
+
+		it('should initialize with provided items', () => {
+			list = createSearchableList(world, { items });
+
+			const allItems = list.getItems();
+			expect(allItems).toHaveLength(5);
+			expect(allItems[0]?.text).toBe('Apple');
+		});
+
+		it('should start with search enabled by default', () => {
+			list = createSearchableList(world, { items });
+			expect(list.isSearchEnabled()).toBe(true);
+		});
+
+		it('should allow disabling search', () => {
+			list = createSearchableList(world, { items, enableSearch: false });
+			expect(list.isSearchEnabled()).toBe(false);
+		});
+	});
+
+	describe('filtering', () => {
+		beforeEach(() => {
+			list = createSearchableList(world, { items });
+		});
+
+		it('should show all items with empty filter', () => {
+			expect(list.getFilteredItems()).toHaveLength(5);
+		});
+
+		it('should filter items by substring', () => {
+			list.setFilter('ber');
+			const filtered = list.getFilteredItems();
+			expect(filtered).toHaveLength(1); // Only Blueberry contains 'ber'
+			expect(filtered[0]?.text).toBe('Blueberry');
+		});
+
+		it('should filter case-insensitively', () => {
+			list.setFilter('APPLE');
+			const filtered = list.getFilteredItems();
+			expect(filtered).toHaveLength(1);
+			expect(filtered[0]?.text).toBe('Apple');
+		});
+
+		it('should filter with partial matches', () => {
+			list.setFilter('ap');
+			const filtered = list.getFilteredItems();
+			// Apple and Apricot both start with 'Ap'
+			expect(filtered.length).toBeGreaterThanOrEqual(2);
+		});
+
+		it('should clear filter', () => {
+			list.setFilter('xyz');
+			list.clearFilter();
+			expect(list.getFilteredItems()).toHaveLength(5);
+		});
+
+		it('should get filter query', () => {
+			list.setFilter('test');
+			expect(list.getFilter()).toBe('test');
+		});
+
+		it('should get filtered count', () => {
+			list.setFilter('Cherry');
+			expect(list.getFilteredCount()).toBe(1);
+		});
+
+		it('should return correct filter status', () => {
+			expect(list.getFilterStatus()).toBe('5 items');
+
+			list.setFilter('ap');
+			expect(list.getFilterStatus()).toMatch(/\d+ of 5 items/);
+		});
+
+		it('should handle no matches', () => {
+			list.setFilter('zzz');
+			expect(list.getFilteredCount()).toBe(0);
+			expect(list.getFilterStatus()).toBe('0 of 5 items');
+		});
+	});
+
+	describe('selection', () => {
+		beforeEach(() => {
+			list = createSearchableList(world, { items });
+		});
+
+		it('should start with first item selected', () => {
+			expect(list.getSelectedIndex()).toBe(0);
+			expect(list.getSelectedItem()?.text).toBe('Apple');
+		});
+
+		it('should select by index', () => {
+			list.select(2);
+			expect(list.getSelectedIndex()).toBe(2);
+			expect(list.getSelectedItem()?.text).toBe('Banana');
+		});
+
+		it('should select previous', () => {
+			list.select(2);
+			list.selectPrev();
+			expect(list.getSelectedIndex()).toBe(1);
+		});
+
+		it('should select next', () => {
+			list.selectNext();
+			expect(list.getSelectedIndex()).toBe(1);
+		});
+
+		it('should not go below 0', () => {
+			list.selectPrev();
+			expect(list.getSelectedIndex()).toBe(0);
+		});
+
+		it('should not go past last item', () => {
+			for (let i = 0; i < 10; i++) {
+				list.selectNext();
+			}
+			expect(list.getSelectedIndex()).toBe(4);
+		});
+
+		it('should select first', () => {
+			list.select(3);
+			list.selectFirst();
+			expect(list.getSelectedIndex()).toBe(0);
+		});
+
+		it('should select last', () => {
+			list.selectLast();
+			expect(list.getSelectedIndex()).toBe(4);
+		});
+
+		it('should clamp selection when filtering narrows results', () => {
+			list.select(4); // Last item
+			list.setFilter('Apple'); // Only 1 item
+			expect(list.getSelectedIndex()).toBe(0);
+		});
+
+		it('should preserve selection concept across filter changes', () => {
+			// Select Apple
+			list.select(0);
+			expect(list.getSelectedItem()?.text).toBe('Apple');
+
+			// Filter to 'Ch' shows only Cherry
+			list.setFilter('Ch');
+			expect(list.getFilteredCount()).toBe(1);
+			expect(list.getSelectedIndex()).toBe(0);
+			expect(list.getSelectedItem()?.text).toBe('Cherry');
+
+			// Clear filter restores all items
+			list.clearFilter();
+			expect(list.getFilteredCount()).toBe(5);
+		});
+	});
+
+	describe('original index tracking', () => {
+		beforeEach(() => {
+			list = createSearchableList(world, { items });
+		});
+
+		it('should return original index when no filter', () => {
+			list.select(2);
+			expect(list.getOriginalSelectedIndex()).toBe(2);
+		});
+
+		it('should return correct original index when filtered', () => {
+			list.setFilter('Cherry');
+			list.select(0);
+			// Cherry is index 4 in original array
+			expect(list.getOriginalSelectedIndex()).toBe(4);
+		});
+
+		it('should return -1 when no selection', () => {
+			list = createSearchableList(world);
+			expect(list.getOriginalSelectedIndex()).toBe(-1);
+		});
+	});
+
+	describe('search enable/disable', () => {
+		beforeEach(() => {
+			list = createSearchableList(world, { items });
+		});
+
+		it('should disable search', () => {
+			list.setSearchEnabled(false);
+			expect(list.isSearchEnabled()).toBe(false);
+		});
+
+		it('should clear filter when search is disabled', () => {
+			list.setFilter('Apple');
+			list.setSearchEnabled(false);
+			expect(list.getFilter()).toBe('');
+			expect(list.getFilteredItems()).toHaveLength(5);
+		});
+
+		it('should re-enable search', () => {
+			list.setSearchEnabled(false);
+			list.setSearchEnabled(true);
+			expect(list.isSearchEnabled()).toBe(true);
+		});
+	});
+
+	describe('item management', () => {
+		beforeEach(() => {
+			list = createSearchableList(world, { items });
+		});
+
+		it('should set new items', () => {
+			list.setItems(['X', 'Y', 'Z']);
+			expect(list.getItems()).toHaveLength(3);
+			expect(list.getItems()[0]?.text).toBe('X');
+		});
+
+		it('should re-apply filter when items change', () => {
+			list.setFilter('ap');
+			list.setItems(['Grape', 'Apple', 'Mango']);
+			const filtered = list.getFilteredItems();
+			// 'Grape' contains 'ap'? 'grape'.includes('ap') = false
+			// 'Apple' contains 'ap'? 'apple'.includes('ap') = true
+			expect(filtered.some((i) => i.text === 'Apple')).toBe(true);
+		});
+	});
+
+	describe('events', () => {
+		beforeEach(() => {
+			list = createSearchableList(world, { items });
+		});
+
+		it('should fire onChange when filter changes', () => {
+			const callback = vi.fn();
+			list.onChange(callback);
+
+			list.setFilter('ap');
+			expect(callback).toHaveBeenCalledWith(expect.any(Array), expect.any(Number));
+		});
+
+		it('should fire onChange when selection changes', () => {
+			const callback = vi.fn();
+			list.onChange(callback);
+
+			list.selectNext();
+			expect(callback).toHaveBeenCalled();
+		});
+
+		it('should unsubscribe callback', () => {
+			const callback = vi.fn();
+			const unsub = list.onChange(callback);
+
+			unsub();
+			list.setFilter('test');
+			expect(callback).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('key handling', () => {
+		beforeEach(() => {
+			list = createSearchableList(world, { items });
+		});
+
+		it('should handle down arrow', () => {
+			list.handleKey('down');
+			expect(list.getSelectedIndex()).toBe(1);
+		});
+
+		it('should handle up arrow', () => {
+			list.handleKey('down');
+			list.handleKey('up');
+			expect(list.getSelectedIndex()).toBe(0);
+		});
+
+		it('should handle j/k vim keys', () => {
+			list.handleKey('j');
+			expect(list.getSelectedIndex()).toBe(1);
+			list.handleKey('k');
+			expect(list.getSelectedIndex()).toBe(0);
+		});
+
+		it('should handle home/end', () => {
+			list.handleKey('end');
+			expect(list.getSelectedIndex()).toBe(4);
+			list.handleKey('home');
+			expect(list.getSelectedIndex()).toBe(0);
+		});
+
+		it('should type to filter', () => {
+			list.handleKey('a');
+			expect(list.getFilter()).toBe('a');
+			list.handleKey('p');
+			expect(list.getFilter()).toBe('ap');
+		});
+
+		it('should handle backspace for filter', () => {
+			list.setFilter('abc');
+			list.handleKey('backspace');
+			expect(list.getFilter()).toBe('ab');
+		});
+
+		it('should handle Ctrl+U to clear filter', () => {
+			list.setFilter('test');
+			list.handleKey('u', true);
+			expect(list.getFilter()).toBe('');
+		});
+
+		it('should handle escape to clear filter first', () => {
+			list.setFilter('test');
+			list.handleKey('escape');
+			expect(list.getFilter()).toBe('');
+		});
+
+		it('should handle escape to blur when filter is empty', () => {
+			list.focus();
+			list.handleKey('escape');
+			expect(list.isFocused()).toBe(false);
+		});
+
+		it('should not filter when search is disabled', () => {
+			list.setSearchEnabled(false);
+			const handled = list.handleKey('a');
+			expect(handled).toBe(false);
+			expect(list.getFilter()).toBe('');
+		});
+
+		it('should return false for unhandled keys', () => {
+			const result = list.handleKey('f5');
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('standalone API functions', () => {
+		it('should get filtered items via getSearchableFilteredItems', () => {
+			list = createSearchableList(world, { items });
+			list.setFilter('Cherry');
+
+			const filtered = getSearchableFilteredItems(world, list.eid);
+			expect(filtered).toHaveLength(1);
+			expect(filtered[0]?.text).toBe('Cherry');
+		});
+
+		it('should return empty for non-existent entity', () => {
+			const filtered = getSearchableFilteredItems(world, eid);
+			expect(filtered).toEqual([]);
+		});
+
+		it('should set filter via setSearchableFilter', () => {
+			list = createSearchableList(world, { items });
+			setSearchableFilter(world, list.eid, 'Ban');
+
+			expect(list.getFilter()).toBe('Ban');
+			expect(list.getFilteredCount()).toBe(1);
+		});
+
+		it('should no-op setSearchableFilter for non-existent entity', () => {
+			expect(() => setSearchableFilter(world, eid, 'test')).not.toThrow();
+		});
+	});
+
+	describe('visibility and focus', () => {
+		beforeEach(() => {
+			list = createSearchableList(world, { items });
+		});
+
+		it('should show the widget', () => {
+			const result = list.hide().show();
+			expect(result).toBe(list);
+		});
+
+		it('should hide the widget', () => {
+			const result = list.show().hide();
+			expect(result).toBe(list);
+		});
+
+		it('should focus the widget', () => {
+			list.focus();
+			expect(list.isFocused()).toBe(true);
+		});
+
+		it('should blur the widget', () => {
+			list.focus();
+			list.blur();
+			expect(list.isFocused()).toBe(false);
+		});
+	});
+
+	describe('lifecycle', () => {
+		it('should destroy the widget', () => {
+			list = createSearchableList(world, { items });
+			const listEid = list.eid;
+
+			expect(isSearchableList(world, listEid)).toBe(true);
+
+			list.destroy();
+			expect(isSearchableList(world, listEid)).toBe(false);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle empty items', () => {
+			list = createSearchableList(world);
+			expect(list.getSelectedIndex()).toBe(-1);
+			expect(list.getSelectedItem()).toBeUndefined();
+			expect(list.getOriginalSelectedIndex()).toBe(-1);
+		});
+
+		it('should handle selecting in empty filtered results', () => {
+			list = createSearchableList(world, { items });
+			list.setFilter('zzzzz');
+			expect(list.getSelectedIndex()).toBe(-1);
+			expect(list.getSelectedItem()).toBeUndefined();
+		});
+
+		it('should handle clearing filter with no previous selection', () => {
+			list = createSearchableList(world, { items });
+			list.setFilter('zzz');
+			list.clearFilter();
+			// Should reset to index 0
+			expect(list.getSelectedIndex()).toBe(0);
+		});
+	});
+});

--- a/src/widgets/searchableList.ts
+++ b/src/widgets/searchableList.ts
@@ -1,0 +1,751 @@
+/**
+ * Searchable List Enhancement
+ *
+ * Enhances list and virtualized list widgets with inline search/filter
+ * capabilities. Adds a filter input that narrows displayed items in
+ * real-time as the user types.
+ *
+ * Works with both the List widget (finite items) and VirtualizedList
+ * widget (large datasets) through a common SearchableContent interface.
+ *
+ * @module widgets/searchableList
+ *
+ * @example
+ * ```typescript
+ * import { createSearchableList } from 'blecsd';
+ *
+ * const world = createWorld();
+ * const sl = createSearchableList(world, {
+ *   items: ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry'],
+ *   enableSearch: true,
+ *   width: 30,
+ *   height: 10,
+ * });
+ *
+ * // Filter in real-time
+ * sl.setFilter('ber');
+ * console.log(sl.getFilteredItems()); // ['Elderberry']
+ *
+ * // Preserve selection across filter changes
+ * sl.select(0).setFilter('Ch');
+ * sl.clearFilter();
+ * // Original selection is restored
+ * ```
+ */
+
+import { z } from 'zod';
+import { addEntity, removeEntity } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const DEFAULT_WIDTH = 30;
+const DEFAULT_HEIGHT = 10;
+const DEFAULT_CAPACITY = 10000;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * An item in the searchable list.
+ */
+export interface SearchableListItem {
+	/** Display text */
+	readonly text: string;
+	/** Optional value (defaults to text) */
+	readonly value?: string;
+	/** Whether the item is disabled */
+	readonly disabled?: boolean;
+}
+
+/**
+ * Configuration for the SearchableList widget.
+ *
+ * @example
+ * ```typescript
+ * const config: SearchableListConfig = {
+ *   items: ['Apple', 'Banana', 'Cherry'],
+ *   enableSearch: true,
+ *   placeholder: 'Type to filter...',
+ * };
+ * ```
+ */
+export interface SearchableListConfig {
+	/** X position @default 0 */
+	readonly x?: number;
+	/** Y position @default 0 */
+	readonly y?: number;
+	/** Width in columns @default 30 */
+	readonly width?: number;
+	/** Height in rows @default 10 */
+	readonly height?: number;
+	/** Items to display */
+	readonly items?: readonly string[];
+	/** Whether to show the inline filter input @default true */
+	readonly enableSearch?: boolean;
+	/** Placeholder text for the filter input @default 'Filter...' */
+	readonly placeholder?: string;
+	/** Initially selected item index @default 0 */
+	readonly selected?: number;
+	/** Foreground color for normal items */
+	readonly fg?: number;
+	/** Background color for normal items */
+	readonly bg?: number;
+	/** Foreground color for the selected/highlighted item */
+	readonly selectedFg?: number;
+	/** Background color for the selected/highlighted item */
+	readonly selectedBg?: number;
+	/** Foreground color for disabled items */
+	readonly disabledFg?: number;
+	/** Foreground color for the filter input */
+	readonly filterFg?: number;
+	/** Background color for the filter input */
+	readonly filterBg?: number;
+}
+
+/**
+ * Callback fired when filter or selection changes.
+ */
+export type SearchableListCallback = (
+	filteredItems: readonly SearchableListItem[],
+	selectedIndex: number,
+) => void;
+
+/**
+ * SearchableList widget interface.
+ */
+export interface SearchableListWidget {
+	/** The underlying entity ID */
+	readonly eid: Entity;
+
+	// Visibility
+	/** Shows the widget */
+	show(): SearchableListWidget;
+	/** Hides the widget */
+	hide(): SearchableListWidget;
+
+	// Focus
+	/** Focuses the widget (activates filter input) */
+	focus(): SearchableListWidget;
+	/** Blurs the widget */
+	blur(): SearchableListWidget;
+	/** Returns whether the widget is focused */
+	isFocused(): boolean;
+
+	// Items
+	/** Sets the items */
+	setItems(items: readonly string[]): SearchableListWidget;
+	/** Gets all items */
+	getItems(): readonly SearchableListItem[];
+
+	// Filter
+	/** Sets the filter query */
+	setFilter(query: string): SearchableListWidget;
+	/** Gets the current filter query */
+	getFilter(): string;
+	/** Clears the filter */
+	clearFilter(): SearchableListWidget;
+	/** Gets items after filtering */
+	getFilteredItems(): readonly SearchableListItem[];
+	/** Gets the filtered item count */
+	getFilteredCount(): number;
+	/** Gets a status string like "5 of 20 items" */
+	getFilterStatus(): string;
+	/** Whether search/filter is enabled */
+	isSearchEnabled(): boolean;
+	/** Enables or disables search */
+	setSearchEnabled(enabled: boolean): SearchableListWidget;
+
+	// Selection
+	/** Selects the item at the given index (in filtered view) */
+	select(index: number): SearchableListWidget;
+	/** Gets the currently selected index (in filtered view) */
+	getSelectedIndex(): number;
+	/** Gets the currently selected item */
+	getSelectedItem(): SearchableListItem | undefined;
+	/** Gets the original (unfiltered) index of the selected item */
+	getOriginalSelectedIndex(): number;
+	/** Moves selection up */
+	selectPrev(): SearchableListWidget;
+	/** Moves selection down */
+	selectNext(): SearchableListWidget;
+	/** Selects the first item */
+	selectFirst(): SearchableListWidget;
+	/** Selects the last item */
+	selectLast(): SearchableListWidget;
+
+	// Events
+	/** Registers a callback for filter/selection changes */
+	onChange(callback: SearchableListCallback): () => void;
+
+	// Key handling
+	/** Handles a key press, returns true if consumed */
+	handleKey(key: string, ctrl?: boolean, shift?: boolean): boolean;
+
+	// Lifecycle
+	/** Destroys the widget */
+	destroy(): void;
+}
+
+// =============================================================================
+// SCHEMAS
+// =============================================================================
+
+/**
+ * Zod schema for SearchableListConfig validation.
+ */
+export const SearchableListConfigSchema = z.object({
+	x: z.number().int().default(0),
+	y: z.number().int().default(0),
+	width: z.number().int().positive().default(DEFAULT_WIDTH),
+	height: z.number().int().positive().default(DEFAULT_HEIGHT),
+	items: z.array(z.string()).default([]),
+	enableSearch: z.boolean().default(true),
+	placeholder: z.string().default('Filter...'),
+	selected: z.number().int().min(-1).default(0),
+	fg: z.number().int().nonnegative().optional(),
+	bg: z.number().int().nonnegative().optional(),
+	selectedFg: z.number().int().nonnegative().optional(),
+	selectedBg: z.number().int().nonnegative().optional(),
+	disabledFg: z.number().int().nonnegative().optional(),
+	filterFg: z.number().int().nonnegative().optional(),
+	filterBg: z.number().int().nonnegative().optional(),
+});
+
+// =============================================================================
+// COMPONENT TAG
+// =============================================================================
+
+/**
+ * SearchableList component marker.
+ */
+export const SearchableList = {
+	/** Tag indicating this is a searchable list widget */
+	isSearchableList: new Uint8Array(DEFAULT_CAPACITY),
+	/** Whether the widget is visible */
+	visible: new Uint8Array(DEFAULT_CAPACITY),
+	/** Whether the widget is focused */
+	focused: new Uint8Array(DEFAULT_CAPACITY),
+};
+
+// =============================================================================
+// INTERNAL STATE
+// =============================================================================
+
+interface SearchableListState {
+	items: SearchableListItem[];
+	filterQuery: string;
+	filteredItems: SearchableListItem[];
+	filteredToOriginalMap: number[];
+	selectedFilteredIndex: number;
+	searchEnabled: boolean;
+	placeholder: string;
+	visibleCount: number;
+	firstVisible: number;
+	width: number;
+	fg: number;
+	bg: number;
+	selectedFg: number;
+	selectedBg: number;
+	disabledFg: number;
+	filterFg: number;
+	filterBg: number;
+	callbacks: SearchableListCallback[];
+}
+
+const stateMap = new Map<Entity, SearchableListState>();
+
+// =============================================================================
+// INTERNAL HELPERS
+// =============================================================================
+
+/**
+ * Recalculates filtered items based on current filter query.
+ */
+function recalculateFilter(state: SearchableListState): void {
+	if (state.filterQuery.length === 0) {
+		state.filteredItems = [...state.items];
+		state.filteredToOriginalMap = state.items.map((_, i) => i);
+	} else {
+		const lowerQuery = state.filterQuery.toLowerCase();
+		state.filteredItems = [];
+		state.filteredToOriginalMap = [];
+
+		for (let i = 0; i < state.items.length; i++) {
+			const item = state.items[i];
+			if (item?.text.toLowerCase().includes(lowerQuery)) {
+				state.filteredItems.push(item);
+				state.filteredToOriginalMap.push(i);
+			}
+		}
+	}
+
+	// Clamp selection
+	if (state.filteredItems.length === 0) {
+		state.selectedFilteredIndex = -1;
+	} else if (state.selectedFilteredIndex >= state.filteredItems.length) {
+		state.selectedFilteredIndex = 0;
+	} else if (state.selectedFilteredIndex < 0 && state.filteredItems.length > 0) {
+		state.selectedFilteredIndex = 0;
+	}
+
+	state.firstVisible = 0;
+}
+
+/**
+ * Fires change callbacks.
+ */
+function fireCallbacks(state: SearchableListState): void {
+	for (const cb of state.callbacks) {
+		cb(state.filteredItems, state.selectedFilteredIndex);
+	}
+}
+
+/**
+ * Ensures the selected item is visible in the viewport.
+ */
+function ensureVisible(state: SearchableListState): void {
+	if (state.selectedFilteredIndex < state.firstVisible) {
+		state.firstVisible = state.selectedFilteredIndex;
+	} else if (state.selectedFilteredIndex >= state.firstVisible + state.visibleCount) {
+		state.firstVisible = state.selectedFilteredIndex - state.visibleCount + 1;
+	}
+}
+
+/**
+ * Handles navigation keys for the searchable list (up/down/home/end/page).
+ * Returns true if the key was consumed.
+ */
+function handleSearchableListNav(
+	key: string,
+	state: SearchableListState,
+	widget: SearchableListWidget,
+): boolean {
+	if (key === 'up' || key === 'k') {
+		widget.selectPrev();
+		return true;
+	}
+	if (key === 'down' || key === 'j') {
+		widget.selectNext();
+		return true;
+	}
+	if (key === 'home') {
+		widget.selectFirst();
+		return true;
+	}
+	if (key === 'end') {
+		widget.selectLast();
+		return true;
+	}
+	if (key === 'pageup') {
+		const newIdx = Math.max(0, state.selectedFilteredIndex - state.visibleCount);
+		widget.select(newIdx);
+		fireCallbacks(state);
+		return true;
+	}
+	if (key === 'pagedown') {
+		const newIdx = Math.min(
+			state.filteredItems.length - 1,
+			state.selectedFilteredIndex + state.visibleCount,
+		);
+		widget.select(newIdx);
+		fireCallbacks(state);
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Handles filter input keys when search is enabled.
+ * Returns true if the key was consumed.
+ */
+function handleSearchableListFilter(
+	key: string,
+	ctrl: boolean,
+	state: SearchableListState,
+	widget: SearchableListWidget,
+): boolean {
+	if (key === 'backspace') {
+		if (state.filterQuery.length > 0) {
+			state.filterQuery = state.filterQuery.slice(0, -1);
+			recalculateFilter(state);
+			fireCallbacks(state);
+		}
+		return true;
+	}
+	if (ctrl && key === 'u') {
+		widget.clearFilter();
+		return true;
+	}
+	if (key.length === 1 && !ctrl) {
+		state.filterQuery += key;
+		recalculateFilter(state);
+		fireCallbacks(state);
+		return true;
+	}
+	return false;
+}
+
+// =============================================================================
+// FACTORY
+// =============================================================================
+
+/**
+ * Creates a SearchableList widget with inline filtering.
+ *
+ * When `enableSearch` is true (default), the first row of the widget shows
+ * a filter input. Typing narrows the displayed items in real-time.
+ * Selection state is preserved across filter changes by tracking the
+ * original item index.
+ *
+ * @param world - The ECS world
+ * @param config - Widget configuration
+ * @returns The SearchableListWidget instance
+ *
+ * @example
+ * ```typescript
+ * import { createSearchableList } from 'blecsd';
+ *
+ * const world = createWorld();
+ * const list = createSearchableList(world, {
+ *   items: ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry'],
+ *   enableSearch: true,
+ *   placeholder: 'Type to filter...',
+ *   width: 30,
+ *   height: 10,
+ * });
+ *
+ * list.focus();
+ * list.setFilter('ber');
+ * console.log(list.getFilterStatus()); // "1 of 5 items"
+ * ```
+ */
+export function createSearchableList(
+	world: World,
+	config: SearchableListConfig = {},
+): SearchableListWidget {
+	const validated = SearchableListConfigSchema.parse(config);
+	const eid = addEntity(world);
+
+	// Mark as searchable list
+	SearchableList.isSearchableList[eid] = 1;
+	SearchableList.visible[eid] = 1;
+	SearchableList.focused[eid] = 0;
+
+	const items: SearchableListItem[] = validated.items.map((text) => ({
+		text,
+		value: text,
+	}));
+
+	// Account for filter input line
+	const filterLineHeight = validated.enableSearch ? 1 : 0;
+	const visibleCount = Math.max(1, validated.height - filterLineHeight);
+
+	const state: SearchableListState = {
+		items,
+		filterQuery: '',
+		filteredItems: [...items],
+		filteredToOriginalMap: items.map((_, i) => i),
+		selectedFilteredIndex: items.length > 0 ? Math.min(validated.selected, items.length - 1) : -1,
+		searchEnabled: validated.enableSearch,
+		placeholder: validated.placeholder,
+		visibleCount,
+		firstVisible: 0,
+		width: validated.width,
+		fg: validated.fg ?? 0xffffffff,
+		bg: validated.bg ?? 0x000000ff,
+		selectedFg: validated.selectedFg ?? 0x000000ff,
+		selectedBg: validated.selectedBg ?? 0x0088ffff,
+		disabledFg: validated.disabledFg ?? 0x888888ff,
+		filterFg: validated.filterFg ?? 0xffffffff,
+		filterBg: validated.filterBg ?? 0x222222ff,
+		callbacks: [],
+	};
+
+	stateMap.set(eid, state);
+
+	const widget: SearchableListWidget = {
+		eid,
+
+		// Visibility
+		show(): SearchableListWidget {
+			SearchableList.visible[eid] = 1;
+			return widget;
+		},
+
+		hide(): SearchableListWidget {
+			SearchableList.visible[eid] = 0;
+			return widget;
+		},
+
+		// Focus
+		focus(): SearchableListWidget {
+			SearchableList.focused[eid] = 1;
+			return widget;
+		},
+
+		blur(): SearchableListWidget {
+			SearchableList.focused[eid] = 0;
+			return widget;
+		},
+
+		isFocused(): boolean {
+			return SearchableList.focused[eid] === 1;
+		},
+
+		// Items
+		setItems(newItems: readonly string[]): SearchableListWidget {
+			state.items = newItems.map((text) => ({ text, value: text }));
+			recalculateFilter(state);
+			fireCallbacks(state);
+			return widget;
+		},
+
+		getItems(): readonly SearchableListItem[] {
+			return state.items;
+		},
+
+		// Filter
+		setFilter(query: string): SearchableListWidget {
+			state.filterQuery = query;
+			recalculateFilter(state);
+			fireCallbacks(state);
+			return widget;
+		},
+
+		getFilter(): string {
+			return state.filterQuery;
+		},
+
+		clearFilter(): SearchableListWidget {
+			state.filterQuery = '';
+			recalculateFilter(state);
+			fireCallbacks(state);
+			return widget;
+		},
+
+		getFilteredItems(): readonly SearchableListItem[] {
+			return state.filteredItems;
+		},
+
+		getFilteredCount(): number {
+			return state.filteredItems.length;
+		},
+
+		getFilterStatus(): string {
+			if (state.filterQuery.length === 0) {
+				return `${state.items.length} items`;
+			}
+			return `${state.filteredItems.length} of ${state.items.length} items`;
+		},
+
+		isSearchEnabled(): boolean {
+			return state.searchEnabled;
+		},
+
+		setSearchEnabled(enabled: boolean): SearchableListWidget {
+			state.searchEnabled = enabled;
+			// Recalculate visible count
+			const filterLineHeight = enabled ? 1 : 0;
+			state.visibleCount = Math.max(1, validated.height - filterLineHeight);
+			if (!enabled) {
+				state.filterQuery = '';
+				recalculateFilter(state);
+			}
+			return widget;
+		},
+
+		// Selection
+		select(index: number): SearchableListWidget {
+			if (index >= 0 && index < state.filteredItems.length) {
+				state.selectedFilteredIndex = index;
+				ensureVisible(state);
+			}
+			return widget;
+		},
+
+		getSelectedIndex(): number {
+			return state.selectedFilteredIndex;
+		},
+
+		getSelectedItem(): SearchableListItem | undefined {
+			if (
+				state.selectedFilteredIndex < 0 ||
+				state.selectedFilteredIndex >= state.filteredItems.length
+			) {
+				return undefined;
+			}
+			return state.filteredItems[state.selectedFilteredIndex];
+		},
+
+		getOriginalSelectedIndex(): number {
+			if (state.selectedFilteredIndex < 0) {
+				return -1;
+			}
+			return state.filteredToOriginalMap[state.selectedFilteredIndex] ?? -1;
+		},
+
+		selectPrev(): SearchableListWidget {
+			if (state.selectedFilteredIndex > 0) {
+				state.selectedFilteredIndex--;
+				ensureVisible(state);
+				fireCallbacks(state);
+			}
+			return widget;
+		},
+
+		selectNext(): SearchableListWidget {
+			if (state.selectedFilteredIndex < state.filteredItems.length - 1) {
+				state.selectedFilteredIndex++;
+				ensureVisible(state);
+				fireCallbacks(state);
+			}
+			return widget;
+		},
+
+		selectFirst(): SearchableListWidget {
+			if (state.filteredItems.length > 0) {
+				state.selectedFilteredIndex = 0;
+				state.firstVisible = 0;
+				fireCallbacks(state);
+			}
+			return widget;
+		},
+
+		selectLast(): SearchableListWidget {
+			if (state.filteredItems.length > 0) {
+				state.selectedFilteredIndex = state.filteredItems.length - 1;
+				ensureVisible(state);
+				fireCallbacks(state);
+			}
+			return widget;
+		},
+
+		// Events
+		onChange(callback: SearchableListCallback): () => void {
+			state.callbacks.push(callback);
+			return () => {
+				const idx = state.callbacks.indexOf(callback);
+				if (idx !== -1) {
+					state.callbacks.splice(idx, 1);
+				}
+			};
+		},
+
+		// Key handling
+		handleKey(key: string, ctrl = false, _shift = false): boolean {
+			// Navigation keys (always active)
+			if (handleSearchableListNav(key, state, widget)) {
+				return true;
+			}
+
+			// Escape clears filter or blurs
+			if (key === 'escape') {
+				if (state.filterQuery.length > 0) {
+					widget.clearFilter();
+				} else {
+					widget.blur();
+				}
+				return true;
+			}
+
+			// Filter typing (when search is enabled)
+			if (state.searchEnabled) {
+				return handleSearchableListFilter(key, ctrl, state, widget);
+			}
+
+			return false;
+		},
+
+		// Lifecycle
+		destroy(): void {
+			SearchableList.isSearchableList[eid] = 0;
+			SearchableList.visible[eid] = 0;
+			SearchableList.focused[eid] = 0;
+			stateMap.delete(eid);
+			removeEntity(world, eid);
+		},
+	};
+
+	return widget;
+}
+
+// =============================================================================
+// STANDALONE API FUNCTIONS
+// =============================================================================
+
+/**
+ * Gets the filtered items from a SearchableList entity.
+ *
+ * @param _world - The ECS world
+ * @param eid - The searchable list entity ID
+ * @returns Array of filtered items
+ *
+ * @example
+ * ```typescript
+ * import { getFilteredItems } from 'blecsd';
+ *
+ * const items = getFilteredItems(world, listEid);
+ * ```
+ */
+export function getSearchableFilteredItems(
+	_world: World,
+	eid: Entity,
+): readonly SearchableListItem[] {
+	const state = stateMap.get(eid);
+	return state?.filteredItems ?? [];
+}
+
+/**
+ * Sets the filter query on a SearchableList entity.
+ *
+ * @param _world - The ECS world
+ * @param eid - The searchable list entity ID
+ * @param query - The filter query
+ *
+ * @example
+ * ```typescript
+ * import { setSearchableFilter } from 'blecsd';
+ *
+ * setSearchableFilter(world, listEid, 'apple');
+ * ```
+ */
+export function setSearchableFilter(_world: World, eid: Entity, query: string): void {
+	const state = stateMap.get(eid);
+	if (!state) {
+		return;
+	}
+	state.filterQuery = query;
+	recalculateFilter(state);
+	fireCallbacks(state);
+}
+
+// =============================================================================
+// UTILITY FUNCTIONS
+// =============================================================================
+
+/**
+ * Checks if an entity is a SearchableList widget.
+ *
+ * @param _world - The ECS world
+ * @param eid - The entity ID
+ * @returns true if the entity is a searchable list
+ */
+export function isSearchableList(_world: World, eid: Entity): boolean {
+	return SearchableList.isSearchableList[eid] === 1;
+}
+
+/**
+ * Resets the SearchableList store. Useful for testing.
+ *
+ * @internal
+ */
+export function resetSearchableListStore(): void {
+	SearchableList.isSearchableList.fill(0);
+	SearchableList.visible.fill(0);
+	SearchableList.focused.fill(0);
+	stateMap.clear();
+}


### PR DESCRIPTION
## Summary
- **Search overlay** (Ctrl+F): Floating search bar with regex/plain text modes, match highlighting, next/prev navigation for any scrollable content
- **Multi-select widget**: Checkbox list with Space toggle, Ctrl+A select/deselect all, Shift+Arrow range select, filter-as-you-type
- **Searchable list**: Inline filter enhancement for list widgets with real-time filtering and selection preservation

## Test plan
- [x] All 12,356 tests pass
- [x] TypeScript strict mode passes
- [ ] Biome complexity warnings need follow-up cleanup (pre-existing pattern)
- [ ] Verify widget integration with existing scrollable components