### PR TITLE
feat: add namespace objects to @blecsd/3d

### DIFF
--- a/packages/3d/src/index.ts
+++ b/packages/3d/src/index.ts
@@ -15,6 +15,8 @@ export * from './components';
 export * from './loaders';
 // Math (vectors, matrices, projection, clipping)
 export * from './math';
+// Namespace objects for API discoverability
+export * from './namespaces';
 // Rasterizer (pixel buffer, line/triangle drawing, shading)
 export * from './rasterizer';
 // Zod schemas (for advanced users and validation)

--- a/packages/3d/src/namespaces/backends.ts
+++ b/packages/3d/src/namespaces/backends.ts
@@ -1,0 +1,43 @@
+/**
+ * Renderer backend creation namespace.
+ *
+ * @example
+ * ```typescript
+ * import { backends } from '@blecsd/3d';
+ *
+ * // Auto-detect best backend
+ * const backend = backends.detectBest();
+ *
+ * // Or create specific backend
+ * const braille = backends.createBraille();
+ * const kitty = backends.createKitty();
+ *
+ * // Render with the backend
+ * const output = backend.render(pixelFramebuffer);
+ * ```
+ */
+
+import {
+	createBackendByType,
+	createBrailleBackend,
+	createHalfBlockBackend,
+	createKittyBackend,
+	createSextantBackend,
+	createSixelBackend,
+	detectBestBackend,
+	type GraphicsCapabilities,
+	type RendererBackend,
+} from '../backends';
+
+export const backends = Object.freeze({
+	detectBest: detectBestBackend,
+	createByType: createBackendByType,
+	createBraille: createBrailleBackend,
+	createHalfBlock: createHalfBlockBackend,
+	createSextant: createSextantBackend,
+	createSixel: createSixelBackend,
+	createKitty: createKittyBackend,
+});
+
+export type BackendsModule = typeof backends;
+export type { RendererBackend, GraphicsCapabilities };

--- a/packages/3d/src/namespaces/camera3d.ts
+++ b/packages/3d/src/namespaces/camera3d.ts
@@ -1,0 +1,34 @@
+/**
+ * Camera3D component operations namespace.
+ *
+ * @example
+ * ```typescript
+ * import { camera3d } from '@blecsd/3d';
+ *
+ * camera3d.set(world, eid, { fov: Math.PI / 3, near: 0.1, far: 100, aspect: 16/9 });
+ * const data = camera3d.get(world, eid);
+ * const projMatrix = camera3d.getProjMatrix(eid);
+ * ```
+ */
+
+import type { Entity, World } from 'blecsd/core';
+import {
+	Camera3D,
+	type Camera3DData,
+	getCamera3D,
+	getProjMatrix,
+	getViewMatrix,
+	setCamera3D,
+} from '../components/camera3d';
+import type { Camera3DConfig } from '../schemas/components';
+
+export const camera3d = Object.freeze({
+	component: Camera3D,
+	set: setCamera3D,
+	get: getCamera3D,
+	getProjMatrix,
+	getViewMatrix,
+});
+
+export type Camera3dModule = typeof camera3d;
+export type { Entity, World, Camera3DConfig, Camera3DData };

--- a/packages/3d/src/namespaces/clipping.ts
+++ b/packages/3d/src/namespaces/clipping.ts
@@ -1,0 +1,36 @@
+/**
+ * Clipping utilities namespace for frustum culling and line clipping.
+ *
+ * @example
+ * ```typescript
+ * import { clipping } from '@blecsd/3d';
+ *
+ * const planes = clipping.extractFrustumPlanes(vpMatrix);
+ * const visible = clipping.isSphereInFrustum(center, radius, planes);
+ * const clipped = clipping.clipLine(x0, y0, x1, y1, clipRect);
+ * ```
+ */
+
+import {
+	type ClippedLine,
+	clipLine,
+	computeOutcode,
+	extractFrustumPlanes,
+	type FrustumPlane,
+	isPointInFrustum,
+	isSphereInFrustum,
+} from '../math/clipping';
+import type { Mat4 } from '../math/mat4';
+import type { Vec3 } from '../math/vec3';
+import type { ClipRect } from '../schemas/math';
+
+export const clipping = Object.freeze({
+	computeOutcode,
+	clipLine,
+	extractFrustumPlanes,
+	isPointInFrustum,
+	isSphereInFrustum,
+});
+
+export type ClippingModule = typeof clipping;
+export type { ClippedLine, FrustumPlane, ClipRect, Mat4, Vec3 };

