### PR TITLE
feat: add namespace objects to @blecsd/ai and @blecsd/media

### DIFF
--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -8,6 +8,8 @@
  * @module ai
  */
 
+// Namespace objects for API discoverability
+export * from './namespaces';
 // Agent workflow widget
 export * from './widgets/agentWorkflow';
 // Conversation widget

--- a/packages/ai/src/namespaces/agentWorkflow.ts
+++ b/packages/ai/src/namespaces/agentWorkflow.ts
@@ -1,0 +1,50 @@
+/**
+ * Agent workflow namespace for visualizing AI agent workflows.
+ *
+ * @example
+ * ```typescript
+ * import { agentWorkflow } from '@blecsd/ai';
+ *
+ * const wf = agentWorkflow.createAgentWorkflow(world, { width: 80, height: 30 });
+ * agentWorkflow.addWorkflowStep({ id: '1', label: 'Plan', status: 'complete', parentId: null });
+ * const stats = agentWorkflow.getWorkflowStats();
+ * ```
+ */
+
+import {
+	addWorkflowStep,
+	createAgentWorkflow,
+	createWorkflowState,
+	formatDuration,
+	formatWorkflowDisplay,
+	getStepChildren,
+	getStepDepth,
+	getStepDuration,
+	getVisibleSteps,
+	getWorkflowStats,
+	isAgentWorkflow,
+	resetWorkflowStore,
+	toggleWorkflowCollapse,
+	updateWorkflowStep,
+	workflowStore,
+} from '../widgets/agentWorkflow';
+
+export const agentWorkflow = Object.freeze({
+	createAgentWorkflow,
+	isAgentWorkflow,
+	createWorkflowState,
+	addWorkflowStep,
+	updateWorkflowStep,
+	toggleWorkflowCollapse,
+	getVisibleSteps,
+	getStepChildren,
+	getStepDepth,
+	getStepDuration,
+	getWorkflowStats,
+	formatWorkflowDisplay,
+	formatDuration,
+	workflowStore,
+	resetWorkflowStore,
+});
+
+export type AgentWorkflowModule = typeof agentWorkflow;

--- a/packages/ai/src/namespaces/conversation.ts
+++ b/packages/ai/src/namespaces/conversation.ts
@@ -1,0 +1,48 @@
+/**
+ * Conversation namespace for rendering conversation threads.
+ *
+ * @example
+ * ```typescript
+ * import { conversation } from '@blecsd/ai';
+ *
+ * const conv = conversation.createConversation(world, { width: 80, height: 30 });
+ * conversation.addMessage({ role: 'user', content: 'Hello!' });
+ * conversation.startStreamingMessage({ role: 'assistant', content: '' });
+ * conversation.appendToMessage(msgId, 'Hi there!');
+ * conversation.endStreamingMessage(msgId);
+ * ```
+ */
+
+import {
+	addMessage,
+	appendToMessage,
+	collapseMessage,
+	createConversation,
+	createConversationState,
+	endStreamingMessage,
+	expandMessage,
+	formatConversationDisplay,
+	getVisibleMessages,
+	isConversation,
+	resetConversationStore,
+	searchMessages,
+	startStreamingMessage,
+} from '../widgets/conversation';
+
+export const conversation = Object.freeze({
+	createConversation,
+	isConversation,
+	createConversationState,
+	addMessage,
+	startStreamingMessage,
+	appendToMessage,
+	endStreamingMessage,
+	collapseMessage,
+	expandMessage,
+	getVisibleMessages,
+	searchMessages,
+	formatConversationDisplay,
+	resetConversationStore,
+});
+
+export type ConversationModule = typeof conversation;

--- a/packages/ai/src/namespaces/index.ts
+++ b/packages/ai/src/namespaces/index.ts
@@ -1,0 +1,16 @@
+/**
+ * AI widget namespaces for @blecsd/ai package.
+ *
+ * @module namespaces
+ */
+
+export type { AgentWorkflowModule } from './agentWorkflow';
+export { agentWorkflow } from './agentWorkflow';
+export type { ConversationModule } from './conversation';
+export { conversation } from './conversation';
+export type { StreamingMarkdownModule } from './streamingMarkdown';
+export { streamingMarkdown } from './streamingMarkdown';
+export type { TokenTrackerModule } from './tokenTracker';
+export { tokenTracker } from './tokenTracker';
+export type { ToolUseModule } from './toolUse';
+export { toolUse } from './toolUse';

