### PR TITLE
docs: add namespace and subpath import sections to addon READMEs

### DIFF
--- a/packages/3d/README.md
+++ b/packages/3d/README.md
@@ -53,6 +53,73 @@ const viewport = new Viewport3D(world, {
 viewport.render();
 ```
 
+## Namespace Imports
+
+The @blecsd/3d package provides namespace objects that group related functions for API discoverability. These frozen objects make it easy to explore available functions via IDE autocomplete:
+
+```typescript
+import { vec3, mat4, projection } from '@blecsd/3d';
+
+// Vector operations
+const v1 = vec3.create(1, 0, 0);
+const v2 = vec3.create(0, 1, 0);
+const sum = vec3.add(v1, v2);
+const normalized = vec3.normalize(sum);
+
+// Matrix operations
+const m = mat4.identity();
+const translated = mat4.translate(m, 0, 0, -5);
+const rotated = mat4.rotateY(translated, Math.PI / 4);
+
+// Projection matrices
+const proj = projection.perspective({ fov: Math.PI / 3, aspect: 16/9, near: 0.1, far: 100 });
+const view = projection.lookAt(vec3.create(0, 0, 5), vec3.create(0, 0, 0), vec3.create(0, 1, 0));
+```
+
+### Available Namespaces
+
+| Namespace | Purpose | Key Methods |
+|-----------|---------|-------------|
+| `vec3` | 3D vector operations | `create`, `add`, `sub`, `scale`, `dot`, `cross`, `normalize`, `length`, `distance` |
+| `mat4` | 4x4 matrix operations | `identity`, `multiply`, `translate`, `rotateX`, `rotateY`, `rotateZ`, `scale`, `invert` |
+| `projection` | Camera and projection matrices | `perspective`, `orthographic`, `lookAt`, `viewportTransform`, `projectVertex`, `buildMVP` |
+| `clipping` | Frustum culling and line clipping | `extractFrustumPlanes`, `isPointInFrustum`, `isSphereInFrustum`, `clipLine` |
+| `pixelBuffer` | Pixel framebuffer operations | `create`, `clear`, `setPixel`, `getPixel`, `fill`, `blit` |
+| `raster` | Rasterization functions | `drawLine`, `drawTriangle`, `fillTriangle`, `scanline` |
+| `transform3d` | 3D transform component helpers | `create`, `setPosition`, `setRotation`, `setScale`, `getMatrix` |
+| `camera3d` | Camera component helpers | `create`, `setFOV`, `setNearFar`, `getProjection`, `getView` |
+| `mesh` | Mesh component helpers | `create`, `setVertices`, `setIndices`, `getBounds` |
+| `backends` | Rendering backend management | `createBraille`, `createHalfblock`, `createSextant`, `createSixel`, `createKitty` |
+
+## Subpath Imports
+
+For tree-shakeable imports, use subpath exports to import only the functions you need:
+
+```typescript
+// Import specific math functions
+import { vec3Add, vec3Cross, vec3Normalize } from '@blecsd/3d/math';
+
+// Import specific backends
+import { BrailleBackend, SixelBackend } from '@blecsd/3d/backends';
+
+// Import components
+import { Transform3D, Camera3D, Mesh } from '@blecsd/3d/components';
+
+// Import loaders
+import { loadObjFile } from '@blecsd/3d/loaders';
+```
+
+Available subpath exports:
+- `@blecsd/3d/math` - Math utilities and primitives
+- `@blecsd/3d/backends` - Rendering backends
+- `@blecsd/3d/components` - ECS components
+- `@blecsd/3d/loaders` - Model loaders
+- `@blecsd/3d/rasterizer` - Rasterization functions
+- `@blecsd/3d/systems` - ECS systems
+- `@blecsd/3d/widgets` - Viewport widget
+- `@blecsd/3d/schemas` - Zod schemas
+- `@blecsd/3d/stores` - State stores
+
 ## API
 
 ### Backends

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -55,6 +55,41 @@ const tracker = createTokenTracker(world, {
 });
 ```
 
+## Namespace Imports
+
+The @blecsd/ai package provides namespace objects that group related functions for each widget type. These frozen objects make it easy to explore available functions via IDE autocomplete:
+
+```typescript
+import { conversation, streamingMarkdown, tokenTracker } from '@blecsd/ai';
+
+// Conversation operations
+const conv = conversation.createConversation(world, { width: 80, height: 30 });
+conversation.addMessage(eid, { role: 'user', content: 'Hello!' });
+conversation.startStreamingMessage(eid, { role: 'assistant', content: '' });
+conversation.appendToMessage(eid, msgId, 'Hi there!');
+
+// Streaming markdown operations
+const md = streamingMarkdown.createStreamingMarkdown(world, { width: 80, height: 30 });
+streamingMarkdown.appendMarkdown(eid, '## Response\n\n');
+streamingMarkdown.appendMarkdown(eid, 'This is **bold** text.\n');
+streamingMarkdown.scrollMarkdownByLines(eid, -5);
+
+// Token tracking operations
+const tracker = tokenTracker.createTokenTracker(world, { width: 40, height: 10 });
+tokenTracker.recordTokens(eid, { inputTokens: 100, outputTokens: 200 });
+const stats = tokenTracker.getTokenStats(eid);
+```
+
+### Available Namespaces
+
+| Namespace | Purpose | Key Methods |
+|-----------|---------|-------------|
+| `conversation` | Chat-style conversation threads | `createConversation`, `addMessage`, `startStreamingMessage`, `appendToMessage`, `endStreamingMessage`, `collapseMessage`, `expandMessage`, `searchMessages` |
+| `streamingMarkdown` | Real-time markdown rendering | `createStreamingMarkdown`, `appendMarkdown`, `clearMarkdownState`, `scrollMarkdownByLines`, `scrollMarkdownToLine`, `renderBlock`, `renderAllBlocks` |
+| `tokenTracker` | LLM token usage tracking | `createTokenTracker`, `recordTokens`, `resetTokenState`, `getTokenStats`, `formatTokenDisplay` |
+| `toolUse` | Tool/function call visualization | `createToolUse`, `recordToolCall`, `updateToolResult`, `formatToolDisplay` |
+| `agentWorkflow` | Multi-step agent workflow | `createAgentWorkflow`, `addTask`, `updateTaskStatus`, `getWorkflowProgress`, `formatWorkflowDisplay` |
+
 ## API
 
 ### Widgets

--- a/packages/audio/README.md
+++ b/packages/audio/README.md
@@ -44,6 +44,23 @@ audio.stop('theme');
 audio.dispose();
 ```
 
+## API Style
+
+The @blecsd/audio package uses a direct API without namespace objects. The `AudioManager` returned by `createAudioManager()` provides all methods directly:
+
+```typescript
+import { createAudioManager, AudioChannel } from '@blecsd/audio';
+
+const audio = createAudioManager({ ... });
+
+// All methods are on the manager instance
+audio.load('sound', 'path.mp3', AudioChannel.SFX);
+audio.play('sound', { loop: true });
+audio.setChannelVolume(AudioChannel.MUSIC, 0.5);
+```
+
+This design keeps the audio API simple and focused, since the API surface is intentionally small. The package exports `AudioChannel` as an enum for channel categorization.
+
 ## API
 
 ### Core Functions

--- a/packages/game/README.md
+++ b/packages/game/README.md
@@ -56,6 +56,34 @@ game.onUpdate((dt) => {
 game.start();
 ```
 
+## API Style
+
+The @blecsd/game package uses a direct API without namespace objects. The `Game` interface returned by `createGame()` provides all methods directly:
+
+```typescript
+import { createGame } from '@blecsd/game';
+
+const game = createGame(config);
+
+// All methods are on the game instance
+game.createBox({ ... });
+game.createText({ ... });
+game.onKey('space', handler);
+game.onUpdate(updateFn);
+game.start();
+```
+
+This design keeps the game creation API simple and focused, since the API surface is intentionally small and user-facing. For advanced ECS operations, you can access the underlying world:
+
+```typescript
+import { addComponent, Position } from 'blecsd';
+
+// Access the underlying ECS world
+const entity = game.createBox({ x: 10, y: 5 });
+addComponent(game.world, entity, Position);
+Position.x[entity] = 20;
+```
+
 ## API
 
 ### Game Creation

--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -54,6 +54,82 @@ const cells = renderToANSI(png, {
 });
 ```
 
+## Namespace Imports
+
+The @blecsd/media package provides namespace objects that group related functions for media processing. These frozen objects make it easy to explore available functions via IDE autocomplete:
+
+```typescript
+import { gif, png, ansiRender, imageWidget, videoWidget } from '@blecsd/media';
+
+// GIF parsing with nested namespaces
+const gifResult = gif.parse.parseGIF(buffer);
+if (gifResult.success) {
+  const rgba = gif.frame.frameToRGBA(gifResult.data.frames[0]);
+  const decompressed = gif.lzw.decompressLZW(data, minCodeSize);
+}
+
+// PNG parsing with nested namespaces
+const pngResult = png.parse.parsePNG(buffer);
+if (pngResult.success) {
+  const pixels = png.pixels.extractPixels(pngResult.data);
+  const filtered = png.filters.reconstructFilters(scanlines);
+}
+
+// ANSI rendering
+const bitmap = { width: 100, height: 50, data: new Uint8Array(...) };
+const cellMap = ansiRender.renderToAnsi(bitmap, { mode: '256-color' });
+const output = ansiRender.cellMapToString(cellMap);
+
+// Image widget operations
+const img = imageWidget.create(world, { width: 40, height: 20, imageData: png });
+imageWidget.setFrame(eid, 0);
+imageWidget.play(eid);
+
+// Video widget operations
+const video = videoWidget.create(world, { width: 40, height: 20, frames });
+videoWidget.play(eid);
+videoWidget.setFPS(eid, 30);
+```
+
+### Available Namespaces
+
+| Namespace | Purpose | Key Methods |
+|-----------|---------|-------------|
+| `gif` | GIF image parsing | Nested: `parse` (parseGIF, validateGIFSignature), `lzw` (decompressLZW, createBitReader), `frame` (frameToRGBA, deinterlace) |
+| `png` | PNG image parsing | Nested: `parse` (parsePNG, parseChunks, parseIHDR), `filters` (reconstructFilters, paethPredictor), `pixels` (extractPixels, parsePLTE) |
+| `ansiRender` | Terminal rendering from bitmaps | `renderToAnsi`, `cellMapToString`, `scaleBitmap`, `rgbTo256Color`, `luminanceToChar` |
+| `imageWidget` | Image widget operations | `create`, `setImageData`, `setFrame`, `play`, `pause`, `stop` |
+| `videoWidget` | Video widget operations | `create`, `play`, `pause`, `stop`, `setFPS`, `seek` |
+| `w3m` | W3M overlay support | `createOverlay`, `showImage`, `hideImage`, `updatePosition` |
+
+## Subpath Imports
+
+For tree-shakeable imports, use subpath exports to import only the functions you need:
+
+```typescript
+// Import specific parsers
+import { parseGIF, frameToRGBA } from '@blecsd/media/gif';
+import { parsePNG, extractPixels } from '@blecsd/media/png';
+
+// Import rendering utilities
+import { renderToAnsi, cellMapToString } from '@blecsd/media/render';
+
+// Import widgets
+import { createImage } from '@blecsd/media/widgets/image';
+import { createVideo } from '@blecsd/media/widgets/video';
+
+// Import W3M overlay
+import { createW3MOverlay } from '@blecsd/media/overlay';
+```
+
+Available subpath exports:
+- `@blecsd/media/gif` - GIF parser and utilities
+- `@blecsd/media/png` - PNG parser and utilities
+- `@blecsd/media/render` - ANSI rendering functions
+- `@blecsd/media/widgets/image` - Image widget
+- `@blecsd/media/widgets/video` - Video widget
+- `@blecsd/media/overlay` - W3M overlay support
+
 ## API
 
 ### Image Parsers


### PR DESCRIPTION
## Summary
- Adds Namespace Imports section to @blecsd/3d, @blecsd/ai, and @blecsd/media READMEs
- Adds Subpath Imports section to @blecsd/3d and @blecsd/media READMEs  
- Adds namespace reference tables with available namespaces, purposes, and key methods
- Notes for @blecsd/game and @blecsd/audio about their direct API approach

Closes #1251

## Test plan
- [ ] Verify namespace references match actual exports
- [ ] Verify subpath import paths match package.json exports
- [ ] Visual review of README rendering