### PR TITLE
refactor: update export count and convert encoding to namespace

### DIFF
--- a/docs/guides/export-patterns.md
+++ b/docs/guides/export-patterns.md
@@ -6,7 +6,7 @@ blECSd uses a three-tier export system. Each tier provides a different level of 
 
 ### Tier 1: Curated Essentials (`'blecsd'`)
 
-The top-level import provides ~95 curated exports: the most commonly used functions, types, and schemas. This is the default choice for most applications.
+The top-level import provides ~80 curated exports (64 values + 15 types): the most commonly used functions, types, and schemas. This is the default choice for most applications.
 
 ```typescript
 import {
@@ -108,7 +108,7 @@ const width = unicode.width.stringWidth('Hello');
 
 | Path | Description |
 |------|-------------|
-| `blecsd` | Curated Tier 1 essentials (~95 exports) |
+| `blecsd` | Curated Tier 1 essentials (~80 exports) |
 | `blecsd/core` | ECS primitives, world management, entity factories, schemas |
 | `blecsd/components` | All component definitions, typed getters/setters, and namespaces |
 | `blecsd/systems` | All system functions and namespaces |
@@ -291,7 +291,7 @@ import { rope } from 'blecsd/utils';
 
 ### Q: What changed from the old `export *` approach?
 
-The top-level `'blecsd'` import used to re-export everything (~4,500 symbols). Now it exports ~95 curated symbols. Everything else is still accessible via subpath imports (`blecsd/components`, `blecsd/terminal`, etc.).
+The top-level `'blecsd'` import used to re-export everything (~4,500 symbols). Now it exports ~80 curated symbols (64 values + 15 types). Everything else is still accessible via subpath imports (`blecsd/components`, `blecsd/terminal`, etc.).
 
 ### Q: I was importing X from 'blecsd' and now it's gone. Where did it move?
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -117,7 +117,13 @@ export {
 	toUnifiedDiff,
 } from './diffRender';
 // Legacy codepage encoding utilities (CP437, etc.)
-export * as encoding from './encoding';
+// Accessed via the `encoding` namespace to avoid collisions (e.g., bufferToString exists in ./box)
+export type {
+	CodePage,
+	ConversionOptions,
+	PartialConversionOptions,
+	UnmappableMode,
+} from './encoding';
 // Fast word wrap with caching
 export type {
 	FastWrapOptions,
@@ -272,6 +278,7 @@ export type {
 	ComponentStoreModule,
 	CursorNavModule,
 	DiffRendererModule,
+	EncodingModule,
 	FastWrapModule,
 	FoldModule,
 	FuzzySearchModule,
@@ -299,6 +306,7 @@ export {
 	componentStore,
 	cursorNav,
 	diffRenderer,
+	encoding,
 	fastWrap,
 	fold,
 	fuzzySearch,

--- a/src/utils/namespaces/encoding.ts
+++ b/src/utils/namespaces/encoding.ts
@@ -1,0 +1,57 @@
+/**
+ * Legacy codepage encoding utilities namespace.
+ *
+ * Provides conversion functions between legacy single-byte encodings
+ * (CP437, CP850, CP866, CP1252) and UTF-8/UTF-16 strings. Primary use
+ * case is rendering classic ANSI art files that use CP437.
+ *
+ * @example
+ * ```typescript
+ * import { encoding } from 'blecsd/utils';
+ *
+ * const content = encoding.bufferToString(ansiFile, 'cp437');
+ * const char = encoding.byteToChar(0xdb, 'cp437'); // full block
+ * const supported = encoding.isCodePageSupported('cp437');
+ * ```
+ */
+
+import {
+	bufferToString,
+	byteToChar,
+	CodePageSchema,
+	ConversionOptionsSchema,
+	charToByte,
+	getCodePageMap,
+	getSupportedCodePages,
+	isCodePageSupported,
+	stringToBuffer,
+	UnmappableModeSchema,
+} from '../encoding';
+
+import {
+	CP437_CONTROL_CHARS,
+	CP437_HIGH_BYTES,
+	CP850_HIGH_BYTES,
+	CP866_HIGH_BYTES,
+	CP1252_HIGH_BYTES,
+} from '../encoding/codepages';
+
+export const encoding = Object.freeze({
+	byteToChar,
+	charToByte,
+	bufferToString,
+	stringToBuffer,
+	isCodePageSupported,
+	getSupportedCodePages,
+	getCodePageMap,
+	CodePageSchema,
+	UnmappableModeSchema,
+	ConversionOptionsSchema,
+	CP437_CONTROL_CHARS,
+	CP437_HIGH_BYTES,
+	CP850_HIGH_BYTES,
+	CP866_HIGH_BYTES,
+	CP1252_HIGH_BYTES,
+});
+
+export type EncodingModule = typeof encoding;

--- a/src/utils/namespaces/index.ts
+++ b/src/utils/namespaces/index.ts
@@ -18,6 +18,7 @@ export { type ColorsModule, colors } from './colors';
 export { type ComponentStoreModule, componentStore } from './componentStore';
 export { type CursorNavModule, cursorNav } from './cursorNav';
 export { type DiffRendererModule, diffRenderer } from './diffRenderer';
+export { type EncodingModule, encoding } from './encoding';
 export { type FastWrapModule, fastWrap } from './fastWrap';
 export { type FoldModule, fold } from './fold';
 export { type FuzzySearchModule, fuzzySearch } from './fuzzySearch';


### PR DESCRIPTION
## Summary

- Fix Tier 1 export count in `docs/guides/export-patterns.md`: ~95 -> ~80 (64 values + 15 types)
- Create explicit `encoding` namespace object using `Object.freeze` pattern
- Replace the only remaining `export * as encoding` wildcard with the explicit namespace
- Encoding functions stay namespaced (not flat) to avoid collision with `box.bufferToString`

Closes #1228, closes #1229

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (only pre-existing warnings)
- [x] `pnpm test` passes (12,518 tests)