--- a/packages/ai/src/namespaces/streamingMarkdown.ts
+++ b/packages/ai/src/namespaces/streamingMarkdown.ts
@@ -1,0 +1,51 @@
+/**
+ * Streaming markdown namespace for rendering incrementally arriving markdown.
+ *
+ * @example
+ * ```typescript
+ * import { streamingMarkdown } from '@blecsd/ai';
+ *
+ * const md = streamingMarkdown.createStreamingMarkdown(world, { width: 80, height: 30 });
+ * streamingMarkdown.appendMarkdown(eid, '# Hello\n');
+ * streamingMarkdown.appendMarkdown(eid, 'This is **markdown**.\n');
+ * streamingMarkdown.scrollMarkdownByLines(eid, -5);
+ * ```
+ */
+
+import {
+	appendMarkdown,
+	clearMarkdownState,
+	createStreamingMarkdown,
+	createStreamingMarkdownState,
+	formatInline,
+	getMarkdownVisibleLines,
+	isStreamingMarkdown,
+	parseStreamingBlocks,
+	renderAllBlocks,
+	renderBlock,
+	resetStreamingMarkdownStore,
+	scrollMarkdownByLines,
+	scrollMarkdownToLine,
+	streamingMarkdownStateStore,
+	wrapText,
+} from '../widgets/streamingMarkdown';
+
+export const streamingMarkdown = Object.freeze({
+	createStreamingMarkdown,
+	isStreamingMarkdown,
+	createStreamingMarkdownState,
+	appendMarkdown,
+	clearMarkdownState,
+	getMarkdownVisibleLines,
+	scrollMarkdownByLines,
+	scrollMarkdownToLine,
+	parseStreamingBlocks,
+	renderBlock,
+	renderAllBlocks,
+	formatInline,
+	wrapText,
+	streamingMarkdownStateStore,
+	resetStreamingMarkdownStore,
+});
+
+export type StreamingMarkdownModule = typeof streamingMarkdown;

--- a/packages/ai/src/namespaces/tokenTracker.ts
+++ b/packages/ai/src/namespaces/tokenTracker.ts
@@ -1,0 +1,39 @@
+/**
+ * Token tracker namespace for tracking LLM token usage.
+ *
+ * @example
+ * ```typescript
+ * import { tokenTracker } from '@blecsd/ai';
+ *
+ * const tracker = tokenTracker.createTokenTracker(world, { width: 40, height: 10 });
+ * tokenTracker.recordTokens(eid, { inputTokens: 100, outputTokens: 200 });
+ * const stats = tokenTracker.getTokenStats(eid);
+ * const display = tokenTracker.formatTokenDisplay(stats, config);
+ * ```
+ */
+
+import {
+	createTokenState,
+	createTokenTracker,
+	formatTokenDisplay,
+	getTokenStats,
+	isTokenTracker,
+	recordTokens,
+	resetTokenState,
+	resetTokenTrackerStore,
+	tokenTrackerStateMap,
+} from '../widgets/tokenTracker';
+
+export const tokenTracker = Object.freeze({
+	createTokenTracker,
+	isTokenTracker,
+	createTokenState,
+	recordTokens,
+	resetTokenState,
+	getTokenStats,
+	formatTokenDisplay,
+	tokenTrackerStateMap,
+	resetTokenTrackerStore,
+});
+
+export type TokenTrackerModule = typeof tokenTracker;

