### PR TITLE
docs: add namespace import patterns to core guides

### DIFF
--- a/docs/getting-started/choosing-an-api.md
+++ b/docs/getting-started/choosing-an-api.md
@@ -283,8 +283,70 @@ Position.y[fileList] = 2;
 
 1. Read: [ECS API Getting Started](./ecs-api.md)
 2. Read: [Understanding ECS](../guides/understanding-ecs.md)
-3. Reference: [Entity Factories](../api/entities.md)
-4. Reference: [Components](../api/components.md)
+3. Read: [Export Patterns](../guides/export-patterns.md) - Learn about namespace imports
+4. Reference: [Entity Factories](../api/entities.md)
+5. Reference: [Components](../api/components.md)
+
+---
+
+## Import Patterns
+
+blECSd provides a three-tier export system:
+
+### Tier 1: Curated Essentials from `'blecsd'`
+
+The main `'blecsd'` package exports approximately 80 curated functions covering the most common use cases:
+
+```typescript
+import {
+  createWorld,
+  addEntity,
+  setPosition,
+  setDimensions,
+  createBoxEntity,
+} from 'blecsd';
+```
+
+This is the simplest approach and works well for small to medium applications.
+
+### Tier 2: Namespace Imports (Recommended for Larger Apps)
+
+For more complex applications, use namespace imports from subpaths:
+
+```typescript
+import { position, dimensions, content } from 'blecsd/components';
+import { animation, layout, render } from 'blecsd/systems';
+import { cursor, screen, graphics } from 'blecsd/terminal';
+import { colors, textWrap, unicode } from 'blecsd/utils';
+
+// Organized by domain
+position.set(world, eid, 10, 5);
+dimensions.set(world, eid, { width: 40, height: 10 });
+content.setText(world, eid, 'Hello!');
+```
+
+Namespace imports provide:
+- Clear organization by domain (components, systems, terminal, utils)
+- Reduced naming conflicts
+- Better code navigation and searchability
+- Full access to all module functions
+
+### Tier 3: Deep Imports (Internal Only)
+
+Deep imports from specific files are reserved for internal library use and advanced scenarios:
+
+```typescript
+// Not recommended for most users
+import { someInternalFunction } from 'blecsd/components/position';
+```
+
+### Recommendation
+
+- **Small apps**: Use Tier 1 flat imports from `'blecsd'`
+- **Medium to large apps**: Use Tier 2 namespace imports for organization
+- **Advanced/internal**: Use Tier 3 only when necessary
+
+See the [Export Patterns Guide](../guides/export-patterns.md) for complete details on the export system.
 
 ---
 

