### PR TITLE
refactor: deduplicate render helpers into shared renderHelpers.ts

### DIFF
--- a/src/systems/renderHelpers.ts
+++ b/src/systems/renderHelpers.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared render helper functions used by both renderSystem and virtualizedRenderSystem.
+ * @module systems/renderHelpers
+ */
+
+import { Border, hasBorderVisible } from '../components/border';
+import { Renderable } from '../components/renderable';
+import { hasComponent } from '../core/ecs';
+import type { Entity, World } from '../core/types';
+import { Attr } from '../terminal/screen/cell';
+import { ComputedLayout, hasComputedLayout } from './layoutSystem';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface EntityBounds {
+	readonly x: number;
+	readonly y: number;
+	readonly width: number;
+	readonly height: number;
+}
+
+export interface BorderThickness {
+	top: number;
+	right: number;
+	bottom: number;
+	left: number;
+}
+
+// =============================================================================
+// FUNCTIONS
+// =============================================================================
+
+/**
+ * Converts Renderable style to Cell attributes.
+ */
+export function styleToAttrs(world: World, eid: Entity): number {
+	if (!hasComponent(world, eid, Renderable)) {
+		return Attr.NONE;
+	}
+
+	let attrs = Attr.NONE;
+	if (Renderable.bold[eid] === 1) attrs |= Attr.BOLD;
+	if (Renderable.underline[eid] === 1) attrs |= Attr.UNDERLINE;
+	if (Renderable.blink[eid] === 1) attrs |= Attr.BLINK;
+	if (Renderable.inverse[eid] === 1) attrs |= Attr.INVERSE;
+
+	return attrs;
+}
+
+/**
+ * Gets entity bounds from ComputedLayout.
+ */
+export function getEntityBounds(world: World, eid: Entity): EntityBounds | undefined {
+	if (!hasComputedLayout(world, eid)) {
+		return undefined;
+	}
+
+	return {
+		x: ComputedLayout.x[eid] as number,
+		y: ComputedLayout.y[eid] as number,
+		width: ComputedLayout.width[eid] as number,
+		height: ComputedLayout.height[eid] as number,
+	};
+}
+
+/**
+ * Gets border thickness for each side.
+ */
+export function getBorderThickness(world: World, eid: Entity): BorderThickness {
+	if (!hasBorderVisible(world, eid)) {
+		return { top: 0, right: 0, bottom: 0, left: 0 };
+	}
+
+	return {
+		top: Border.top[eid] === 1 ? 1 : 0,
+		right: Border.right[eid] === 1 ? 1 : 0,
+		bottom: Border.bottom[eid] === 1 ? 1 : 0,
+		left: Border.left[eid] === 1 ? 1 : 0,
+	};
+}
+
+/**
+ * Gets the content area (bounds minus border).
+ */
+export function getContentBounds(
+	bounds: EntityBounds,
+	borderThickness: BorderThickness,
+): EntityBounds {
+	return {
+		x: bounds.x + borderThickness.left,
+		y: bounds.y + borderThickness.top,
+		width: Math.max(0, bounds.width - borderThickness.left - borderThickness.right),
+		height: Math.max(0, bounds.height - borderThickness.top - borderThickness.bottom),
+	};
+}

--- a/src/systems/renderSystem.ts
+++ b/src/systems/renderSystem.ts
@@ -4,7 +4,7 @@
  * @module systems/renderSystem
  */
 
-import { Border, BorderType, getBorder, hasBorderVisible } from '../components/border';
+import { BorderType, getBorder, hasBorderVisible } from '../components/border';
 import { BoxTitle, boxTitleStore } from '../components/boxTitle';
 // getChildren reserved for future tree-based rendering mode
 // import { getChildren } from '../components/hierarchy';
@@ -18,12 +18,17 @@ import {
 } from '../components/renderable';
 import type { DirtyTracker } from '../core/dirtyTracking';
 import { markEntityDirty } from '../core/dirtyTracking';
-import { hasComponent } from '../core/ecs';
 import type { Entity, System, World } from '../core/types';
 import { getWorldAdapter } from '../core/worldAdapter';
 import type { Cell, ScreenBufferData } from '../terminal/screen/cell';
 import { Attr, createCell, fillRect, setCell, writeString } from '../terminal/screen/cell';