--- a/packages/ai/src/namespaces/toolUse.ts
+++ b/packages/ai/src/namespaces/toolUse.ts
@@ -1,0 +1,46 @@
+/**
+ * Tool use namespace for visualizing AI agent tool calls.
+ *
+ * @example
+ * ```typescript
+ * import { toolUse } from '@blecsd/ai';
+ *
+ * const tu = toolUse.createToolUse(world, { width: 80, height: 30 });
+ * toolUse.addToolCall({ toolName: 'search', params: { query: 'AI' } });
+ * toolUse.updateToolCallStatus(callId, 'running');
+ * toolUse.setToolCallError(callId, 'Connection timeout');
+ * const timeline = toolUse.getToolCallTimeline();
+ * ```
+ */
+
+import {
+	addToolCall,
+	createToolUse,
+	createToolUseState,
+	formatToolCallDisplay,
+	getToolCallDuration,
+	getToolCallTimeline,
+	isToolUse,
+	resetToolUseStore,
+	setToolCallError,
+	toggleToolCallExpand,
+	toolUseStateMap,
+	updateToolCallStatus,
+} from '../widgets/toolUse';
+
+export const toolUse = Object.freeze({
+	createToolUse,
+	isToolUse,
+	createToolUseState,
+	addToolCall,
+	updateToolCallStatus,
+	setToolCallError,
+	toggleToolCallExpand,
+	getToolCallDuration,
+	getToolCallTimeline,
+	formatToolCallDisplay,
+	toolUseStateMap,
+	resetToolUseStore,
+});
+
+export type ToolUseModule = typeof toolUse;

--- a/packages/media/src/index.ts
+++ b/packages/media/src/index.ts
@@ -9,6 +9,8 @@
 
 // GIF parser with LZW decompression
 export * from './gif';
+// Namespace objects for API discoverability
+export * from './namespaces';
 // W3M overlay support
 export * from './overlay';
 // PNG parser with filters and pixel handling

--- a/packages/media/src/namespaces/ansiRender.ts
+++ b/packages/media/src/namespaces/ansiRender.ts
@@ -1,0 +1,34 @@
+/**
+ * ANSI rendering namespace for converting bitmaps to terminal output.
+ *
+ * @example
+ * ```typescript
+ * import { ansiRender } from '@blecsd/media';
+ *
+ * const bitmap = { width: 100, height: 50, data: new Uint8Array(...) };
+ * const cellMap = ansiRender.renderToAnsi(bitmap, { mode: '256-color' });
+ * const output = ansiRender.cellMapToString(cellMap);
+ * ```
+ */
+
+import {
+	blendWithBackground,
+	cellMapToString,
+	luminanceToChar,
+	renderToAnsi,
+	rgbLuminance,
+	rgbTo256Color,
+	scaleBitmap,
+} from '../render';
+
+export const ansiRender = Object.freeze({
+	renderToAnsi,
+	cellMapToString,
+	scaleBitmap,
+	rgbTo256Color,
+	rgbLuminance,
+	luminanceToChar,
+	blendWithBackground,
+});
+
+export type AnsiRenderModule = typeof ansiRender;

--- a/packages/media/src/namespaces/gif.ts
+++ b/packages/media/src/namespaces/gif.ts
@@ -1,0 +1,61 @@
+/**
+ * GIF parsing namespace for reading GIF images.
+ *
+ * @example
+ * ```typescript
+ * import { gif } from '@blecsd/media';
+ *
+ * const result = gif.parse.parseGIF(buffer);
+ * if (result.success) {
+ *   const rgba = gif.frame.frameToRGBA(result.data.frames[0]);
+ * }
+ * ```
+ */
+
+import {
+	createBitReader,
+	DisposalMethod,
+	decompressLZW,
+	deinterlace,
+	frameToRGBA,
+	GIF87A_MAGIC,
+	GIF89A_MAGIC,
+	GIFHeaderSchema,
+	parseColorTable,
+	parseGIF,
+	parseGIFHeader,
+	readCode,
+	readSubBlocks,
+	validateGIFSignature,
+} from '../gif';
+
+const parse = Object.freeze({
+	parseGIF,
+	parseGIFHeader,
+	validateGIFSignature,
+	parseColorTable,
+	readSubBlocks,
+	GIF87A_MAGIC,
+	GIF89A_MAGIC,
+	GIFHeaderSchema,
+});
+
+const lzw = Object.freeze({
+	decompressLZW,
+	createBitReader,
+	readCode,
+});
+
+const frame = Object.freeze({
+	frameToRGBA,
+	deinterlace,
+	DisposalMethod,
+});
+
+export const gif = Object.freeze({
+	parse,
+	lzw,
+	frame,
+});
+
+export type GifModule = typeof gif;