--- a/docs/getting-started/ecs-api.md
+++ b/docs/getting-started/ecs-api.md
@@ -552,6 +552,208 @@ const loop = createGameLoop(world, { targetFPS: 60 });
 loop.registerSystem(LoopPhase.POST_RENDER, cleanupSystem);
 ```
 
+## Namespace API
+
+As your application grows, you may want to organize imports using namespace objects. blECSd provides namespace imports from subpaths like `blecsd/components`, `blecsd/systems`, `blecsd/terminal`, and `blecsd/utils`.
+
+### Why Use Namespaces?
+
+Namespace imports help with:
+- Organizing related functions by domain
+- Reducing naming conflicts in larger codebases
+- Making code more maintainable and searchable
+- Creating clearer boundaries between different parts of your application
+
+### Component Namespaces
+
+Instead of importing many individual functions:
+
+```typescript
+import {
+  setPosition,
+  getPosition,
+  moveBy,
+  setDimensions,
+  getDimensions,
+  setContent,
+  getText,
+} from 'blecsd';
+```
+
+Use component namespaces:
+
+```typescript
+import { position, dimensions, content } from 'blecsd/components';
+
+// Position operations
+position.set(world, eid, 10, 5);
+const pos = position.get(world, eid);
+position.moveBy(world, eid, 2, 0);
+
+// Dimensions operations
+dimensions.set(world, eid, { width: 40, height: 10 });
+const size = dimensions.get(world, eid);
+
+// Content operations
+content.setText(world, eid, 'Hello, World!');
+const text = content.getText(world, eid);
+```
+
+### System Namespaces
+
+Systems can also be imported as namespaces:
+
+```typescript
+import { animation, layout, render, input } from 'blecsd/systems';
+import type { World } from 'blecsd';
+
+function gameLoop(world: World): void {
+  // Process input
+  input.processInput(world);
+
+  // Update animations
+  animation.updateAnimations(world);
+
+  // Calculate layout
+  layout.calculateLayout(world);
+
+  // Render to buffer
+  render.renderEntities(world);
+}
+```
+
+### Terminal Namespaces
+
+For low-level terminal operations:
+
+```typescript
+import { cursor, screen, graphics } from 'blecsd/terminal';
+
+// Cursor control
+cursor.hide();
+cursor.to(10, 5);
+process.stdout.write('Hello');
+cursor.show();
+
+// Screen management
+screen.clear();
+screen.alternateOn();
+// ... your app
+screen.alternateOff();
+
+// Graphics primitives
+graphics.drawLine(world, 0, 0, 40, 20, '─');
+graphics.fillRect(world, 5, 5, 30, 10, '█');
+```
+
+### Mixing Approaches
+
+You can mix flat imports and namespace imports freely:
+
+```typescript
+// Core ECS always from 'blecsd'
+import { createWorld, addEntity, query } from 'blecsd';
+
+// Namespaces for organization
+import { position, dimensions, scroll } from 'blecsd/components';
+import { animation, layout } from 'blecsd/systems';
+
+const world = createWorld();
+const eid = addEntity(world);
+
+// Use both styles
+position.set(world, eid, 10, 5);
+dimensions.set(world, eid, { width: 40, height: 10 });
+
+// Systems
+animation.updateAnimations(world);
+layout.calculateLayout(world);
+```
+
+### Complete Example with Namespaces
+
+```typescript
+import { createWorld, addEntity, createGameLoop, LoopPhase } from 'blecsd';
+import { position, dimensions, velocity } from 'blecsd/components';
+import { animation, layout, render } from 'blecsd/systems';
+import { cursor, screen } from 'blecsd/terminal';
+import type { World } from 'blecsd';
+
+// Create world
+const world = createWorld();
+
+// Create entities
+for (let i = 0; i < 10; i++) {
+  const particle = addEntity(world);
+
+  position.set(world, particle, Math.random() * 80, Math.random() * 24);
+  dimensions.set(world, particle, { width: 1, height: 1 });
+  velocity.set(world, particle, {
+    x: (Math.random() - 0.5) * 2,
+    y: (Math.random() - 0.5) * 2,
+  });
+}
+
+// Custom movement system using namespace functions
+function movementSystem(world: World): World {
+  // Get all entities with velocity (using has check)
+  const entities = [];
+  for (let eid = 0; eid < 10000; eid++) {
+    if (velocity.has(world, eid) && position.has(world, eid)) {
+      entities.push(eid);
+    }
+  }
+
+  for (const eid of entities) {
+    const pos = position.get(world, eid);
+    const vel = velocity.get(world, eid);
+
+    if (pos && vel) {
+      position.set(world, eid, pos.x + vel.x, pos.y + vel.y);
+    }
+  }
+
+  return world;
+}
+
+// Setup terminal
+screen.alternateOn();
+cursor.hide();
+
+// Create game loop
+const loop = createGameLoop(world, { targetFPS: 30 });
+
+loop.registerSystem(LoopPhase.UPDATE, movementSystem);
+loop.registerSystem(LoopPhase.ANIMATION, animation.updateAnimations);
+loop.registerSystem(LoopPhase.LAYOUT, layout.calculateLayout);
+loop.registerSystem(LoopPhase.RENDER, render.renderEntities);
+
+loop.start();
+
+// Cleanup on exit
+process.on('SIGINT', () => {
+  loop.stop();
+  cursor.show();
+  screen.alternateOff();
+  process.exit(0);
+});
+```
+
+Note: Namespace imports work best with helper functions like `set()`, `get()`, `has()`. For queries that need component objects, use the flat import style from `'blecsd'` or import component objects directly from their files.
+
+### Namespace Reference
+
+Available namespace subpaths:
+
+| Subpath | Contains |
+|---------|----------|
+| `blecsd/components` | Component namespaces (position, dimensions, content, border, scroll, focus, etc.) |
+| `blecsd/systems` | System namespaces (animation, layout, render, input, output, collision, etc.) |
+| `blecsd/terminal` | Terminal namespaces (cursor, screen, graphics, program, etc.) |
+| `blecsd/utils` | Utility namespaces (colors, textWrap, unicode, rope, etc.) |
+
+See the [Export Patterns Guide](../guides/export-patterns.md) for more details on the three-tier export system.
+
 ## Summary
 
 The ECS API provides:

--- a/docs/getting-started/hello-world.md
+++ b/docs/getting-started/hello-world.md
@@ -53,6 +53,53 @@ console.log(`Box at ${pos?.x}, ${pos?.y}`);
 console.log(`Content: ${content}`);
 ```
 