-import { ComputedLayout, hasComputedLayout } from './layoutSystem';
+import type { EntityBounds } from './renderHelpers';
+import {
+	getBorderThickness,
+	getContentBounds,
+	getEntityBounds,
+	styleToAttrs,
+} from './renderHelpers';
 
 // =============================================================================
 // TYPES
@@ -44,88 +49,10 @@ export interface RenderContext {
 /**
  * Computed bounds for an entity.
  */
-interface EntityBounds {
-	readonly x: number;
-	readonly y: number;
-	readonly width: number;
-	readonly height: number;
-}
-
 /** Reusable scratch array for frame-local render sorting. */
 const renderSortScratch: Entity[] = [];
 /** Reusable scratch array for frame-local occlusion tracking. */
 const occlusionScratch: OcclusionRect[] = [];
-
-// =============================================================================
-// RENDER HELPER FUNCTIONS
-// =============================================================================
-
-/**
- * Converts Renderable style to Cell attributes.
- */
-function styleToAttrs(world: World, eid: Entity): number {
-	if (!hasComponent(world, eid, Renderable)) {
-		return Attr.NONE;
-	}
-
-	let attrs = Attr.NONE;
-	if (Renderable.bold[eid] === 1) attrs |= Attr.BOLD;
-	if (Renderable.underline[eid] === 1) attrs |= Attr.UNDERLINE;
-	if (Renderable.blink[eid] === 1) attrs |= Attr.BLINK;
-	if (Renderable.inverse[eid] === 1) attrs |= Attr.INVERSE;
-
-	return attrs;
-}
-
-/**
- * Gets entity bounds from ComputedLayout.
- */
-function getEntityBounds(world: World, eid: Entity): EntityBounds | undefined {
-	if (!hasComputedLayout(world, eid)) {
-		return undefined;
-	}
-
-	return {
-		x: ComputedLayout.x[eid] as number,
-		y: ComputedLayout.y[eid] as number,
-		width: ComputedLayout.width[eid] as number,
-		height: ComputedLayout.height[eid] as number,
-	};
-}
-
-/**
- * Gets border thickness for each side.
- */
-function getBorderThickness(
-	world: World,
-	eid: Entity,
-): { top: number; right: number; bottom: number; left: number } {
-	if (!hasBorderVisible(world, eid)) {
-		return { top: 0, right: 0, bottom: 0, left: 0 };
-	}
-
-	return {
-		top: Border.top[eid] === 1 ? 1 : 0,
-		right: Border.right[eid] === 1 ? 1 : 0,
-		bottom: Border.bottom[eid] === 1 ? 1 : 0,
-		left: Border.left[eid] === 1 ? 1 : 0,
-	};
-}
-
-/**
- * Gets the content area (bounds minus border).
- */
-function getContentBounds(
-	bounds: EntityBounds,
-	borderThickness: { top: number; right: number; bottom: number; left: number },
-): EntityBounds {
-	return {
-		x: bounds.x + borderThickness.left,
-		y: bounds.y + borderThickness.top,
-		width: Math.max(0, bounds.width - borderThickness.left - borderThickness.right),
-		height: Math.max(0, bounds.height - borderThickness.top - borderThickness.bottom),
-	};
-}
 
 // =============================================================================
 // RENDER FUNCTIONS

--- a/src/systems/virtualizedRenderSystem.ts
+++ b/src/systems/virtualizedRenderSystem.ts
@@ -26,7 +26,7 @@
  */
 
 import { z } from 'zod';
-import { Border, hasBorderVisible } from '../components/border';
+
 import { Position } from '../components/position';
 import { getStyle, isEffectivelyVisible, markClean, Renderable } from '../components/renderable';
 import {
@@ -36,7 +36,7 @@ import {
 	VirtualViewport,
 	type VisibleRange,
 } from '../components/virtualViewport';
-import { hasComponent, query } from '../core/ecs';
+import { query } from '../core/ecs';
 import type { Entity, System, World } from '../core/types';
 import { getWorldStore } from '../core/worldStore';
 import type { ScreenBufferData } from '../terminal/screen/cell';
@@ -45,7 +45,13 @@ import type { DoubleBufferData } from '../terminal/screen/doubleBuffer';
 import { getBackBuffer, markDirtyRegion } from '../terminal/screen/doubleBuffer';
 import type { VirtualizedLineStore } from '../utils/virtualizedLineStore';
 import { getLineRange } from '../utils/virtualizedLineStore';
-import { ComputedLayout, hasComputedLayout } from './layoutSystem';
+import type { EntityBounds } from './renderHelpers';
+import {
+	getBorderThickness,
+	getContentBounds,
+	getEntityBounds,
+	styleToAttrs,
+} from './renderHelpers';
 
 // =============================================================================
 // ZOD SCHEMAS
@@ -135,16 +141,6 @@ export interface VirtualizedRenderContext {
 	readonly buffer: ScreenBufferData;
 	/** The double buffer for dirty tracking */
 	readonly doubleBuffer: DoubleBufferData;
-}
-
-/**
- * Computed bounds for an entity.
- */
-interface EntityBounds {
-	readonly x: number;
-	readonly y: number;
-	readonly width: number;
-	readonly height: number;
 }
 
 /**
@@ -369,73 +365,6 @@ export function clearLineRenderConfig(world: World, eid: Entity): void {
 // =============================================================================
 // INTERNAL HELPERS
 // =============================================================================
-
-/**
- * Converts Renderable style to Cell attributes.
- */
-function styleToAttrs(world: World, eid: Entity): number {
-	if (!hasComponent(world, eid, Renderable)) {
-		return Attr.NONE;
-	}
-
-	let attrs = Attr.NONE;
-	if (Renderable.bold[eid] === 1) attrs |= Attr.BOLD;
-	if (Renderable.underline[eid] === 1) attrs |= Attr.UNDERLINE;
-	if (Renderable.blink[eid] === 1) attrs |= Attr.BLINK;
-	if (Renderable.inverse[eid] === 1) attrs |= Attr.INVERSE;
-
-	return attrs;
-}
-
-/**
- * Gets entity bounds from ComputedLayout.
- */
-function getEntityBounds(world: World, eid: Entity): EntityBounds | undefined {
-	if (!hasComputedLayout(world, eid)) {
-		return undefined;
-	}
-
-	return {
-		x: ComputedLayout.x[eid] as number,
-		y: ComputedLayout.y[eid] as number,
-		width: ComputedLayout.width[eid] as number,
-		height: ComputedLayout.height[eid] as number,
-	};
-}
-
-/**
- * Gets border thickness for each side.
- */
-function getBorderThickness(
-	world: World,
-	eid: Entity,
-): { top: number; right: number; bottom: number; left: number } {
-	if (!hasBorderVisible(world, eid)) {
-		return { top: 0, right: 0, bottom: 0, left: 0 };
-	}
-
-	return {
-		top: Border.top[eid] === 1 ? 1 : 0,
-		right: Border.right[eid] === 1 ? 1 : 0,
-		bottom: Border.bottom[eid] === 1 ? 1 : 0,
-		left: Border.left[eid] === 1 ? 1 : 0,
-	};
-}
-
-/**
- * Gets the content area (bounds minus border).
- */
-function getContentBounds(
-	bounds: EntityBounds,
-	borderThickness: { top: number; right: number; bottom: number; left: number },
-): EntityBounds {
-	return {
-		x: bounds.x + borderThickness.left,
-		y: bounds.y + borderThickness.top,
-		width: Math.max(0, bounds.width - borderThickness.left - borderThickness.right),
-		height: Math.max(0, bounds.height - borderThickness.top - borderThickness.bottom),
-	};
-}
 
 /**
  * Renders a single line to the buffer.


### PR DESCRIPTION
Addresses issue #1297

Extracted 4 duplicated functions from `renderSystem.ts` and `virtualizedRenderSystem.ts` into a shared `src/systems/renderHelpers.ts` module:

- `styleToAttrs` — converts Renderable style to Cell attributes
- `getEntityBounds` — gets entity bounds from ComputedLayout
- `getBorderThickness` — gets border thickness for each side
- `getContentBounds` — gets content area (bounds minus border)

Also exported `EntityBounds` interface and `BorderThickness` interface from the shared module.

Cleaned up unused imports in both consumer files.