### PR TITLE
refactor: standardize widget factory signatures

### DIFF
--- a/src/widgets/box.ts
+++ b/src/widgets/box.ts
@@ -26,7 +26,7 @@ import { appendChild, getChildren } from '../components/hierarchy';
 import { setPadding } from '../components/padding';
 import { moveBy, setPosition } from '../components/position';
 import { markDirty, setStyle, setVisible } from '../components/renderable';
-import { removeEntity } from '../core/ecs';
+import { addEntity, removeEntity } from '../core/ecs';
 import type { Entity, World } from '../core/types';
 import { parseColor } from '../utils/color';
 
@@ -630,9 +630,9 @@ function setupContent(world: World, eid: Entity, config: ValidatedBoxConfig): vo
  * import { createBox } from 'blecsd/widgets';
  *
  * const world = createWorld();
- * const eid = addEntity(world);
  *
- * const box = createBox(world, eid, {
+ * // Pattern A: Self-creates entity
+ * const box1 = createBox(world, {
  *   left: 5,
  *   top: 5,
  *   width: 30,
@@ -642,19 +642,39 @@ function setupContent(world: World, eid: Entity, config: ValidatedBoxConfig): vo
  *   padding: 1,
  * });
  *
+ * // Pattern B: Use existing entity
+ * const eid = addEntity(world);
+ * const box2 = createBox(world, eid, {
+ *   left: 5,
+ *   top: 15,
+ *   width: 30,
+ *   height: 10,
+ *   content: 'Hello, World!',
+ *   border: { type: 'line' },
+ *   padding: 1,
+ * });
+ *
  * // Chain methods
- * box
+ * box1
  *   .setContent('Updated content')
  *   .focus()
  *   .show();
  *
  * // Clean up when done
- * box.destroy();
+ * box1.destroy();
  * ```
  */
-export function createBox(world: World, entity: Entity, config: BoxConfig = {}): BoxWidget {
+export function createBox(world: World, config: BoxConfig): BoxWidget;
+export function createBox(world: World, entity: Entity, config?: BoxConfig): BoxWidget;
+export function createBox(
+	world: World,
+	entityOrConfig: Entity | BoxConfig,
+	maybeConfig?: BoxConfig,
+): BoxWidget {
+	const isEntity = typeof entityOrConfig === 'number';
+	const eid = isEntity ? entityOrConfig : (addEntity(world) as Entity);
+	const config = isEntity ? (maybeConfig ?? {}) : entityOrConfig;
 	const validated = BoxConfigSchema.parse(config) as ValidatedBoxConfig;
-	const eid = entity;
 
 	// Mark as box
 	Box.isBox[eid] = 1;

--- a/src/widgets/flexbox/factory.ts
+++ b/src/widgets/flexbox/factory.ts
@@ -11,7 +11,7 @@ import { blur, focus, isFocused, setFocusable } from '../../components/focusable
 import { appendChild, getParent, NULL_ENTITY } from '../../components/hierarchy';
 import { moveBy, setPosition } from '../../components/position';
 import { markDirty, setStyle, setVisible } from '../../components/renderable';
-import { removeEntity } from '../../core/ecs';
+import { addEntity, removeEntity } from '../../core/ecs';
 import type { Entity, World } from '../../core/types';
 import { parseColor } from '../../utils/color';
 import {
@@ -40,7 +40,7 @@ import type {
  * Creates a Flexbox container widget for responsive layouts.
  *
  * @param world - The ECS world
- * @param entity - The entity to wrap
+ * @param entity - The entity to wrap (or creates a new one if not provided)
  * @param config - Container configuration
  * @returns The Flexbox container widget instance
  *
@@ -50,9 +50,9 @@ import type {
  * import { createFlexContainer, addFlexChild } from 'blecsd/widgets';
  *
  * const world = createWorld();
- * const containerEid = addEntity(world);
  *
- * const flex = createFlexContainer(world, containerEid, {
+ * // Pattern A: Self-creates entity
+ * const flex1 = createFlexContainer(world, {
  *   direction: 'row',
  *   justifyContent: 'space-between',
  *   alignItems: 'center',
@@ -62,24 +62,43 @@ import type {
  *   height: 24
  * });
  *
+ * // Pattern B: Use existing entity
+ * const containerEid = addEntity(world);
+ * const flex2 = createFlexContainer(world, containerEid, {
+ *   direction: 'column',
+ *   justifyContent: 'start',
+ *   alignItems: 'stretch',
+ *   gap: 1,
+ *   width: 80,
+ *   height: 24
+ * });
+ *
  * // Add children with flex options
  * const child1 = addEntity(world);
- * flex.addChild(child1, { flex: 1, flexBasis: 20 });
+ * flex1.addChild(child1, { flex: 1, flexBasis: 20 });
  *
  * const child2 = addEntity(world);
- * flex.addChild(child2, { flex: 2, alignSelf: 'end' });
+ * flex1.addChild(child2, { flex: 2, alignSelf: 'end' });
  *
  * // Apply layout
- * flex.layout();
+ * flex1.layout();
  * ```
  */
+export function createFlexContainer(world: World, config: FlexContainerConfig): FlexContainerWidget;
 export function createFlexContainer(
 	world: World,
 	entity: Entity,
-	config: FlexContainerConfig = {},
+	config?: FlexContainerConfig,
+): FlexContainerWidget;
+export function createFlexContainer(
+	world: World,
+	entityOrConfig: Entity | FlexContainerConfig,
+	maybeConfig?: FlexContainerConfig,
 ): FlexContainerWidget {
+	const isEntity = typeof entityOrConfig === 'number';
+	const eid = isEntity ? entityOrConfig : (addEntity(world) as Entity);
+	const config = isEntity ? (maybeConfig ?? {}) : entityOrConfig;
 	const validated = FlexContainerConfigSchema.parse(config) as ValidatedFlexContainerConfig;
-	const eid = entity;
 
 	// Mark as flex container
 	FlexContainer.isFlexContainer[eid] = 1;

--- a/src/widgets/layout/factory.ts
+++ b/src/widgets/layout/factory.ts
@@ -9,7 +9,7 @@ import { blur, focus, isFocused, setFocusable } from '../../components/focusable
 import { appendChild, getChildren } from '../../components/hierarchy';
 import { getPosition, moveBy, setPosition } from '../../components/position';
 import { markDirty, setStyle, setVisible } from '../../components/renderable';
-import { removeEntity } from '../../core/ecs';
+import { addEntity, removeEntity } from '../../core/ecs';
 import type { Entity, World } from '../../core/types';
 import { parseColor } from '../../utils/color';
 import { Layout } from './state';
@@ -396,13 +396,17 @@ export function calculateFlexLayout(
  * layout.recalculate();
  * ```
  */
+export function createLayout(world: World, config: LayoutConfig): LayoutWidget;
+export function createLayout(world: World, entity: Entity, config?: LayoutConfig): LayoutWidget;
 export function createLayout(
 	world: World,
-	entity: Entity,
-	config: LayoutConfig = {},
+	entityOrConfig: Entity | LayoutConfig,
+	maybeConfig?: LayoutConfig,
 ): LayoutWidget {
+	const isEntity = typeof entityOrConfig === 'number';
+	const eid = isEntity ? entityOrConfig : (addEntity(world) as Entity);
+	const config = isEntity ? (maybeConfig ?? {}) : entityOrConfig;
 	const validated = LayoutConfigSchema.parse(config) as ValidatedLayoutConfig;
-	const eid = entity;
 
 	// Set layout properties
 	const layoutMode = validated.layout ?? 'inline';

--- a/src/widgets/scrollableBox/factory.ts
+++ b/src/widgets/scrollableBox/factory.ts
@@ -12,7 +12,7 @@ import { appendChild, getChildren } from '../../components/hierarchy';
 import { moveBy, setPosition } from '../../components/position';
 import { markDirty, setVisible } from '../../components/renderable';
 import type { ScrollableData, ScrollPercentage, ScrollPosition } from '../../components/scrollable';
-import { removeEntity } from '../../core/ecs';
+import { addEntity, removeEntity } from '../../core/ecs';
 import type { Entity, World } from '../../core/types';
 import {
 	canScroll,
@@ -59,7 +59,7 @@ import type { ScrollableBoxConfig, ScrollableBoxWidget } from './types';
  * It combines Box functionality with scrollable content support.
  *
  * @param world - The ECS world
- * @param entity - The entity to wrap
+ * @param entity - The entity to wrap (or creates a new one if not provided)
  * @param config - Widget configuration
  * @returns The ScrollableBox widget instance
  *
@@ -69,9 +69,9 @@ import type { ScrollableBoxConfig, ScrollableBoxWidget } from './types';
  * import { createScrollableBox } from 'blecsd/widgets';
  *
  * const world = createWorld();
- * const eid = addEntity(world);
  *
- * const scrollBox = createScrollableBox(world, eid, {
+ * // Pattern A: Self-creates entity
+ * const scrollBox1 = createScrollableBox(world, {
  *   left: 5,
  *   top: 5,
  *   width: 40,
@@ -81,23 +81,43 @@ import type { ScrollableBoxConfig, ScrollableBoxWidget } from './types';
  *   scrollbar: true,
  * });
  *
+ * // Pattern B: Use existing entity
+ * const eid = addEntity(world);
+ * const scrollBox2 = createScrollableBox(world, eid, {
+ *   left: 5,
+ *   top: 15,
+ *   width: 40,
+ *   height: 10,
+ *   scrollHeight: 100,
+ *   border: { type: 'line' },
+ *   scrollbar: true,
+ * });
+ *
  * // Scroll down
- * scrollBox.scrollBy(0, 5);
+ * scrollBox1.scrollBy(0, 5);
  *
  * // Scroll to 50%
- * scrollBox.setScrollPerc(0, 50);
+ * scrollBox1.setScrollPerc(0, 50);
  *
  * // Jump to bottom
- * scrollBox.scrollToBottom();
+ * scrollBox1.scrollToBottom();
  * ```
  */
+export function createScrollableBox(world: World, config: ScrollableBoxConfig): ScrollableBoxWidget;
 export function createScrollableBox(
 	world: World,
 	entity: Entity,
-	config: ScrollableBoxConfig = {},
+	config?: ScrollableBoxConfig,
+): ScrollableBoxWidget;
+export function createScrollableBox(
+	world: World,
+	entityOrConfig: Entity | ScrollableBoxConfig,
+	maybeConfig?: ScrollableBoxConfig,
 ): ScrollableBoxWidget {
+	const isEntity = typeof entityOrConfig === 'number';
+	const eid = isEntity ? entityOrConfig : (addEntity(world) as Entity);
+	const config = isEntity ? (maybeConfig ?? {}) : entityOrConfig;
 	const validated = ScrollableBoxConfigSchema.parse(config) as ValidatedScrollableBoxConfig;
-	const eid = entity;
 
 	// Mark as scrollable box
 	ScrollableBox.isScrollableBox[eid] = 1;

--- a/src/widgets/splitPane/factory.ts
+++ b/src/widgets/splitPane/factory.ts
@@ -9,7 +9,7 @@ import { blur, focus, isFocused, setFocusable } from '../../components/focusable
 import { appendChild, getChildren } from '../../components/hierarchy';
 import { moveBy, setPosition } from '../../components/position';
 import { markDirty, setStyle, setVisible } from '../../components/renderable';
-import { removeEntity } from '../../core/ecs';
+import { addEntity, removeEntity } from '../../core/ecs';
 import type { Entity, World } from '../../core/types';
 import { SplitPaneConfigSchema } from './config';
 import {
@@ -97,7 +97,7 @@ function initSplitPaneComponents(
  * and vertical (top-bottom) splits.
  *
  * @param world - The ECS world
- * @param entity - The entity to wrap
+ * @param entity - The entity to wrap (or creates a new one if not provided)
  * @param config - Widget configuration
  * @returns The SplitPane widget instance
  *
@@ -107,10 +107,18 @@ function initSplitPaneComponents(
  * import { createSplitPane } from 'blecsd';
  *
  * const world = createWorld();
- * const eid = addEntity(world);
  *
- * // Two-pane horizontal split (like VS Code)
- * const split = createSplitPane(world, eid, {
+ * // Pattern A: Self-creates entity
+ * const split1 = createSplitPane(world, {
+ *   width: 120,
+ *   height: 40,
+ *   direction: 'horizontal',
+ *   ratios: [0.5, 0.5],
+ * });
+ *
+ * // Pattern B: Use existing entity
+ * const eid = addEntity(world);
+ * const split2 = createSplitPane(world, eid, {
  *   width: 120,
  *   height: 40,
  *   direction: 'horizontal',
@@ -120,20 +128,28 @@ function initSplitPaneComponents(
  * // Add pane content
  * const pane1 = addEntity(world);
  * const pane2 = addEntity(world);
- * split.append(pane1).append(pane2);
+ * split1.append(pane1).append(pane2);
  *
  * // Scroll panes independently
- * split.scrollPane(0, 0, 10);
- * split.scrollPane(1, 0, 20);
+ * split1.scrollPane(0, 0, 10);
+ * split1.scrollPane(1, 0, 20);
  * ```
  */
+export function createSplitPane(world: World, config: SplitPaneConfig): SplitPaneWidget;
 export function createSplitPane(
 	world: World,
 	entity: Entity,
-	config: SplitPaneConfig = {},
+	config?: SplitPaneConfig,
+): SplitPaneWidget;
+export function createSplitPane(
+	world: World,
+	entityOrConfig: Entity | SplitPaneConfig,
+	maybeConfig?: SplitPaneConfig,
 ): SplitPaneWidget {
+	const isEntity = typeof entityOrConfig === 'number';
+	const eid = isEntity ? entityOrConfig : (addEntity(world) as Entity);
+	const config = isEntity ? (maybeConfig ?? {}) : entityOrConfig;
 	const validated = SplitPaneConfigSchema.parse(config) as ValidatedSplitPaneConfig;
-	const eid = entity;
 
 	const direction: SplitDirection = validated.direction ?? 'horizontal';
 	const minPaneSize = validated.minPaneSize ?? 3;

--- a/src/widgets/tabs/factory.ts
+++ b/src/widgets/tabs/factory.ts
@@ -11,7 +11,7 @@ import { blur, focus, isFocused, setFocusable } from '../../components/focusable
 import { getChildren } from '../../components/hierarchy';
 import { moveBy, setPosition } from '../../components/position';
 import { markDirty, setVisible } from '../../components/renderable';
-import { removeEntity } from '../../core/ecs';
+import { addEntity, removeEntity } from '../../core/ecs';
 import type { Entity, World } from '../../core/types';
 import { TabsConfigSchema, type ValidatedTabsConfig } from './config';
 import {
@@ -38,7 +38,7 @@ import type { TabConfig, TabData, TabsAction, TabsConfig, TabsWidget } from './t
  * between multiple content panels.
  *
  * @param world - The ECS world
- * @param entity - The entity to wrap
+ * @param entity - The entity to wrap (or creates a new one if not provided)
  * @param config - Widget configuration
  * @returns The Tabs widget instance
  *
@@ -48,10 +48,9 @@ import type { TabConfig, TabData, TabsAction, TabsConfig, TabsWidget } from './t
  * import { createTabs } from 'blecsd/widgets';
  *
  * const world = createWorld();
- * const eid = addEntity(world);
  *
- * // Basic tabs
- * const tabs = createTabs(world, eid, {
+ * // Pattern A: Self-creates entity
+ * const tabs1 = createTabs(world, {
  *   left: 0,
  *   top: 0,
  *   width: 60,
@@ -63,14 +62,35 @@ import type { TabConfig, TabData, TabsAction, TabsConfig, TabsWidget } from './t
  *   ],
  * });
  *
+ * // Pattern B: Use existing entity
+ * const eid = addEntity(world);
+ * const tabs2 = createTabs(world, eid, {
+ *   left: 0,
+ *   top: 25,
+ *   width: 60,
+ *   height: 20,
+ *   tabs: [
+ *     { label: 'Tab 1' },
+ *     { label: 'Tab 2' },
+ *   ],
+ * });
+ *
  * // Navigate between tabs
- * tabs.nextTab();
- * tabs.setActiveTab(2);
+ * tabs1.nextTab();
+ * tabs1.setActiveTab(2);
  * ```
  */
-export function createTabs(world: World, entity: Entity, config: TabsConfig = {}): TabsWidget {
+export function createTabs(world: World, config: TabsConfig): TabsWidget;
+export function createTabs(world: World, entity: Entity, config?: TabsConfig): TabsWidget;
+export function createTabs(
+	world: World,
+	entityOrConfig: Entity | TabsConfig,
+	maybeConfig?: TabsConfig,
+): TabsWidget {
+	const isEntity = typeof entityOrConfig === 'number';
+	const eid = isEntity ? entityOrConfig : (addEntity(world) as Entity);
+	const config = isEntity ? (maybeConfig ?? {}) : entityOrConfig;
 	const validated = TabsConfigSchema.parse(config) as ValidatedTabsConfig;
-	const eid = entity;
 
 	// Mark as tabs and initialize data
 	Tabs.isTabs[eid] = 1;


### PR DESCRIPTION
Addresses issue #1279

## Changes

Adds function overloads to standardize widget factory signatures across all widgets:

### Pattern Support

All listed widgets now support both patterns:
- **Pattern A** (self-creates): `createWidget(world, config)`
- **Pattern B** (existing entity): `createWidget(world, entity, config)`

### Updated Widgets

- ✅ `createBox` (src/widgets/box.ts)
- ✅ `createScrollableBox` (src/widgets/scrollableBox/)
- ✅ `createTabs` (src/widgets/tabs/)
- ✅ `createSplitPane` (src/widgets/splitPane/)
- ✅ `createLayout` (src/widgets/layout/)
- ✅ `createFlexContainer` (src/widgets/flexbox/)

### Implementation

Each widget follows the same overload pattern used by Panel and Log:

```typescript
export function createWidget(world: World, config: WidgetConfig): Widget;
export function createWidget(world: World, entity: Entity, config?: WidgetConfig): Widget;
export function createWidget(
  world: World,
  entityOrConfig: Entity | WidgetConfig,
  maybeConfig?: WidgetConfig,
): Widget {
  const isEntity = typeof entityOrConfig === 'number';
  const eid = isEntity ? entityOrConfig : (addEntity(world) as Entity);
  const config = isEntity ? (maybeConfig ?? {}) : entityOrConfig;
  // ...rest unchanged
}
```

## Acceptance Criteria

- [x] All listed widgets accept both `(world, config)` and `(world, entity, config)`
- [x] Existing code using old signatures still works (backwards compatible)
- [x] TypeScript signature overloads properly defined
- [ ] All widget tests pass (to be verified by CI)