+## Alternative: Namespace Imports
+
+For larger applications, you can use namespace imports from `blecsd/components` to organize your code:
+
+```typescript
+import { createWorld, addEntity } from 'blecsd';
+import { position, dimensions, content, border, renderable } from 'blecsd/components';
+import { BorderType } from 'blecsd';
+
+// Create world and entity
+const world = createWorld();
+const box = addEntity(world);
+
+// Position at 5, 3
+position.set(world, box, 5, 3);
+
+// Size 30x5
+dimensions.set(world, box, { width: 30, height: 5 });
+
+// White text on blue background
+renderable.setStyle(world, box, {
+  fg: '#ffffff',
+  bg: '#0066cc',
+});
+
+// Line border on all sides
+border.set(world, box, {
+  type: BorderType.Line,
+  left: true,
+  right: true,
+  top: true,
+  bottom: true,
+});
+
+// Text content
+content.setText(world, box, 'Hello, Terminal!');
+
+// Read back the data
+const pos = position.get(world, box);
+const text = content.getText(world, box);
+
+console.log(`Box at ${pos?.x}, ${pos?.y}`);
+console.log(`Content: ${text}`);
+```
+
+Namespace imports help organize related functions and reduce naming conflicts as your application grows.
+
 ## What Happened
 
 1. **createWorld()** initializes a bitECS world

--- a/docs/guides/cheat-sheet.md
+++ b/docs/guides/cheat-sheet.md
@@ -18,6 +18,8 @@ removeEntity(world, eid);                  // Destroy entity
 entityExists(world, eid);                  // Check if entity exists
 ```
 
+**Note:** Core ECS functions like `createWorld`, `addEntity`, `removeEntity` are always imported from `'blecsd'`. Namespace imports are for components, systems, terminal, and utilities.
+
 ---
 
 ## Widgets
@@ -91,6 +93,22 @@ setDimensions(world, eid, 30, 10);         // Set width, height
 const { width, height } = getDimensions(world, eid);
 ```
 
+**Using namespaces:**
+
+```typescript
+import { position, dimensions } from 'blecsd/components';
+
+// Position
+position.set(world, eid, 10, 5);           // Set x, y
+const { x, y } = position.get(world, eid); // Get position
+position.moveBy(world, eid, 5, 0);         // Move by offset
+position.zIndex.set(world, eid, 10);       // Set rendering order
+
+// Dimensions
+dimensions.set(world, eid, { width: 30, height: 10 });
+const { width, height } = dimensions.get(world, eid);
+```
+
 ### Style & Appearance
 
 ```typescript
@@ -114,6 +132,26 @@ setPadding(world, eid, { top: 1, left: 2, right: 2, bottom: 1 });
 setContent(world, eid, 'Hello!', TextAlign.Center);     // left, center, right
 ```
 
+**Using namespaces:**
+
+```typescript
+import { border, padding, content } from 'blecsd/components';
+
+// Borders
+border.set(world, eid, {
+  type: 'single',      // single, double, rounded, bold, ascii
+  color: 0x0000ff
+});
+
+// Padding
+padding.set(world, eid, { all: 1 });       // All sides
+padding.set(world, eid, { top: 1, left: 2, right: 2, bottom: 1 });
+
+// Content
+content.setText(world, eid, 'Hello!');
+content.setAlign(world, eid, TextAlign.Center);
+```
+
 ### Hierarchy
 
 ```typescript
@@ -128,6 +166,18 @@ appendChild(world, parent, child);         // Add child to parent
 removeChild(world, parent, child);         // Remove child
 const children = getChildren(world, parent); // Get all children
 const parentEid = getParent(world, child);    // Get parent
+```
+
+**Using namespaces:**
+
+```typescript
+import { hierarchy } from 'blecsd/components';
+
+// Parent-child relationships
+hierarchy.appendChild(world, parent, child);
+hierarchy.removeChild(world, parent, child);
+const children = hierarchy.getChildren(world, parent);
+const parentEid = hierarchy.getParent(world, child);
 ```
 
 ### Focus & Interaction
