### PR TITLE
refactor: deduplicate buildPalette across 3d/backends and terminal/graphics

### DIFF
--- a/packages/3d/src/backends/sixel.ts
+++ b/packages/3d/src/backends/sixel.ts
@@ -17,6 +17,7 @@
  * @module 3d/backends/sixel
  */
 
+import { buildPalette } from 'blecsd/terminal';
 import type { PixelFramebuffer } from '../rasterizer/pixelBuffer';
 import type { BackendCapabilities, EncodedOutput } from '../schemas/backends';
 import { type SixelConfig, SixelConfigSchema } from '../schemas/backends';
@@ -42,35 +43,6 @@ function countColors(buf: Uint8ClampedArray, pixelCount: number): Map<number, nu
 		colorCounts.set(key, (colorCounts.get(key) ?? 0) + 1);
 	}
 	return colorCounts;
-}
-
-/**
- * Build palette from color counts, sorted by popularity.
- */
-function buildPalette(
-	colorCounts: Map<number, number>,
-	maxColors: number,
-): { paletteFlat: Uint8Array; paletteCount: number } {
-	const entries: Array<[number, number]> = [];
-	for (const entry of colorCounts) {
-		entries.push(entry);
-	}
-	entries.sort((a, b) => b[1] - a[1]);
-
-	const paletteCount = Math.min(entries.length, maxColors) || 1;
-	const paletteFlat = new Uint8Array(paletteCount * 3);
-
-	for (let i = 0; i < paletteCount; i++) {
-		const entry = entries[i];
-		if (entry) {
-			const key = entry[0];
-			paletteFlat[i * 3] = (key >> 16) & 0xff;
-			paletteFlat[i * 3 + 1] = (key >> 8) & 0xff;
-			paletteFlat[i * 3 + 2] = key & 0xff;
-		}
-	}
-
-	return { paletteFlat, paletteCount };
 }
 
 /**

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -483,6 +483,7 @@ export {
 	// Kitty protocol constants
 	APC_PREFIX,
 	BRAILLE_BACKEND_NAME,
+	buildPalette,
 	canvasToCells as brailleCanvasToCells,
 	// Vector-to-pixel bridge
 	canvasToPixelBitmap,


### PR DESCRIPTION
Addresses issue #1298

## Changes

- Removed duplicate `buildPalette` function from `packages/3d/src/backends/sixel.ts`
- Added `buildPalette` to the re-exports in `src/terminal/index.ts`
- `packages/3d/src/backends/sixel.ts` now imports `buildPalette` from `blecsd/terminal` (the canonical location)

No circular dependency: 3d → terminal is the correct dependency direction.

All 12,598 tests pass. TypeScript compiles cleanly.