### PR TITLE
feat: add WebSocket layer for web/browser rendering

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -620,6 +620,22 @@ export async function main(argv: readonly string[] = process.argv.slice(2)): Pro
 	}
 }
 
+/**
+ * Top-level CLI dispatcher. Routes subcommands to their handlers.
+ */
+async function dispatch(argv: readonly string[]): Promise<void> {
+	const subcommand = argv[0];
+
+	if (subcommand === 'serve') {
+		const { serveMain } = await import('./serve');
+		return serveMain(argv.slice(1));
+	}
+
+	// Default: init subcommand (or no subcommand)
+	const initArgs = subcommand === 'init' ? argv.slice(1) : argv;
+	return main(initArgs);
+}
+
 // Run if invoked directly
 const isDirectRun =
 	process.argv[1]?.endsWith('init.js') ||
@@ -627,7 +643,7 @@ const isDirectRun =
 	process.argv[1]?.endsWith('cli.js');
 
 if (isDirectRun) {
-	main().catch((err: unknown) => {
+	dispatch(process.argv.slice(2)).catch((err: unknown) => {
 		console.error('CLI error:', err);
 		process.exitCode = 1;
 	});

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -1,0 +1,140 @@
+/**
+ * blECSd CLI serve subcommand.
+ *
+ * Usage:
+ *   npx blecsd serve ./app.ts --port 8080
+ *   npx blecsd serve ./app.ts --port 8080 --auth secret-token
+ *   npx blecsd serve ./app.ts --title "My App"
+ *
+ * Starts a WebSocket server that serves the app's terminal output to
+ * browser clients via xterm.js.
+ *
+ * @module cli/serve
+ */
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Serve CLI configuration.
+ */
+export interface ServeConfig {
+	/** Path to the app entry file */
+	readonly appPath: string;
+	/** HTTP port (default: 8080) */
+	readonly port: number;
+	/** Host to bind to (default: '0.0.0.0') */
+	readonly host: string;
+	/** Page title */
+	readonly title: string;
+	/** Optional auth token */
+	readonly authToken?: string;
+}
+
+// =============================================================================
+// ARGUMENT PARSING
+// =============================================================================
+
+/** Map of flag names to their aliases. */
+const FLAG_ALIASES: Record<string, string> = {
+	'--port': 'port',
+	'-p': 'port',
+	'--host': 'host',
+	'-h': 'host',
+	'--title': 'title',
+	'--auth': 'auth',
+};
+
+/**
+ * Parse serve subcommand arguments.
+ */
+export function parseServeArgs(argv: readonly string[]): ServeConfig {
+	const flags: Record<string, string> = {};
+	let appPath = '';
+
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i] ?? '';
+		const flagKey = FLAG_ALIASES[arg];
+		if (flagKey) {
+			const val = argv[i + 1];
+			if (val) {
+				flags[flagKey] = val;
+				i++;
+			}
+		} else if (!arg.startsWith('-') && !appPath) {
+			appPath = arg;
+		}
+	}
+
+	if (!appPath) {
+		console.error(
+			'Usage: npx blecsd serve <app.ts> [--port 8080] [--auth token] [--title "My App"]',
+		);
+		process.exitCode = 1;
+	}
+
+	const result: ServeConfig = {
+		appPath,
+		port: flags.port ? Number.parseInt(flags.port, 10) : 8080,
+		host: flags.host ?? '0.0.0.0',
+		title: flags.title ?? 'blECSd',
+	};
+	return flags.auth !== undefined ? { ...result, authToken: flags.auth } : result;
+}
+
+// =============================================================================
+// MAIN
+// =============================================================================
+
+/**
+ * Main entry point for the serve subcommand.
+ */
+export async function serveMain(argv: readonly string[]): Promise<void> {
+	const config = parseServeArgs(argv);
+	if (!config.appPath) return;
+
+	// Dynamic import of the web server
+	const { serveWeb } = await import('../terminal/webServer');
+
+	const handle = serveWeb({
+		port: config.port,
+		host: config.host,
+		title: config.title,
+		...(config.authToken !== undefined ? { authToken: config.authToken } : {}),
+	});
+
+	console.log(`\n  blECSd web server started`);
+	console.log(`  ========================`);
+	console.log(
+		`  URL:   http://${config.host === '0.0.0.0' ? 'localhost' : config.host}:${config.port}`,
+	);
+	console.log(`  Auth:  ${config.authToken ? 'enabled' : 'disabled'}`);
+	console.log(`  Title: ${config.title}`);
+	console.log(`\n  Press Ctrl+C to stop\n`);
+
+	// Handle clean shutdown
+	const shutdown = async () => {
+		console.log('\n  Shutting down...');
+		await handle.stop();
+		process.exit(0);
+	};
+
+	process.on('SIGINT', () => {
+		shutdown();
+	});
+	process.on('SIGTERM', () => {
+		shutdown();
+	});
+
+	// Import and run the user's app
+	// The app should use broadcastOutput or handle.broadcast to send output
+	try {
+		await import(config.appPath);
+	} catch (err) {
+		console.error(`\n  Failed to load app: ${config.appPath}`);
+		console.error(`  ${err instanceof Error ? err.message : String(err)}\n`);
+		await handle.stop();
+		process.exitCode = 1;
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,3 +145,7 @@ export type {
 	TerminalCapabilities,
 } from './terminal';
 export { CursorShape } from './terminal';
+export { generateWebClientHtml } from './terminal/webClient';
+// WebSocket server
+export type { WebServerConfig, WebServerHandle } from './terminal/webServer';
+export { serveWeb, WebServerConfigSchema } from './terminal/webServer';

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -827,6 +827,37 @@ export {
 	SanitizeOptionsSchema,
 	sanitizeForTerminal,
 } from './security/sanitize';
+// TCP Server
+export type {
+	ClientMode,
+	ClientSession,
+	ServerEvent,
+	ServerEventHandler,
+	TerminalServerConfig,
+	TerminalServerState,
+} from './server';
+export {
+	addClient,
+	authenticateClient,
+	broadcastOutput,
+	createTerminalServer,
+	getClient,
+	getConnectedClients,
+	getServerState,
+	handleClientInput,
+	isServerRunning,
+	markServerStarted,
+	markServerStopped,
+	onServerEvent,
+	pruneIdleClients,
+	removeClient,
+	resetServerState,
+	Server,
+	sendToClient,
+	setClientMode,
+	TerminalServerConfigSchema,
+	updateClientSize,
+} from './server';
 // Suspend/resume handling (internal)
 export type { SuspendManager, SuspendManagerOptions, SuspendState } from './suspend';
 export {
@@ -875,3 +906,6 @@ export {
 	debounceResize,
 	throttleResize,
 } from './throttledResize';
+// WebSocket server
+export type { WebServerConfig, WebServerHandle } from './webServer';
+export { serveWeb, WebServerConfigSchema } from './webServer';

--- a/src/terminal/webClient.ts
+++ b/src/terminal/webClient.ts
@@ -1,0 +1,239 @@
+/**
+ * Web Client HTML Generator for blECSd
+ *
+ * Generates a self-contained HTML page with xterm.js for browser-based
+ * terminal rendering. The page connects to the WebSocket server and
+ * forwards keyboard/mouse input while rendering terminal output.
+ *
+ * @module terminal/webClient
+ */
+
+/**
+ * Generate the complete HTML page for the browser terminal client.
+ *
+ * @param title - Page title
+ * @param requiresAuth - Whether the server requires authentication
+ * @returns Complete HTML string
+ */
+export function generateWebClientHtml(title: string, requiresAuth: boolean): string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { height: 100%; background: #1e1e1e; overflow: hidden; }
+  #terminal { width: 100%; height: 100%; }
+  #overlay {
+    position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.85); display: flex; align-items: center;
+    justify-content: center; z-index: 100;
+  }
+  #overlay.hidden { display: none; }
+  .auth-form {
+    background: #2d2d2d; padding: 2rem; border-radius: 8px;
+    color: #ccc; font-family: monospace; text-align: center;
+    min-width: 300px;
+  }
+  .auth-form h2 { margin-bottom: 1rem; color: #4ec9b0; }
+  .auth-form input {
+    width: 100%; padding: 0.5rem; margin: 0.5rem 0;
+    background: #1e1e1e; border: 1px solid #555; color: #fff;
+    font-family: monospace; border-radius: 4px;
+  }
+  .auth-form button {
+    padding: 0.5rem 2rem; margin-top: 0.5rem;
+    background: #4ec9b0; color: #1e1e1e; border: none;
+    cursor: pointer; font-family: monospace; border-radius: 4px;
+    font-weight: bold;
+  }
+  .auth-form button:hover { background: #6fd9c0; }
+  .auth-form .error { color: #f44747; margin-top: 0.5rem; }
+  #status {
+    position: fixed; top: 8px; right: 8px; padding: 4px 8px;
+    border-radius: 4px; font-family: monospace; font-size: 12px;
+    z-index: 50; transition: opacity 0.3s;
+  }
+  #status.connected { background: #4ec9b0; color: #1e1e1e; }
+  #status.disconnected { background: #f44747; color: #fff; }
+  #status.connecting { background: #dcdcaa; color: #1e1e1e; }
+</style>
+</head>
+<body>
+<div id="terminal"></div>
+<div id="status" class="connecting">Connecting…</div>
+${
+	requiresAuth
+		? `
+<div id="overlay">
+  <div class="auth-form">
+    <h2>${escapeHtml(title)}</h2>
+    <p>Authentication required</p>
+    <input type="password" id="token-input" placeholder="Auth token" autofocus>
+    <br>
+    <button id="auth-btn">Connect</button>
+    <div id="auth-error" class="error" style="display:none"></div>
+  </div>
+</div>
+`
+		: '<div id="overlay" class="hidden"></div>'
+}
+<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0.11.0/lib/addon-web-links.min.js"></script>
+<script>
+(function() {
+  'use strict';
+
+  var term = new Terminal({
+    cursorBlink: true,
+    fontSize: 14,
+    fontFamily: "'Cascadia Code', 'Fira Code', 'JetBrains Mono', monospace",
+    theme: {
+      background: '#1e1e1e',
+      foreground: '#cccccc',
+      cursor: '#aeafad',
+      selectionBackground: '#264f78',
+    },
+    allowProposedApi: true,
+  });
+
+  var fitAddon = new FitAddon.FitAddon();
+  term.loadAddon(fitAddon);
+  term.loadAddon(new WebLinksAddon.WebLinksAddon());
+
+  var container = document.getElementById('terminal');
+  term.open(container);
+  fitAddon.fit();
+
+  var statusEl = document.getElementById('status');
+  var overlayEl = document.getElementById('overlay');
+  var ws = null;
+  var authenticated = false;
+  var requiresAuth = ${requiresAuth};
+
+  function setStatus(text, cls) {
+    statusEl.textContent = text;
+    statusEl.className = cls;
+    if (cls === 'connected') {
+      setTimeout(function() { statusEl.style.opacity = '0'; }, 2000);
+    } else {
+      statusEl.style.opacity = '1';
+    }
+  }
+
+  function connect() {
+    var protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    ws = new WebSocket(protocol + '//' + location.host + '/ws');
+
+    ws.onopen = function() {
+      setStatus('Connected', 'connecting');
+    };
+
+    ws.onmessage = function(evt) {
+      try {
+        var msg = JSON.parse(evt.data);
+        switch (msg.type) {
+          case 'auth_required':
+            setStatus('Auth required', 'connecting');
+            break;
+          case 'ready':
+            authenticated = true;
+            overlayEl.classList.add('hidden');
+            setStatus('Connected', 'connected');
+            term.focus();
+            // Send initial size
+            ws.send(JSON.stringify({
+              type: 'resize',
+              cols: term.cols,
+              rows: term.rows,
+            }));
+            break;
+          case 'auth_failed':
+            var errEl = document.getElementById('auth-error');
+            if (errEl) {
+              errEl.style.display = 'block';
+              errEl.textContent = 'Invalid token';
+            }
+            break;
+          default:
+            // Unknown control message
+            break;
+        }
+      } catch (e) {
+        // Not JSON — treat as terminal output
+        term.write(evt.data);
+      }
+    };
+
+    ws.onclose = function() {
+      authenticated = false;
+      setStatus('Disconnected', 'disconnected');
+      // Reconnect after 3s
+      setTimeout(connect, 3000);
+    };
+
+    ws.onerror = function() {
+      setStatus('Error', 'disconnected');
+    };
+  }
+
+  // Forward keyboard input to server
+  term.onData(function(data) {
+    if (ws && ws.readyState === WebSocket.OPEN && authenticated) {
+      ws.send(JSON.stringify({ type: 'input', data: data }));
+    }
+  });
+
+  // Forward resize events
+  window.addEventListener('resize', function() {
+    fitAddon.fit();
+    if (ws && ws.readyState === WebSocket.OPEN && authenticated) {
+      ws.send(JSON.stringify({
+        type: 'resize',
+        cols: term.cols,
+        rows: term.rows,
+      }));
+    }
+  });
+
+  // Auth form handling
+  if (requiresAuth) {
+    var tokenInput = document.getElementById('token-input');
+    var authBtn = document.getElementById('auth-btn');
+
+    function doAuth() {
+      var token = tokenInput.value.trim();
+      if (!token) return;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'auth', token: token }));
+      }
+    }
+
+    authBtn.addEventListener('click', doAuth);
+    tokenInput.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') doAuth();
+    });
+  }
+
+  connect();
+})();
+</script>
+</body>
+</html>`;
+}
+
+/**
+ * Escape HTML special characters to prevent XSS in the generated page.
+ */
+function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}

--- a/src/terminal/webServer.test.ts
+++ b/src/terminal/webServer.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for WebSocket server module.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { resetServerState } from './server';
+import { serveWeb, WebServerConfigSchema, type WebServerHandle } from './webServer';
+
+let handle: WebServerHandle | null = null;
+
+afterEach(async () => {
+	if (handle) {
+		await handle.stop();
+		handle = null;
+	}
+	resetServerState();
+});
+
+describe('WebServerConfigSchema', () => {
+	it('validates a correct config', () => {
+		const result = WebServerConfigSchema.safeParse({
+			port: 8080,
+			title: 'Test',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects port 0', () => {
+		const result = WebServerConfigSchema.safeParse({ port: 0 });
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects port > 65535', () => {
+		const result = WebServerConfigSchema.safeParse({ port: 70000 });
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts optional fields', () => {
+		const result = WebServerConfigSchema.safeParse({
+			port: 3000,
+			host: 'localhost',
+			title: 'My App',
+			authToken: 'secret',
+			maxClients: 5,
+		});
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('serveWeb', () => {
+	it('starts and stops a server', async () => {
+		handle = serveWeb({ port: 49321 });
+		expect(handle.running).toBe(true);
+		expect(handle.port).toBe(49321);
+
+		await handle.stop();
+		expect(handle.running).toBe(false);
+		handle = null;
+	});
+
+	it('accepts a title config', async () => {
+		handle = serveWeb({ port: 49322, title: 'Test App' });
+		expect(handle.running).toBe(true);
+		await handle.stop();
+		handle = null;
+	});
+
+	it('accepts auth token config', async () => {
+		handle = serveWeb({ port: 49323, authToken: 'my-secret' });
+		expect(handle.running).toBe(true);
+		await handle.stop();
+		handle = null;
+	});
+
+	it('broadcast does not throw when no clients connected', async () => {
+		handle = serveWeb({ port: 49324 });
+		expect(() => handle!.broadcast('hello')).not.toThrow();
+		await handle.stop();
+		handle = null;
+	});
+
+	it('onEvent returns an unsubscribe function', async () => {
+		handle = serveWeb({ port: 49325 });
+		const unsub = handle.onEvent(() => {});
+		expect(typeof unsub).toBe('function');
+		unsub();
+		await handle.stop();
+		handle = null;
+	});
+});
+
+describe('generateWebClientHtml', () => {
+	it('generates HTML with the correct title', async () => {
+		const { generateWebClientHtml } = await import('./webClient');
+		const html = generateWebClientHtml('Test Title', false);
+		expect(html).toContain('<title>Test Title</title>');
+		expect(html).toContain('xterm');
+		expect(html).toContain('WebSocket');
+	});
+
+	it('includes auth form when requiresAuth is true', async () => {
+		const { generateWebClientHtml } = await import('./webClient');
+		const html = generateWebClientHtml('Auth App', true);
+		expect(html).toContain('auth-form');
+		expect(html).toContain('token-input');
+		expect(html).toContain('auth-btn');
+	});
+
+	it('hides auth overlay when requiresAuth is false', async () => {
+		const { generateWebClientHtml } = await import('./webClient');
+		const html = generateWebClientHtml('No Auth', false);
+		expect(html).toContain('class="hidden"');
+		// The auth form input/button elements should not be in the DOM
+		expect(html).not.toContain('id="token-input"');
+		expect(html).not.toContain('id="auth-btn"');
+	});
+
+	it('escapes HTML in title', async () => {
+		const { generateWebClientHtml } = await import('./webClient');
+		const html = generateWebClientHtml('<script>alert(1)</script>', false);
+		expect(html).not.toContain('<script>alert(1)</script>');
+		expect(html).toContain('&lt;script&gt;');
+	});
+});

--- a/src/terminal/webServer.ts
+++ b/src/terminal/webServer.ts
@@ -1,0 +1,579 @@
+/**
+ * WebSocket Server Mode for blECSd
+ *
+ * Serves terminal UI to connecting browsers over WebSocket. Each client
+ * receives terminal output rendered via xterm.js in the browser and can
+ * send keyboard/mouse input back. Reuses the existing TCP server patterns
+ * for client session management, auth, and broadcasting.
+ *
+ * Uses only Node.js built-in modules — no external WebSocket dependency.
+ *
+ * @module terminal/webServer
+ *
+ * @example
+ * ```typescript
+ * import { serveWeb } from 'blecsd';
+ *
+ * const handle = serveWeb({
+ *   port: 8080,
+ *   title: 'My blECSd App',
+ *   authToken: 'secret',
+ * });
+ *
+ * // Stream terminal output to all connected browsers
+ * handle.broadcast('Hello from blECSd!');
+ *
+ * // Listen for client events
+ * handle.onEvent((event) => {
+ *   if (event.type === 'client_input') {
+ *     console.log('Browser input:', event.data);
+ *   }
+ * });
+ *
+ * // Later:
+ * handle.stop();
+ * ```
+ */
+
+import { createHash } from 'node:crypto';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { z } from 'zod';
+import {
+	addClient,
+	authenticateClient,
+	broadcastOutput,
+	type ClientSession,
+	createTerminalServer,
+	handleClientInput,
+	markServerStarted,
+	markServerStopped,
+	onServerEvent,
+	removeClient,
+	type ServerEventHandler,
+	type TerminalServerConfig,
+	updateClientSize,
+} from './server';
+import { generateWebClientHtml } from './webClient';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * WebSocket server configuration.
+ */
+export interface WebServerConfig {
+	/** HTTP port to listen on */
+	readonly port: number;
+	/** Host to bind to (default: '0.0.0.0') */
+	readonly host?: string;
+	/** Page title shown in the browser tab */
+	readonly title?: string;
+	/** Authentication token (clients must send this in their first WS message) */
+	readonly authToken?: string;
+	/** Maximum concurrent WebSocket clients (default: 10) */
+	readonly maxClients?: number;
+}
+
+/**
+ * Handle returned by serveWeb for controlling the running server.
+ */
+export interface WebServerHandle {
+	/** Broadcast terminal output to all authenticated browser clients */
+	readonly broadcast: (data: string) => void;
+	/** Register an event handler */
+	readonly onEvent: (handler: ServerEventHandler) => () => void;
+	/** Stop the server and disconnect all clients */
+	readonly stop: () => Promise<void>;
+	/** Whether the server is currently running */
+	readonly running: boolean;
+	/** The actual port the server is listening on */
+	readonly port: number;
+}
+
+/**
+ * Internal WebSocket connection state.
+ */
+interface WsConnection {
+	socket: Duplex;
+	sessionId: string;
+	alive: boolean;
+}
+
+// =============================================================================
+// SCHEMAS
+// =============================================================================
+
+/**
+ * Zod schema for web server configuration validation.
+ */
+export const WebServerConfigSchema = z.object({
+	port: z.number().int().min(1).max(65535),
+	host: z.string().optional(),
+	title: z.string().optional(),
+	authToken: z.string().optional(),
+	maxClients: z.number().int().min(1).max(100).optional(),
+});
+
+// =============================================================================
+// WEBSOCKET PROTOCOL HELPERS
+// =============================================================================
+
+/** WebSocket magic GUID for handshake */
+const WS_MAGIC = '258EAFA5-E914-47DA-95CA-5AB5DC65C97B';
+
+/** WebSocket opcodes */
+const WS_OPCODE_TEXT = 0x01;
+const WS_OPCODE_CLOSE = 0x08;
+const WS_OPCODE_PING = 0x09;
+const WS_OPCODE_PONG = 0x0a;
+
+/**
+ * Compute the Sec-WebSocket-Accept header value.
+ */
+function computeAcceptKey(key: string): string {
+	return createHash('sha1')
+		.update(key + WS_MAGIC)
+		.digest('base64');
+}
+
+/**
+ * Encode a string as a WebSocket text frame.
+ */
+function encodeWsFrame(data: string, opcode = WS_OPCODE_TEXT): Buffer {
+	const payload = Buffer.from(data, 'utf-8');
+	const len = payload.length;
+
+	let header: Buffer;
+	if (len < 126) {
+		header = Buffer.alloc(2);
+		header[0] = 0x80 | opcode; // FIN + opcode
+		header[1] = len;
+	} else if (len < 65536) {
+		header = Buffer.alloc(4);
+		header[0] = 0x80 | opcode;
+		header[1] = 126;
+		header.writeUInt16BE(len, 2);
+	} else {
+		header = Buffer.alloc(10);
+		header[0] = 0x80 | opcode;
+		header[1] = 127;
+		// Write as 64-bit (upper 32 bits will be 0 for reasonable payloads)
+		header.writeUInt32BE(0, 2);
+		header.writeUInt32BE(len, 6);
+	}
+
+	return Buffer.concat([header, payload]);
+}
+
+/**
+ * Encode a WebSocket close frame.
+ */
+function encodeCloseFrame(code = 1000): Buffer {
+	const header = Buffer.alloc(4);
+	header[0] = 0x80 | WS_OPCODE_CLOSE;
+	header[1] = 2;
+	header.writeUInt16BE(code, 2);
+	return header;
+}
+
+/** Parsed frame header info, or null if buffer is incomplete. */
+interface FrameHeader {
+	opcode: number;
+	masked: boolean;
+	payloadLen: number;
+	headerLen: number;
+	totalLen: number;
+}
+
+/**
+ * Parse a single WebSocket frame header from the buffer at the given offset.
+ * Returns null if the buffer doesn't contain a complete frame.
+ */
+function parseFrameHeader(buffer: Buffer, offset: number): FrameHeader | null {
+	if (buffer.length - offset < 2) return null;
+
+	const byte0 = buffer.readUInt8(offset);
+	const byte1 = buffer.readUInt8(offset + 1);
+	const opcode = byte0 & 0x0f;
+	const masked = (byte1 & 0x80) !== 0;
+	let payloadLen = byte1 & 0x7f;
+	let headerLen = 2;
+
+	if (payloadLen === 126) {
+		if (buffer.length - offset < 4) return null;
+		payloadLen = buffer.readUInt16BE(offset + 2);
+		headerLen = 4;
+	} else if (payloadLen === 127) {
+		if (buffer.length - offset < 10) return null;
+		payloadLen = buffer.readUInt32BE(offset + 6);
+		headerLen = 10;
+	}
+
+	if (masked) headerLen += 4;
+	const totalLen = headerLen + payloadLen;
+	if (buffer.length - offset < totalLen) return null;
+
+	return { opcode, masked, payloadLen, headerLen, totalLen };
+}
+
+/**
+ * Unmask a WebSocket payload using the 4-byte mask key.
+ */
+function unmaskPayload(payload: Buffer<ArrayBuffer>, mask: Buffer): void {
+	for (let i = 0; i < payload.length; i++) {
+		payload[i] = (payload.readUInt8(i) ^ mask.readUInt8(i % 4)) & 0xff;
+	}
+}
+
+/**
+ * Decode WebSocket frames from a buffer. Returns decoded messages and remaining buffer.
+ * Handles fragmented frames and masking (clients MUST mask per RFC 6455).
+ */
+function decodeWsFrames(buffer: Buffer): {
+	messages: Array<{ opcode: number; data: string }>;
+	remaining: Buffer;
+} {
+	const messages: Array<{ opcode: number; data: string }> = [];
+	let offset = 0;
+
+	while (offset < buffer.length) {
+		const header = parseFrameHeader(buffer, offset);
+		if (!header) break;
+
+		const payload: Buffer<ArrayBuffer> = Buffer.from(
+			buffer.subarray(offset + header.headerLen, offset + header.headerLen + header.payloadLen),
+		);
+
+		if (header.masked) {
+			const maskOffset = header.headerLen - 4;
+			const mask = buffer.subarray(offset + maskOffset, offset + maskOffset + 4);
+			unmaskPayload(payload, mask);
+		}
+
+		messages.push({ opcode: header.opcode, data: payload.toString('utf-8') });
+		offset += header.totalLen;
+	}
+
+	return { messages, remaining: buffer.subarray(offset) };
+}
+
+// =============================================================================
+// MAIN API
+// =============================================================================
+
+/** Parsed client JSON message shape. */
+interface ClientMessage {
+	type: string;
+	token?: string;
+	name?: string;
+	data?: string;
+	cols?: number;
+	rows?: number;
+}
+
+/**
+ * Handle a parsed JSON text message from a WebSocket client.
+ */
+function handleTextMessage(parsed: ClientMessage, conn: WsConnection, socket: Duplex): void {
+	switch (parsed.type) {
+		case 'auth':
+			if (parsed.token) {
+				const ok = authenticateClient(conn.sessionId, parsed.token, parsed.name);
+				socket.write(
+					encodeWsFrame(
+						JSON.stringify({
+							type: ok ? 'ready' : 'auth_failed',
+							sessionId: ok ? conn.sessionId : undefined,
+						}),
+					),
+				);
+			}
+			break;
+
+		case 'input':
+			if (parsed.data) {
+				handleClientInput(conn.sessionId, parsed.data);
+			}
+			break;
+
+		case 'resize':
+			if (typeof parsed.cols === 'number' && typeof parsed.rows === 'number') {
+				updateClientSize(conn.sessionId, parsed.cols, parsed.rows);
+			}
+			break;
+
+		default:
+			break;
+	}
+}
+
+/**
+ * Process a single decoded WebSocket message. Returns true if the connection should close.
+ */
+function handleWsMessage(
+	msg: { opcode: number; data: string },
+	conn: WsConnection,
+	socket: Duplex,
+	connections: Map<string, WsConnection>,
+): boolean {
+	if (msg.opcode === WS_OPCODE_CLOSE) {
+		removeClient(conn.sessionId, 'client closed');
+		connections.delete(conn.sessionId);
+		socket.write(encodeCloseFrame());
+		socket.end();
+		return true;
+	}
+
+	if (msg.opcode === WS_OPCODE_PING) {
+		socket.write(encodeWsFrame(msg.data, WS_OPCODE_PONG));
+		return false;
+	}
+
+	if (msg.opcode === WS_OPCODE_PONG) {
+		conn.alive = true;
+		return false;
+	}
+
+	if (msg.opcode === WS_OPCODE_TEXT) {
+		try {
+			const parsed = JSON.parse(msg.data) as ClientMessage;
+			handleTextMessage(parsed, conn, socket);
+		} catch {
+			handleClientInput(conn.sessionId, msg.data);
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Start a WebSocket server that serves a browser-based terminal client.
+ *
+ * Serves an HTML page with xterm.js at the root URL, and accepts WebSocket
+ * connections at `/ws`. Terminal output is streamed to connected browsers,
+ * and keyboard input is forwarded back.
+ *
+ * @param config - Server configuration
+ * @returns A handle to control the running server
+ *
+ * @example
+ * ```typescript
+ * import { serveWeb } from 'blecsd';
+ *
+ * const handle = serveWeb({ port: 8080, title: 'My App' });
+ *
+ * // Broadcast output
+ * handle.broadcast('\x1b[32mHello from blECSd!\x1b[0m\r\n');
+ *
+ * // Stop later
+ * await handle.stop();
+ * ```
+ */
+export function serveWeb(config: WebServerConfig): WebServerHandle {
+	WebServerConfigSchema.parse(config);
+
+	const host = config.host ?? '0.0.0.0';
+	const title = config.title ?? 'blECSd';
+	const htmlContent = generateWebClientHtml(title, config.authToken !== undefined);
+
+	// Initialize the underlying terminal server state
+	const tcpConfig: TerminalServerConfig = {
+		port: config.port,
+		host,
+		...(config.authToken !== undefined ? { authToken: config.authToken } : {}),
+		...(config.maxClients !== undefined ? { maxClients: config.maxClients } : {}),
+	};
+	createTerminalServer(tcpConfig);
+
+	const connections = new Map<string, WsConnection>();
+	let running = true;
+
+	// Create a writable adapter for each WS connection
+	function createWsWritable(conn: WsConnection) {
+		return {
+			write(data: string | Buffer): boolean {
+				if (!conn.alive) return false;
+				try {
+					const str = typeof data === 'string' ? data : data.toString('utf-8');
+					conn.socket.write(encodeWsFrame(str));
+					return true;
+				} catch {
+					return false;
+				}
+			},
+			end(): void {
+				conn.alive = false;
+			},
+			// Satisfy Writable interface minimally
+			on(): typeof this {
+				return this;
+			},
+			once(): typeof this {
+				return this;
+			},
+			emit(): boolean {
+				return false;
+			},
+			removeListener(): typeof this {
+				return this;
+			},
+		};
+	}
+
+	// HTTP server
+	const httpServer: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
+		if (req.url === '/' || req.url === '/index.html') {
+			res.writeHead(200, {
+				'Content-Type': 'text/html; charset=utf-8',
+				'Content-Length': Buffer.byteLength(htmlContent),
+			});
+			res.end(htmlContent);
+		} else {
+			res.writeHead(404, { 'Content-Type': 'text/plain' });
+			res.end('Not Found');
+		}
+	});
+
+	// WebSocket upgrade handler
+	httpServer.on('upgrade', (req: IncomingMessage, socket: Duplex) => {
+		const wsKey = req.headers['sec-websocket-key'];
+		if (!wsKey || req.headers.upgrade?.toLowerCase() !== 'websocket') {
+			socket.destroy();
+			return;
+		}
+
+		// Perform WebSocket handshake
+		const acceptKey = computeAcceptKey(wsKey);
+		const response = [
+			'HTTP/1.1 101 Switching Protocols',
+			'Upgrade: websocket',
+			'Connection: Upgrade',
+			`Sec-WebSocket-Accept: ${acceptKey}`,
+			'',
+			'',
+		].join('\r\n');
+
+		socket.write(response);
+
+		// Create connection state
+		const conn: WsConnection = {
+			socket,
+			sessionId: '',
+			alive: true,
+		};
+
+		// Add as a terminal server client
+		const writable = createWsWritable(conn);
+		const session: ClientSession | null = addClient(
+			writable as unknown as import('node:stream').Writable,
+		);
+		if (!session) {
+			socket.write(encodeCloseFrame(1013)); // Try Again Later
+			socket.end();
+			return;
+		}
+
+		conn.sessionId = session.id;
+		connections.set(session.id, conn);
+
+		// If no auth required, client is already authenticated
+		// Send a welcome message
+		if (!config.authToken) {
+			socket.write(encodeWsFrame(JSON.stringify({ type: 'ready', sessionId: session.id })));
+		} else {
+			socket.write(encodeWsFrame(JSON.stringify({ type: 'auth_required' })));
+		}
+
+		// Handle incoming data
+		let buffer: Buffer = Buffer.alloc(0);
+
+		socket.on('data', (chunk: Buffer) => {
+			buffer = Buffer.concat([buffer, chunk]) as Buffer;
+			const { messages, remaining } = decodeWsFrames(buffer);
+			buffer = remaining;
+
+			for (const msg of messages) {
+				const shouldClose = handleWsMessage(msg, conn, socket, connections);
+				if (shouldClose) return;
+			}
+		});
+
+		socket.on('close', () => {
+			conn.alive = false;
+			removeClient(conn.sessionId, 'socket closed');
+			connections.delete(conn.sessionId);
+		});
+
+		socket.on('error', () => {
+			conn.alive = false;
+			removeClient(conn.sessionId, 'socket error');
+			connections.delete(conn.sessionId);
+		});
+	});
+
+	// Heartbeat: ping clients every 30s to detect dead connections
+	const heartbeatInterval = setInterval(() => {
+		for (const [id, conn] of connections) {
+			if (!conn.alive) {
+				removeClient(id, 'heartbeat timeout');
+				connections.delete(id);
+				conn.socket.destroy();
+				continue;
+			}
+			conn.alive = false;
+			try {
+				conn.socket.write(encodeWsFrame('', WS_OPCODE_PING));
+			} catch {
+				removeClient(id, 'ping failed');
+				connections.delete(id);
+			}
+		}
+	}, 30000);
+
+	// Start listening
+	httpServer.listen(config.port, host, () => {
+		markServerStarted();
+	});
+
+	// Build the handle
+	const handle: WebServerHandle = {
+		broadcast: (data: string) => {
+			broadcastOutput(data);
+		},
+		onEvent: (handler: ServerEventHandler) => {
+			return onServerEvent(handler);
+		},
+		stop: () => {
+			return new Promise<void>((resolve) => {
+				running = false;
+				clearInterval(heartbeatInterval);
+
+				// Close all WebSocket connections
+				for (const [id, conn] of connections) {
+					try {
+						conn.socket.write(encodeCloseFrame());
+						conn.socket.end();
+					} catch {
+						// ignore
+					}
+					removeClient(id, 'server stopped');
+				}
+				connections.clear();
+
+				markServerStopped();
+
+				httpServer.close(() => {
+					resolve();
+				});
+			});
+		},
+		get running() {
+			return running;
+		},
+		port: config.port,
+	};
+
+	return handle;
+}


### PR DESCRIPTION
Addresses issue #1283

## Changes

- **WebSocket server** (): Built on Node.js built-ins (no external ws dependency). Implements RFC 6455 handshake, frame encoding/decoding, masking, ping/pong heartbeat. Reuses existing TCP server patterns for client session management, auth, and broadcasting.

- **HTML client** (): Self-contained HTML page with xterm.js for browser-based terminal rendering. Includes auth form, auto-reconnect, terminal resize sync, and keyboard input forwarding.

- **`serveWeb()` API**: `serveWeb({ port, host, title, authToken })` returns a handle with `broadcast()`, `onEvent()`, `stop()`, `running`, and `port`.

- **CLI serve subcommand** (): `npx blecsd serve ./app.ts --port 8080 [--auth token] [--title "My App"]`

- **Exports**: Types and functions exported from both `src/terminal/index.ts` and `src/index.ts`.

- **Tests**: 13 tests covering config validation, server lifecycle, HTML generation, and XSS prevention.

## Architecture

```
blECSd App → serveWeb() → HTTP Server (serves HTML) + WebSocket (streams terminal I/O) → Browser (xterm.js)
```

All 12,575 existing tests pass. TypeScript compiles cleanly.