--- a/packages/media/src/namespaces/imageWidget.ts
+++ b/packages/media/src/namespaces/imageWidget.ts
@@ -1,0 +1,41 @@
+/**
+ * Image widget namespace for rendering bitmap images in the terminal.
+ *
+ * @example
+ * ```typescript
+ * import { imageWidget } from '@blecsd/media';
+ *
+ * const img = imageWidget.createImage(world, {
+ *   width: 80,
+ *   height: 30,
+ *   source: 'path/to/image.png',
+ *   mode: '256-color',
+ * });
+ * const bitmap = imageWidget.getImageBitmap(img);
+ * imageWidget.clearImageCache(img);
+ * ```
+ */
+
+import {
+	calculateAspectRatioDimensions,
+	clearAllImageCaches,
+	clearImageCache,
+	createImage,
+	getImageBitmap,
+	getImageCellMap,
+	isImage,
+	resetImageStore,
+} from '../widgets/image';
+
+export const imageWidget = Object.freeze({
+	createImage,
+	isImage,
+	getImageBitmap,
+	getImageCellMap,
+	calculateAspectRatioDimensions,
+	clearImageCache,
+	clearAllImageCaches,
+	resetImageStore,
+});
+
+export type ImageWidgetModule = typeof imageWidget;

--- a/packages/media/src/namespaces/index.ts
+++ b/packages/media/src/namespaces/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Media namespaces for @blecsd/media package.
+ *
+ * @module namespaces
+ */
+
+export type { AnsiRenderModule } from './ansiRender';
+export { ansiRender } from './ansiRender';
+export type { GifModule } from './gif';
+export { gif } from './gif';
+export type { ImageWidgetModule } from './imageWidget';
+export { imageWidget } from './imageWidget';
+export type { PngModule } from './png';
+export { png } from './png';
+export type { VideoWidgetModule } from './videoWidget';
+export { videoWidget } from './videoWidget';
+export type { W3mModule } from './w3m';
+export { w3m } from './w3m';

--- a/packages/media/src/namespaces/png.ts
+++ b/packages/media/src/namespaces/png.ts
@@ -1,0 +1,69 @@
+/**
+ * PNG parsing namespace for reading PNG images.
+ *
+ * @example
+ * ```typescript
+ * import { png } from '@blecsd/media';
+ *
+ * const result = png.parse.parsePNG(buffer);
+ * if (result.success) {
+ *   const pixels = png.pixels.extractPixels(result.data);
+ * }
+ * ```
+ */
+
+import {
+	bytesPerPixel,
+	ColorType,
+	decompressIDAT,
+	extractPixels,
+	FilterType,
+	PNG_MAGIC,
+	PNGChunkSchema,
+	PNGHeaderSchema,
+	paethPredictor,
+	parseChunks,
+	parseIHDR,
+	parsePLTE,
+	parsePNG,
+	parseTRNS,
+	reconstructFilters,
+	scanlineBytes,
+	validateCRC,
+	validateMagicBytes,
+} from '../png';
+
+const parse = Object.freeze({
+	parsePNG,
+	parseChunks,
+	parseIHDR,
+	decompressIDAT,
+	validateMagicBytes,
+	validateCRC,
+	PNG_MAGIC,
+	PNGHeaderSchema,
+	PNGChunkSchema,
+	ColorType,
+});
+
+const filters = Object.freeze({
+	reconstructFilters,
+	paethPredictor,
+	bytesPerPixel,
+	scanlineBytes,
+	FilterType,
+});
+
+const pixels = Object.freeze({
+	extractPixels,
+	parsePLTE,
+	parseTRNS,
+});
+
+export const png = Object.freeze({
+	parse,
+	filters,
+	pixels,
+});
+
+export type PngModule = typeof png;