@@ -148,6 +198,19 @@ focusNext(world);                          // Tab to next
 focusPrev(world);                          // Shift+Tab to previous
 ```
 
+**Using namespaces:**
+
+```typescript
+import { focus } from 'blecsd/components';
+
+// Focus management
+focus.makeFocusable(world, eid);
+focus.focus(world, eid);
+const focused = focus.getFocused(world);
+focus.next(world);
+focus.prev(world);
+```
+
 ### Scrolling
 
 <!-- blecsd-doccheck:ignore -->
@@ -166,6 +229,19 @@ scrollBy(world, eid, 5);                   // Scroll by delta
 scrollToTop(world, eid);                   // Jump to top
 scrollToBottom(world, eid);                // Jump to bottom
 scrollToLine(world, eid, 2);               // Jump to line
+```
+
+**Using namespaces:**
+
+```typescript
+import { scroll } from 'blecsd/components';
+
+// Scrollable content
+scroll.set(world, eid, true);
+scroll.by(world, eid, 0, 5);
+scroll.toTop(world, eid);
+scroll.toBottom(world, eid);
+scroll.viewport.toLine(world, eid, 2);
 ```
 
 ---
@@ -412,6 +488,121 @@ screen.clear();                            // Clear screen
 screen.alternateBuffer();                  // Enter alternate buffer
 screen.restoreBuffer();                    // Restore main buffer
 ```
+
+---
+
+## Namespace Imports
+
+For larger applications, use namespace imports to organize related functions and avoid naming conflicts:
+
+### Component Namespaces
+
+```typescript
+import { position, dimensions, content, border, padding } from 'blecsd/components';
+import { scroll, focus, hierarchy, renderable } from 'blecsd/components';
+
+// Position operations
+position.set(world, eid, 10, 5);
+position.moveBy(world, eid, 2, 0);
+const pos = position.get(world, eid);
+
+// Dimensions operations
+dimensions.set(world, eid, { width: 40, height: 10 });
+const size = dimensions.get(world, eid);
+
+// Content operations
+content.setText(world, eid, 'Hello!');
+content.setAlign(world, eid, TextAlign.Center);
+const text = content.getText(world, eid);
+
+// Border and padding
+border.set(world, eid, { type: BorderType.Single });
+padding.set(world, eid, { all: 1 });
+
+// Scrolling
+scroll.by(world, eid, 0, 5);
+scroll.toTop(world, eid);
+
+// Focus management
+focus.makeFocusable(world, eid);
+focus.next(world);
+
+// Hierarchy
+hierarchy.appendChild(world, parent, child);
+const children = hierarchy.getChildren(world, parent);
+```
+
+### System Namespaces
+
+```typescript
+import { animation, layout, render } from 'blecsd/systems';
+import { input, output, collision, spring } from 'blecsd/systems';
+
+// Run systems manually
+input.processInput(world);
+animation.updateAnimations(world);
+layout.calculateLayout(world);
+render.renderEntities(world);
+output.flushOutput(world);
+
+// Collision detection
+collision.detectCollisions(world);
+const collisions = collision.getCollisions(world);
+
+// Spring physics
+spring.updateSprings(world, deltaTime);
+```
+
+### Terminal Namespaces
+
+```typescript
+import { cursor, screen, graphics } from 'blecsd/terminal';
+
+// Cursor operations
+cursor.hide();
+cursor.show();
+cursor.to(10, 5);
+
+// Screen management
+screen.clear();
+screen.alternateOn();
+screen.alternateOff();
+
+// Graphics drawing
+graphics.drawLine(world, x1, y1, x2, y2, char);
+graphics.fillRect(world, x, y, width, height, char);
+```
+
+### Utility Namespaces
+
+```typescript
+import { colors, textWrap, unicode } from 'blecsd/utils';
+
+// Color utilities
+const packed = colors.hexToColor('#ff0000');
+const hex = colors.colorToHex(packed);
+
+// Text wrapping
+const wrapped = textWrap.wrap('Long text...', 40);
+const lines = textWrap.wrapLines('Text', 40);
+
+// Unicode handling
+const width = unicode.stringWidth('Hello 世界');
+const truncated = unicode.truncate('Long string', 20);
+```
+
+### When to Use Namespaces
+
+Use flat imports from `'blecsd'` for:
+- Small scripts and prototypes
+- Simple applications with few imports
+- When you know exactly what you need
+
+Use namespace imports from `'blecsd/components'`, `'blecsd/systems'`, etc. for:
+- Larger applications with many components
+- When you want to organize imports by domain
+- To avoid naming conflicts
+- When building reusable modules
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds namespace import alternatives to hello-world.md
- Adds namespace quick reference sections to cheat-sheet.md
- Adds Namespace API section to ecs-api.md
- Updates choosing-an-api.md with namespace tier information

Closes #1252

## Test plan
- [ ] Verify namespace references match actual source files
- [ ] Verify import paths are correct
- [ ] Visual review of doc rendering