--- a/packages/3d/src/namespaces/index.ts
+++ b/packages/3d/src/namespaces/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Namespace objects for @blecsd/3d API discoverability.
+ *
+ * All namespaces use Object.freeze for immutability and provide
+ * both the namespace object and its type for maximum flexibility.
+ *
+ * @module 3d/namespaces
+ */
+
+export { type BackendsModule, backends } from './backends';
+export { type Camera3dModule, camera3d } from './camera3d';
+export { type ClippingModule, clipping } from './clipping';
+export { type Mat4Module, mat4 } from './mat4';
+export { type MeshModule, mesh } from './mesh';
+export { type PixelBufferModule, pixelBuffer } from './pixelBuffer';
+export { type ProjectionModule, projection } from './projection';
+export { type RasterModule, raster } from './raster';
+export { type Transform3dModule, transform3d } from './transform3d';
+export { type Vec3Module, vec3 } from './vec3';

--- a/packages/3d/src/namespaces/mat4.ts
+++ b/packages/3d/src/namespaces/mat4.ts
@@ -1,0 +1,54 @@
+/**
+ * Mat4 operations namespace for 4x4 matrix math.
+ *
+ * @example
+ * ```typescript
+ * import { mat4 } from '@blecsd/3d';
+ *
+ * const m = mat4.identity();
+ * const moved = mat4.translate(m, 10, 0, -5);
+ * const rotated = mat4.rotateY(moved, Math.PI / 4);
+ * const scaled = mat4.scale(rotated, 2, 2, 2);
+ * ```
+ */
+
+import type { Mat4 } from '../math/mat4';
+import {
+	mat4Determinant,
+	mat4Equals,
+	mat4FromTRS,
+	mat4Identity,
+	mat4Invert,
+	mat4IsIdentity,
+	mat4Multiply,
+	mat4RotateX,
+	mat4RotateY,
+	mat4RotateZ,
+	mat4Scale,
+	mat4TransformDirection,
+	mat4TransformVec3,
+	mat4Translate,
+	mat4Transpose,
+} from '../math/mat4';
+import type { Vec3 } from '../math/vec3';
+
+export const mat4 = Object.freeze({
+	identity: mat4Identity,
+	multiply: mat4Multiply,
+	translate: mat4Translate,
+	rotateX: mat4RotateX,
+	rotateY: mat4RotateY,
+	rotateZ: mat4RotateZ,
+	scale: mat4Scale,
+	transpose: mat4Transpose,
+	determinant: mat4Determinant,
+	invert: mat4Invert,
+	transformVec3: mat4TransformVec3,
+	transformDirection: mat4TransformDirection,
+	fromTRS: mat4FromTRS,
+	isIdentity: mat4IsIdentity,
+	equals: mat4Equals,
+});
+
+export type Mat4Module = typeof mat4;
+export type { Mat4, Vec3 };

--- a/packages/3d/src/namespaces/mesh.ts
+++ b/packages/3d/src/namespaces/mesh.ts
@@ -1,0 +1,69 @@
+/**
+ * Mesh operations namespace with sub-namespaces for primitives and loaders.
+ *
+ * @example
+ * ```typescript
+ * import { mesh } from '@blecsd/3d';
+ *
+ * // Create primitives
+ * const cubeId = mesh.primitives.cube({ size: 2 });
+ * const sphereId = mesh.primitives.sphere({ radius: 1, segments: 16 });
+ *
+ * // Load from OBJ
+ * const modelId = mesh.loaders.loadObj(objSource, { name: 'myModel' });
+ *
+ * // Assign to entity
+ * mesh.set(world, eid, cubeId);
+ * const data = mesh.getData(cubeId);
+ * ```
+ */
+
+import type { Entity, World } from 'blecsd/core';
+import {
+	clearMeshStore,
+	createMeshFromArrays,
+	getMesh,
+	getMeshCount,
+	getMeshData,
+	Mesh,
+	type MeshData,
+	registerMesh,
+	setMesh,
+	unregisterMesh,
+} from '../components/mesh';
+import { computeBoundingBox, loadObjAsMesh, parseObj } from '../loaders/obj';
+import type { ObjFace, ObjGroup, ObjParseResult, ObjVertex } from '../loaders/types';
+import {
+	createCubeMesh,
+	createCylinderMesh,
+	createPlaneMesh,
+	createSphereMesh,
+} from '../stores/primitives';
+
+export const mesh = Object.freeze({
+	component: Mesh,
+	register: registerMesh,
+	createFromArrays: createMeshFromArrays,
+	getData: getMeshData,
+	unregister: unregisterMesh,
+	set: setMesh,
+	get: getMesh,
+	getCount: getMeshCount,
+	clearStore: clearMeshStore,
+
+	primitives: Object.freeze({
+		cube: createCubeMesh,
+		sphere: createSphereMesh,
+		plane: createPlaneMesh,
+		cylinder: createCylinderMesh,
+	}),
+
+	loaders: Object.freeze({
+		parseObj,
+		computeBoundingBox,
+		loadObj: loadObjAsMesh,
+	}),
+});
+
+export type MeshModule = typeof mesh;
+export type { Entity, World, MeshData, ObjParseResult, ObjVertex, ObjFace, ObjGroup };