--- a/packages/media/src/namespaces/videoWidget.ts
+++ b/packages/media/src/namespaces/videoWidget.ts
@@ -1,0 +1,52 @@
+/**
+ * Video widget namespace for playing video files in the terminal.
+ *
+ * @example
+ * ```typescript
+ * import { videoWidget } from '@blecsd/media';
+ *
+ * const vid = videoWidget.createVideo(world, {
+ *   width: 80,
+ *   height: 30,
+ *   source: 'path/to/video.mp4',
+ *   player: 'mpv',
+ * });
+ * videoWidget.sendPauseCommand(vid);
+ * videoWidget.sendSeekCommand(vid, 30);
+ * const state = videoWidget.getVideoPlaybackState(vid);
+ * ```
+ */
+
+import {
+	buildMplayerArgs,
+	buildMpvArgs,
+	buildPlayerArgs,
+	createVideo,
+	detectVideoPlayer,
+	getVideoPlaybackState,
+	getVideoPlayer,
+	isVideo,
+	MPLAYER_SEARCH_PATHS,
+	MPV_SEARCH_PATHS,
+	resetVideoStore,
+	sendPauseCommand,
+	sendSeekCommand,
+} from '../widgets/video';
+
+export const videoWidget = Object.freeze({
+	createVideo,
+	isVideo,
+	getVideoPlaybackState,
+	getVideoPlayer,
+	detectVideoPlayer,
+	buildMpvArgs,
+	buildMplayerArgs,
+	buildPlayerArgs,
+	sendPauseCommand,
+	sendSeekCommand,
+	MPV_SEARCH_PATHS,
+	MPLAYER_SEARCH_PATHS,
+	resetVideoStore,
+});
+
+export type VideoWidgetModule = typeof videoWidget;

--- a/packages/media/src/namespaces/w3m.ts
+++ b/packages/media/src/namespaces/w3m.ts
@@ -1,0 +1,71 @@
+/**
+ * W3M image overlay namespace for external image protocol support.
+ *
+ * @example
+ * ```typescript
+ * import { w3m } from '@blecsd/media';
+ *
+ * const state = w3m.createW3MState();
+ * const drawCmd = w3m.commands.formatDrawCommand({ x: 0, y: 0, path: 'image.png' });
+ * const clearCmd = w3m.commands.formatClearCommand();
+ * const size = w3m.sizing.maxDisplaySize({ width: 100, height: 50 });
+ * ```
+ */
+
+import {
+	buildClearSequence,
+	buildDrawSequence,
+	cellToPixels,
+	createW3MState,
+	DEFAULT_CELL_HEIGHT,
+	DEFAULT_CELL_WIDTH,
+	drawConfigFromCells,
+	findW3MBinary,
+	formatClearCommand,
+	formatDrawCommand,
+	formatGetSizeCommand,
+	formatNopCommand,
+	formatRedrawCommand,
+	formatSyncCommand,
+	formatTerminateCommand,
+	maxDisplaySize,
+	parseSizeResponse,
+	pixelsToCells,
+	scaleToFit,
+	W3M_SEARCH_PATHS,
+	W3MCommand,
+} from '../overlay';
+
+const commands = Object.freeze({
+	formatDrawCommand,
+	formatClearCommand,
+	formatGetSizeCommand,
+	formatRedrawCommand,
+	formatSyncCommand,
+	formatNopCommand,
+	formatTerminateCommand,
+	buildDrawSequence,
+	buildClearSequence,
+	parseSizeResponse,
+	W3MCommand,
+});
+
+const sizing = Object.freeze({
+	cellToPixels,
+	pixelsToCells,
+	maxDisplaySize,
+	scaleToFit,
+	drawConfigFromCells,
+	DEFAULT_CELL_WIDTH,
+	DEFAULT_CELL_HEIGHT,
+});
+
+export const w3m = Object.freeze({
+	createW3MState,
+	findW3MBinary,
+	commands,
+	sizing,
+	W3M_SEARCH_PATHS,
+});
+
+export type W3mModule = typeof w3m;


### PR DESCRIPTION
## Summary
- Add 5 namespace objects to @blecsd/ai (agentWorkflow, conversation, streamingMarkdown, tokenTracker, toolUse)
- Add 6 namespace objects to @blecsd/media (gif, png, ansiRender, w3m, imageWidget, videoWidget)
- Follows same Object.freeze pattern as main blecsd package
- Some media namespaces use sub-namespaces (gif.parse/lzw/frame, w3m.commands/sizing)
- No API changes to existing flat exports

Partially addresses #1237

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] Build passes