### PR TITLE
feat: add subpath exports to @blecsd/3d and @blecsd/media

### DIFF
--- a/packages/3d/package.json
+++ b/packages/3d/package.json
@@ -7,8 +7,44 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    },
+    "./backends": {
+      "import": "./src/backends/index.ts",
+      "types": "./src/backends/index.ts"
+    },
+    "./components": {
+      "import": "./src/components/index.ts",
+      "types": "./src/components/index.ts"
+    },
+    "./loaders": {
+      "import": "./src/loaders/index.ts",
+      "types": "./src/loaders/index.ts"
+    },
+    "./math": {
+      "import": "./src/math/index.ts",
+      "types": "./src/math/index.ts"
+    },
+    "./rasterizer": {
+      "import": "./src/rasterizer/index.ts",
+      "types": "./src/rasterizer/index.ts"
+    },
+    "./schemas": {
+      "import": "./src/schemas/index.ts",
+      "types": "./src/schemas/index.ts"
+    },
+    "./stores": {
+      "import": "./src/stores/index.ts",
+      "types": "./src/stores/index.ts"
+    },
+    "./systems": {
+      "import": "./src/systems/index.ts",
+      "types": "./src/systems/index.ts"
+    },
+    "./widgets": {
+      "import": "./src/widgets/viewport3d.ts",
+      "types": "./src/widgets/viewport3d.ts"
     }
   },
   "files": ["dist", "README.md", "LICENSE"],

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -7,8 +7,32 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    },
+    "./gif": {
+      "import": "./src/gif/index.ts",
+      "types": "./src/gif/index.ts"
+    },
+    "./overlay": {
+      "import": "./src/overlay/index.ts",
+      "types": "./src/overlay/index.ts"
+    },
+    "./png": {
+      "import": "./src/png/index.ts",
+      "types": "./src/png/index.ts"
+    },
+    "./render": {
+      "import": "./src/render/index.ts",
+      "types": "./src/render/index.ts"
+    },
+    "./widgets/image": {
+      "import": "./src/widgets/image/index.ts",
+      "types": "./src/widgets/image/index.ts"
+    },
+    "./widgets/video": {
+      "import": "./src/widgets/video/index.ts",
+      "types": "./src/widgets/video/index.ts"
     }
   },
   "files": ["dist", "README.md", "LICENSE"],


### PR DESCRIPTION
## Summary
- Add exports field to @blecsd/3d package.json with subpath entries for all modules
- Add exports field to @blecsd/media package.json with subpath entries for all modules
- Enables imports like `import { vec3 } from '@blecsd/3d/math'`

Closes #1236

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] Build passes
- [x] Subpath entries reference valid files