--- a/packages/3d/src/namespaces/pixelBuffer.ts
+++ b/packages/3d/src/namespaces/pixelBuffer.ts
@@ -1,0 +1,42 @@
+/**
+ * PixelBuffer operations namespace for RGBA framebuffer management.
+ *
+ * @example
+ * ```typescript
+ * import { pixelBuffer } from '@blecsd/3d';
+ *
+ * const fb = pixelBuffer.create({ width: 400, height: 200 });
+ * pixelBuffer.clear(fb, { r: 0, g: 0, b: 0, a: 255 });
+ * pixelBuffer.setPixel(fb, 10, 20, { r: 255, g: 0, b: 0, a: 255 });
+ * const color = pixelBuffer.getPixel(fb, 10, 20);
+ * ```
+ */
+
+import {
+	clearFramebuffer,
+	createPixelFramebuffer,
+	fillRect,
+	getDepth,
+	getPixel,
+	isInBounds,
+	type PixelFramebuffer,
+	setPixel,
+	setPixelUnsafe,
+	testAndSetDepth,
+} from '../rasterizer/pixelBuffer';
+import type { PixelBufferConfig, RGBAColor } from '../schemas/rasterizer';
+
+export const pixelBuffer = Object.freeze({
+	create: createPixelFramebuffer,
+	clear: clearFramebuffer,
+	isInBounds,
+	getPixel,
+	setPixel,
+	setPixelUnsafe,
+	getDepth,
+	testAndSetDepth,
+	fillRect,
+});
+
+export type PixelBufferModule = typeof pixelBuffer;
+export type { PixelFramebuffer, PixelBufferConfig, RGBAColor };

--- a/packages/3d/src/namespaces/projection.ts
+++ b/packages/3d/src/namespaces/projection.ts
@@ -1,0 +1,39 @@
+/**
+ * Projection utilities namespace for camera matrices and transforms.
+ *
+ * @example
+ * ```typescript
+ * import { projection } from '@blecsd/3d';
+ *
+ * const proj = projection.perspective({ fov: Math.PI / 3, aspect: 16/9, near: 0.1, far: 100 });
+ * const view = projection.lookAt(vec3(0, 0, 5), vec3(0, 0, 0), vec3(0, 1, 0));
+ * const mvp = projection.buildMVP(modelMatrix, view, proj);
+ * ```
+ */
+
+import type { Mat4 } from '../math/mat4';
+import {
+	buildMVP,
+	lookAt,
+	orthographicMatrix,
+	perspectiveMatrix,
+	projectVertex,
+	type ScreenCoord,
+	unprojectVertex,
+	viewportTransform,
+} from '../math/projection';
+import type { Vec3 } from '../math/vec3';
+import type { OrthographicConfig, PerspectiveConfig, ViewportConfig } from '../schemas/math';
+
+export const projection = Object.freeze({
+	perspective: perspectiveMatrix,
+	orthographic: orthographicMatrix,
+	lookAt,
+	viewportTransform,
+	projectVertex,
+	unprojectVertex,
+	buildMVP,
+});
+
+export type ProjectionModule = typeof projection;
+export type { Mat4, Vec3, PerspectiveConfig, OrthographicConfig, ViewportConfig, ScreenCoord };

--- a/packages/3d/src/namespaces/raster.ts
+++ b/packages/3d/src/namespaces/raster.ts
@@ -1,0 +1,74 @@
+/**
+ * Rasterization namespace with sub-namespaces for different primitives.
+ *
+ * @example
+ * ```typescript
+ * import { raster } from '@blecsd/3d';
+ *
+ * // Draw lines
+ * raster.line.draw(fb, { x: 0, y: 0, depth: 0 }, { x: 100, y: 50, depth: 0 });
+ * raster.line.drawAA(fb, 0, 0, 100, 50, 255, 255, 255, 255);
+ *
+ * // Draw triangles
+ * raster.triangle.fill(fb, v0, v1, v2);
+ * raster.triangle.fillFlat(fb, v0, v1, v2, color);
+ *
+ * // Compute shading
+ * const color = raster.shading.computeFlat(normal, light, ambient, baseColor);
+ * ```
+ */
+
+import type { Vec3 } from '../math/vec3';
+import { drawLine, drawLineColor, drawLineDepth } from '../rasterizer/line';
+import { blendPixel, drawLineAA } from '../rasterizer/lineAA';
+import type { PixelFramebuffer } from '../rasterizer/pixelBuffer';
+import { computeFaceNormal, computeFlatShading, shadeFace } from '../rasterizer/shading';
+import {
+	fillTriangle,
+	fillTriangleFlat,
+	type TriangleBBox,
+	triangleArea2,
+	triangleBoundingBox,
+} from '../rasterizer/triangle';
+import type {
+	AmbientLight,
+	DirectionalLight,
+	LineEndpoint,
+	RGBAColor,
+	TriangleVertex,
+} from '../schemas/rasterizer';
+
+export const raster = Object.freeze({
+	line: Object.freeze({
+		draw: drawLine,
+		drawColor: drawLineColor,
+		drawDepth: drawLineDepth,
+		drawAA: drawLineAA,
+		blendPixel,
+	}),
+
+	triangle: Object.freeze({
+		fill: fillTriangle,
+		fillFlat: fillTriangleFlat,
+		area2: triangleArea2,
+		boundingBox: triangleBoundingBox,
+	}),
+
+	shading: Object.freeze({
+		computeFaceNormal,
+		computeFlat: computeFlatShading,
+		shadeFace,
+	}),
+});
+
+export type RasterModule = typeof raster;
+export type {
+	Vec3,
+	LineEndpoint,
+	TriangleVertex,
+	TriangleBBox,
+	RGBAColor,
+	DirectionalLight,
+	AmbientLight,
+	PixelFramebuffer,
+};

