### PR TITLE
chore: add Claude Code quality gate hooks

### DIFF
--- a/.claude/hooks/biome-check.sh
+++ b/.claude/hooks/biome-check.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# PostToolUse hook: Run biome check on edited/written files
+# Extracts file_path from the JSON on stdin and runs biome lint
+
+set -euo pipefail
+
+FILE=$(jq -r '.tool_input.file_path // empty')
+
+# Skip if no file path or file doesn't exist
+[ -z "$FILE" ] && exit 0
+[ -f "$FILE" ] || exit 0
+
+# Only check TypeScript/JavaScript files
+case "$FILE" in
+  *.ts|*.tsx|*.js|*.jsx|*.json) ;;
+  *) exit 0 ;;
+esac
+
+# Run biome check (read-only, just report issues)
+cd "$CLAUDE_PROJECT_DIR"
+npx biome check "$FILE" 2>&1 || true

--- a/.claude/hooks/task-completed.sh
+++ b/.claude/hooks/task-completed.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# TaskCompleted hook: Verify task quality before marking complete
+# Ensures typecheck passes and no lint errors exist in changed files
+
+set -euo pipefail
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Run typecheck
+if ! pnpm typecheck 2>&1 | tail -5; then
+  echo "Typecheck failed. Fix type errors before marking task complete."
+  exit 2
+fi
+
+# Run lint on changed files only (faster than full lint)
+CHANGED_FILES=$(git diff --name-only HEAD~1 2>/dev/null | grep '\.ts$' || true)
+if [ -n "$CHANGED_FILES" ]; then
+  if ! echo "$CHANGED_FILES" | xargs npx biome check 2>&1 | tail -5; then
+    echo "Lint errors found in changed files. Fix before marking task complete."
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/teammate-idle.sh
+++ b/.claude/hooks/teammate-idle.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# TeammateIdle hook: Verify teammate's work before letting them go idle
+# Checks that typecheck and lint pass on any modified files
+
+set -euo pipefail
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Check if there are any uncommitted changes (teammate might have unfinished work)
+if git diff --name-only --diff-filter=M 2>/dev/null | grep -q '\.ts$'; then
+  echo "Teammate has uncommitted TypeScript changes. Run typecheck and lint before going idle."
+  exit 2
+fi
+
+# Check for unpushed commits
+UNPUSHED=$(git log --oneline @{upstream}..HEAD 2>/dev/null | wc -l || echo "0")
+if [ "$UNPUSHED" -gt 0 ]; then
+  echo "Teammate has $UNPUSHED unpushed commits. Push and create PR before going idle."
+  exit 2
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Add three Claude Code hooks for agent team quality enforcement
- `biome-check.sh`: PostToolUse hook that runs biome lint on edited files inline
- `task-completed.sh`: Verifies typecheck + lint pass before marking tasks complete
- `teammate-idle.sh`: Ensures teammates push their work before going idle

## Test plan
- [ ] Verify hooks are executable (`chmod +x`)
- [ ] Test biome-check fires on file edits during Claude Code sessions
- [ ] Test task-completed blocks completion when typecheck fails