### PR TITLE
refactor: deduplicate canMergeRects and mergeRects functions

### DIFF
--- a/src/core/dirtyRects.ts
+++ b/src/core/dirtyRects.ts
@@ -34,6 +34,7 @@
 
 import { ComputedLayout, hasComputedLayout } from '../systems/layoutSystem';
 import { type ComponentStore, createComponentStore } from '../utils/componentStorage';
+import { canMergeRects, mergeRects } from './dirtyRects/utils';
 import type { Entity, World } from './types';
 
 // =============================================================================
@@ -613,34 +614,6 @@ function coalesceRegions(regions: DirtyRect[]): DirtyRect[] {
 	}
 
 	return result;
-}
-
-/**
- * Checks if two rectangles can be merged.
- * @internal
- */
-function canMergeRects(a: DirtyRect, b: DirtyRect): boolean {
-	// Allow merging if they overlap or are adjacent (within 1 cell)
-	const aRight = a.x + a.width;
-	const aBottom = a.y + a.height;
-	const bRight = b.x + b.width;
-	const bBottom = b.y + b.height;
-
-	// Check if they're within 1 cell of each other
-	return !(b.x > aRight + 1 || bRight < a.x - 1 || b.y > aBottom + 1 || bBottom < a.y - 1);
-}
-
-/**
- * Merges two rectangles into their bounding box.
- * @internal
- */
-function mergeRects(a: DirtyRect, b: DirtyRect): DirtyRect {
-	const x = Math.min(a.x, b.x);
-	const y = Math.min(a.y, b.y);
-	const right = Math.max(a.x + a.width, b.x + b.width);
-	const bottom = Math.max(a.y + a.height, b.y + b.height);
-
-	return { x, y, width: right - x, height: bottom - y };
 }
 
 // =============================================================================

--- a/src/core/dirtyRects/regions.ts
+++ b/src/core/dirtyRects/regions.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DirtyRect, DirtyTrackerData } from './types';
+import { canMergeRects, mergeRects } from './utils';
 
 /** Get byte and bit index for a cell position */
 function getCellIndices(
@@ -182,34 +183,6 @@ function coalesceRegions(regions: DirtyRect[]): DirtyRect[] {
 	}
 
 	return result;
-}
-
-/**
- * Checks if two rectangles can be merged.
- * @internal
- */
-function canMergeRects(a: DirtyRect, b: DirtyRect): boolean {
-	// Allow merging if they overlap or are adjacent (within 1 cell)
-	const aRight = a.x + a.width;
-	const aBottom = a.y + a.height;
-	const bRight = b.x + b.width;
-	const bBottom = b.y + b.height;
-
-	// Check if they're within 1 cell of each other
-	return !(b.x > aRight + 1 || bRight < a.x - 1 || b.y > aBottom + 1 || bBottom < a.y - 1);
-}
-
-/**
- * Merges two rectangles into their bounding box.
- * @internal
- */
-function mergeRects(a: DirtyRect, b: DirtyRect): DirtyRect {
-	const x = Math.min(a.x, b.x);
-	const y = Math.min(a.y, b.y);
-	const right = Math.max(a.x + a.width, b.x + b.width);
-	const bottom = Math.max(a.y + a.height, b.y + b.height);
-
-	return { x, y, width: right - x, height: bottom - y };
 }
 
 /**

--- a/src/core/dirtyRects/utils.ts
+++ b/src/core/dirtyRects/utils.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared utilities for dirty rectangle manipulation.
+ * @module core/dirtyRects/utils
+ */
+
+import type { DirtyRect } from './types';
+
+/**
+ * Checks if two rectangles can be merged.
+ * Returns true if they overlap or are adjacent (within 1 cell of each other).
+ *
+ * @param a - First rectangle
+ * @param b - Second rectangle
+ * @returns True if rectangles can be merged
+ * @internal
+ */
+export function canMergeRects(a: DirtyRect, b: DirtyRect): boolean {
+	// Allow merging if they overlap or are adjacent (within 1 cell)
+	const aRight = a.x + a.width;
+	const aBottom = a.y + a.height;
+	const bRight = b.x + b.width;
+	const bBottom = b.y + b.height;
+
+	// Check if they're within 1 cell of each other
+	return !(b.x > aRight + 1 || bRight < a.x - 1 || b.y > aBottom + 1 || bBottom < a.y - 1);
+}
+
+/**
+ * Merges two rectangles into their bounding box.
+ *
+ * @param a - First rectangle
+ * @param b - Second rectangle
+ * @returns A new rectangle that encompasses both inputs
+ * @internal
+ */
+export function mergeRects(a: DirtyRect, b: DirtyRect): DirtyRect {
+	const x = Math.min(a.x, b.x);
+	const y = Math.min(a.y, b.y);
+	const right = Math.max(a.x + a.width, b.x + b.width);
+	const bottom = Math.max(a.y + a.height, b.y + b.height);
+
+	return { x, y, width: right - x, height: bottom - y };
+}


### PR DESCRIPTION
Addresses issue #1282

## Summary
Extract duplicate  and  functions to a shared utils module to eliminate code duplication found in the Semfora audit.

## Changes
- Created  with shared functions
- Updated  to import from utils
- Updated  to import from utils
- Removed duplicate function definitions

## Verification
- ✅ TypeScript compiles cleanly (no circular dependencies)
- ✅ All tests pass (12,562 tests)
- ✅ Functions now defined in exactly one place
- ✅ No behavioral changes

## Note on Semfora Audit
The issue description mentioned additional duplicates (`clearBuffer`, `resetStats`, `buildPalette`) that could not be verified. After careful inspection:
- `clearBuffer` functions have different type signatures (InputEventBufferData vs ScreenBufferData) and are NOT duplicates
- `resetStats` and `buildPalette` were only found in single locations

This PR resolves the confirmed exact duplicates between the legacy monolithic `dirtyRects.ts` and the modular `dirtyRects/` structure.