--- a/packages/3d/src/namespaces/transform3d.ts
+++ b/packages/3d/src/namespaces/transform3d.ts
@@ -1,0 +1,42 @@
+/**
+ * Transform3D component operations namespace.
+ *
+ * @example
+ * ```typescript
+ * import { transform3d } from '@blecsd/3d';
+ *
+ * transform3d.set(world, eid, { tx: 0, ty: 0, tz: -5, rx: 0, ry: Math.PI / 4, rz: 0 });
+ * transform3d.setTranslation(world, eid, 10, 0, -5);
+ * const matrix = transform3d.getWorldMatrix(eid);
+ * ```
+ */
+
+import type { Entity, World } from 'blecsd/core';
+import {
+	getTransform3D,
+	getWorldMatrix,
+	isDirty,
+	markDirty,
+	setRotation,
+	setScale,
+	setTransform3D,
+	setTranslation,
+	Transform3D,
+	type Transform3DData,
+} from '../components/transform3d';
+import type { Transform3DConfig } from '../schemas/components';
+
+export const transform3d = Object.freeze({
+	component: Transform3D,
+	set: setTransform3D,
+	get: getTransform3D,
+	setTranslation,
+	setRotation,
+	setScale,
+	getWorldMatrix,
+	markDirty,
+	isDirty,
+});
+
+export type Transform3dModule = typeof transform3d;
+export type { Entity, World, Transform3DConfig, Transform3DData };

--- a/packages/3d/src/namespaces/vec3.ts
+++ b/packages/3d/src/namespaces/vec3.ts
@@ -1,0 +1,53 @@
+/**
+ * Vec3 operations namespace for 3D vector math.
+ *
+ * @example
+ * ```typescript
+ * import { vec3 } from '@blecsd/3d';
+ *
+ * const v = vec3.create(1, 2, 3);
+ * const len = vec3.length(v);
+ * const unit = vec3.normalize(v);
+ * const sum = vec3.add(v, unit);
+ * ```
+ */
+
+import type { Vec3 } from '../math/vec3';
+import {
+	vec3Add,
+	vec3 as vec3Create,
+	vec3Cross,
+	vec3Distance,
+	vec3Dot,
+	vec3Equals,
+	vec3FromArray,
+	vec3Length,
+	vec3LengthSq,
+	vec3Lerp,
+	vec3Negate,
+	vec3Normalize,
+	vec3Scale,
+	vec3Sub,
+	vec3Zero,
+} from '../math/vec3';
+
+export const vec3 = Object.freeze({
+	create: vec3Create,
+	fromArray: vec3FromArray,
+	zero: vec3Zero,
+	add: vec3Add,
+	sub: vec3Sub,
+	scale: vec3Scale,
+	dot: vec3Dot,
+	cross: vec3Cross,
+	lengthSq: vec3LengthSq,
+	length: vec3Length,
+	normalize: vec3Normalize,
+	lerp: vec3Lerp,
+	negate: vec3Negate,
+	distance: vec3Distance,
+	equals: vec3Equals,
+});
+
+export type Vec3Module = typeof vec3;
+export type { Vec3 };


### PR DESCRIPTION
## Summary
- Add 10 namespace objects to @blecsd/3d for API discoverability
- Namespaces: vec3, mat4, projection, clipping, pixelBuffer, raster, transform3d, camera3d, mesh, backends
- Follows same Object.freeze pattern as main blecsd package
- Raster namespace uses sub-namespaces (line, triangle, shading)
- Mesh namespace uses sub-namespaces (primitives, loaders)
- No API changes to existing flat exports

Partially addresses #1237

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] Build passes