### PR TITLE
feat: add screen.spawn() and screen.exec() for process management

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1021,7 +1021,9 @@ export type {
 	CursorShapeValue,
 	ScreenCursor,
 	ScreenData,
+	ScreenExecOptions,
 	ScreenOptions,
+	ScreenSpawnOptions,
 } from './screen';
 export {
 	CursorShape,
@@ -1042,6 +1044,8 @@ export {
 	resetScreenSingleton,
 	resizeScreen,
 	Screen,
+	screenExec,
+	screenSpawn,
 	setAutoPadding,
 	setFullUnicode,
 	setScreenCursor,

--- a/src/components/namespaces/screenComponent.ts
+++ b/src/components/namespaces/screenComponent.ts
@@ -27,6 +27,8 @@ import {
 	registerScreenSingleton,
 	resetScreenSingleton,
 	resizeScreen,
+	screenExec,
+	screenSpawn,
 	setAutoPadding,
 	setFullUnicode,
 	setScreenCursor,
@@ -66,6 +68,9 @@ export const screenComponent = Object.freeze({
 		setShape: setScreenCursorShape,
 		setVisible: setScreenCursorVisible,
 	}),
+
+	spawn: screenSpawn,
+	exec: screenExec,
 });
 
 export type ScreenComponentModule = typeof screenComponent;

--- a/src/components/screen.ts
+++ b/src/components/screen.ts
@@ -32,8 +32,14 @@
  * ```
  */
 
+import type { ChildProcess } from 'node:child_process';
 import { addComponent, hasComponent } from '../core/ecs';
 import type { Entity, World } from '../core/types';
+import {
+	exec as processExec,
+	spawn as processSpawn,
+} from '../terminal/process';
+import type { ExecOptions, ExecResult, SpawnOptions } from '../terminal/process';
 import { getDimensions, setDimensions } from './dimensions';
 import { NULL_ENTITY } from './hierarchy';
 import { Renderable } from './renderable';
@@ -575,4 +581,147 @@ export function destroyScreen(world: World): boolean {
  */
 export function resetScreenSingleton(world: World): void {
 	screenEntityMap.delete(world);
+}
+
+// ===== Process Management =====
+
+/**
+ * Options for screen-level spawn/exec that extend base process options
+ * with world-aware rendering pause/resume.
+ */
+export interface ScreenSpawnOptions extends SpawnOptions {
+	/** If true, mark the screen dirty on restore so a full redraw occurs (default: true) */
+	redrawOnRestore?: boolean;
+}
+
+/**
+ * Options for screen-level exec.
+ */
+export interface ScreenExecOptions extends ExecOptions {
+	/** If true, mark the screen dirty on restore so a full redraw occurs (default: true) */
+	redrawOnRestore?: boolean;
+}
+
+/**
+ * Pause rendering on the screen entity.
+ * Sets the Renderable visible flag to 0 so render systems skip it.
+ *
+ * @internal
+ */
+function pauseScreenRendering(world: World, eid: Entity): void {
+	if (hasComponent(world, eid, Renderable)) {
+		Renderable.visible[eid] = 0;
+	}
+}
+
+/**
+ * Resume rendering on the screen entity and mark dirty for a full redraw.
+ *
+ * @internal
+ */
+function resumeScreenRendering(world: World, eid: Entity, markDirty: boolean): void {
+	if (hasComponent(world, eid, Renderable)) {
+		Renderable.visible[eid] = 1;
+		if (markDirty) {
+			Renderable.dirty[eid] = 1;
+		}
+	}
+}
+
+/**
+ * Spawn a child process with screen lifecycle integration.
+ *
+ * This pauses screen rendering, delegates to the terminal-level spawn
+ * (which handles alternate buffer, cursor, mouse, raw mode), and resumes
+ * rendering when the process exits. A full redraw is triggered by default.
+ *
+ * @param world - The ECS world
+ * @param command - Command to spawn
+ * @param args - Arguments for the command
+ * @param options - Spawn options
+ * @returns The spawned child process
+ * @throws {Error} If no screen entity exists in the world
+ *
+ * @example
+ * ```typescript
+ * import { screenSpawn } from 'blecsd';
+ *
+ * const child = screenSpawn(world, 'vim', ['file.txt'], {
+ *   isAlternateBuffer: true,
+ *   isMouseEnabled: true,
+ * });
+ * ```
+ */
+export function screenSpawn(
+	world: World,
+	command: string,
+	args: string[] = [],
+	options: ScreenSpawnOptions = {},
+): ChildProcess {
+	const eid = getScreen(world);
+	if (eid === null) {
+		throw new Error('No screen entity exists in this world. Create one with createScreenEntity first.');
+	}
+
+	const { redrawOnRestore = true, onExit, ...spawnOpts } = options;
+
+	// Pause rendering before spawning
+	pauseScreenRendering(world, eid);
+
+	return processSpawn(command, args, {
+		...spawnOpts,
+		onExit: (code, signal) => {
+			// Resume rendering after process exits
+			resumeScreenRendering(world, eid, redrawOnRestore);
+			// Forward to user callback
+			onExit?.(code, signal);
+		},
+	});
+}
+
+/**
+ * Execute a command with screen lifecycle integration, returning stdout/stderr.
+ *
+ * This pauses screen rendering, delegates to the terminal-level exec
+ * (which handles alternate buffer, cursor, mouse, raw mode), and resumes
+ * rendering when the process completes. A full redraw is triggered by default.
+ *
+ * @param world - The ECS world
+ * @param command - Command to execute
+ * @param args - Arguments for the command
+ * @param options - Exec options
+ * @returns Promise resolving to the exec result with stdout/stderr
+ * @throws {Error} If no screen entity exists in the world
+ *
+ * @example
+ * ```typescript
+ * import { screenExec } from 'blecsd';
+ *
+ * const result = await screenExec(world, 'git', ['status']);
+ * console.log(result.stdout);
+ * ```
+ */
+export async function screenExec(
+	world: World,
+	command: string,
+	args: string[] = [],
+	options: ScreenExecOptions = {},
+): Promise<ExecResult> {
+	const eid = getScreen(world);
+	if (eid === null) {
+		throw new Error('No screen entity exists in this world. Create one with createScreenEntity first.');
+	}
+
+	const { redrawOnRestore = true, ...execOpts } = options;
+
+	// Pause rendering before executing
+	pauseScreenRendering(world, eid);
+
+	try {
+		const result = await processExec(command, args, execOpts);
+		return result;
+	} finally {
+		// Always resume rendering, even on error
+		resumeScreenRendering(world, eid, redrawOnRestore);
+	}
 }

--- a/src/components/screenProcess.test.ts
+++ b/src/components/screenProcess.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for screen.spawn() and screen.exec() process management
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createWorld } from '../core/ecs';
+import { createScreenEntity } from '../core/entities';
+import type { World } from '../core/types';
+import { Renderable } from './renderable';
+import { resetScreenSingleton, screenExec, screenSpawn } from './screen';
+
+describe('Screen Process Management', () => {
+	let world: World;
+
+	afterEach(() => {
+		if (world) {
+			resetScreenSingleton(world);
+		}
+	});
+
+	describe('screenSpawn', () => {
+		it('throws if no screen entity exists', () => {
+			world = createWorld();
+			expect(() => screenSpawn(world, 'echo', ['hello'])).toThrow(
+				'No screen entity exists',
+			);
+		});
+
+		it('pauses rendering during spawn and resumes on exit', async () => {
+			world = createWorld();
+			const screen = createScreenEntity(world, { width: 80, height: 24 });
+
+			// Verify rendering is initially active
+			expect(Renderable.visible[screen]).toBe(1);
+
+			const exitPromise = new Promise<number | null>((resolve) => {
+				const child = screenSpawn(world, 'echo', ['hello'], {
+					onExit: (code) => {
+						resolve(code);
+					},
+				});
+
+				// While process is running, rendering should be paused
+				expect(Renderable.visible[screen]).toBe(0);
+			});
+
+			const code = await exitPromise;
+			expect(code).toBe(0);
+
+			// After exit, rendering should be resumed
+			expect(Renderable.visible[screen]).toBe(1);
+			// And dirty flag set for redraw
+			expect(Renderable.dirty[screen]).toBe(1);
+		});
+
+		it('supports redrawOnRestore=false', async () => {
+			world = createWorld();
+			const screen = createScreenEntity(world, { width: 80, height: 24 });
+
+			// Clear dirty flag
+			Renderable.dirty[screen] = 0;
+
+			const exitPromise = new Promise<void>((resolve) => {
+				screenSpawn(world, 'echo', ['hello'], {
+					redrawOnRestore: false,
+					onExit: () => resolve(),
+				});
+			});
+
+			await exitPromise;
+			// dirty should NOT have been set
+			expect(Renderable.dirty[screen]).toBe(0);
+		});
+
+		it('forwards onExit callback', async () => {
+			world = createWorld();
+			createScreenEntity(world, { width: 80, height: 24 });
+
+			const onExit = vi.fn();
+			const exitPromise = new Promise<void>((resolve) => {
+				screenSpawn(world, 'echo', ['hello'], {
+					onExit: (code, signal) => {
+						onExit(code, signal);
+						resolve();
+					},
+				});
+			});
+
+			await exitPromise;
+			expect(onExit).toHaveBeenCalledWith(0, null);
+		});
+	});
+
+	describe('screenExec', () => {
+		it('throws if no screen entity exists', async () => {
+			world = createWorld();
+			await expect(screenExec(world, 'echo', ['hello'])).rejects.toThrow(
+				'No screen entity exists',
+			);
+		});
+
+		it('returns stdout/stderr from executed command', async () => {
+			world = createWorld();
+			createScreenEntity(world, { width: 80, height: 24 });
+
+			const result = await screenExec(world, 'echo', ['hello']);
+			expect(result.stdout.trim()).toBe('hello');
+			expect(result.exitCode).toBe(0);
+		});
+
+		it('pauses rendering during exec and resumes after', async () => {
+			world = createWorld();
+			const screen = createScreenEntity(world, { width: 80, height: 24 });
+
+			expect(Renderable.visible[screen]).toBe(1);
+
+			const result = await screenExec(world, 'echo', ['test']);
+
+			// After completion, rendering should be resumed
+			expect(Renderable.visible[screen]).toBe(1);
+			expect(Renderable.dirty[screen]).toBe(1);
+			expect(result.stdout.trim()).toBe('test');
+		});
+
+		it('resumes rendering even on command failure', async () => {
+			world = createWorld();
+			const screen = createScreenEntity(world, { width: 80, height: 24 });
+
+			const result = await screenExec(world, 'ls', ['nonexistent-path-12345']);
+
+			// Rendering should still be resumed
+			expect(Renderable.visible[screen]).toBe(1);
+			expect(result.exitCode).not.toBe(0);
+		});
+
+		it('resumes rendering on spawn error', async () => {
+			world = createWorld();
+			const screen = createScreenEntity(world, { width: 80, height: 24 });
+
+			await expect(
+				screenExec(world, 'nonexistent-command-xyz-12345'),
+			).rejects.toThrow();
+
+			// Rendering should still be resumed
+			expect(Renderable.visible[screen]).toBe(1);
+		});
+
+		it('captures stderr', async () => {
+			world = createWorld();
+			createScreenEntity(world, { width: 80, height: 24 });
+
+			const result = await screenExec(world, 'sh', ['-c', 'echo err >&2']);
+			expect(result.stderr.trim()).toBe('err');
+		});
+	});
+});


### PR DESCRIPTION
Addresses issue #1301

## Changes

Adds `screenSpawn()` and `screenExec()` functions that integrate process spawning with the screen/world lifecycle:

- **`screenSpawn(world, command, args, opts)`** — Pauses screen rendering, spawns a child process (delegating terminal state save/restore to the existing `terminal/process.ts` utilities), and resumes rendering with a dirty-flag redraw on exit.

- **`screenExec(world, command, args, opts)`** — Same lifecycle integration but returns a Promise with stdout/stderr. Rendering is always resumed in a `finally` block, even on errors.

Both functions:
- Throw if no screen entity exists in the world
- Set `Renderable.visible = 0` to pause render systems during the process
- Set `Renderable.dirty = 1` on restore to trigger a full redraw (configurable via `redrawOnRestore` option)
- Delegate terminal state management (alternate buffer, cursor, mouse, raw mode) to the existing `spawn()`/`exec()` in `terminal/process.ts`

## Exports

- Added to `screenComponent` namespace as `screenComponent.spawn()` and `screenComponent.exec()`
- Exported from `components/index.ts` (types: `ScreenSpawnOptions`, `ScreenExecOptions`)

## Tests

10 tests covering:
- Error on missing screen entity
- Rendering pause/resume lifecycle
- `redrawOnRestore` option
- `onExit` callback forwarding
- stdout/stderr capture
- Resume on command failure and spawn error