### PR TITLE
docs: update getting-started, guides, tutorials, and README to use createApp() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,60 +30,27 @@ npm install blecsd
 Create a terminal app with a bordered panel, text, and keyboard input:
 
 ```typescript
-import { createWorld, createScreenEntity, createBoxEntity, createTextEntity } from 'blecsd/core';
-import { createDirtyTracker } from 'blecsd/core';
-import {
-  layoutSystem, renderSystem, outputSystem, cleanup,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { createProgram, createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { createApp } from 'blecsd';
+import { createBoxEntity, createTextEntity } from 'blecsd/core';
 
-const cols = process.stdout.columns ?? 80;
-const rows = process.stdout.rows ?? 24;
+const app = await createApp({ fullscreen: true, fps: 30 });
 
-// 1. Initialize the terminal (alternate screen, hidden cursor, raw mode)
-const program = createProgram();
-await program.init();
-
-// 2. Create the ECS world and screen entity
-const world = createWorld();
-createScreenEntity(world, { width: cols, height: rows });
-
-// 3. Wire up the render pipeline buffers
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
-
-// 4. Build your UI
-const panel = createBoxEntity(world, {
+const panel = createBoxEntity(app.world, {
   x: 2, y: 1, width: 40, height: 12,
   border: { type: 1, top: true, bottom: true, left: true, right: true },
 });
 
-createTextEntity(world, {
+createTextEntity(app.world, {
   x: 4, y: 2, text: 'My Dashboard', parent: panel,
 });
 
-// 5. Render
-function render(): void {
-  layoutSystem(world);
-  renderSystem(world);
-  outputSystem(world);
-}
-
-render();
-
-// 6. Handle keyboard input
-program.on('key', (event) => {
-  if (event.name === 'q' || (event.ctrl && event.name === 'c')) {
-    cleanup(world);
-    program.destroy();
-    process.exit(0);
-  }
-  render();
-});
+app.program.on('key', (e) => { if (e.name === 'q') app.shutdown(); });
+app.start();
 ```
+
+`createApp()` handles world creation, screen entity, render pipeline wiring, alternate screen mode, and SIGINT/SIGTERM shutdown — so you can focus on building your UI.
+
+> **Need more control?** See the [Hello World guide](./docs/getting-started/hello-world.md) for `createRenderPipeline()`, `onShutdown()`, and the full low-level API.
 
 ## Namespace Imports
 
@@ -277,9 +244,8 @@ blECSd is a library, not a framework:
 
 ```typescript
 import { createWorld, addEntity } from 'blecsd/core';
-import { createDirtyTracker } from 'blecsd/core';
-import { layoutSystem, renderSystem, outputSystem, setOutputStream, setOutputBuffer, setRenderBuffer } from 'blecsd/systems';
-import { createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { createRenderPipeline } from 'blecsd';
+import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
 import { position, renderable } from 'blecsd/components';
 
 const world = createWorld();
@@ -289,11 +255,8 @@ const eid = addEntity(world);
 position.set(world, eid, 10, 5);
 renderable.show(world, eid);
 
-// Initialize buffers (required for render/output systems)
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(80, 24);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(80, 24), getBackBuffer(db));
+// Wire up the render pipeline in one call
+createRenderPipeline(process.stdout);
 
 // Call systems when you want
 layoutSystem(world);

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -83,21 +83,13 @@ Systems are functions that process entities with specific components. blECSd pro
 
 ```typescript
 import { createWorld } from 'blecsd/core';
-import {
-  layoutSystem, renderSystem, outputSystem,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
-import { createDirtyTracker } from 'blecsd/core';
+import { createRenderPipeline } from 'blecsd';
+import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
 
 const world = createWorld();
 
 // Initialize render pipeline (required before renderSystem/outputSystem)
-const cols = 80, rows = 24;
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
+createRenderPipeline(process.stdout);
 
 // Run the render pipeline
 layoutSystem(world);   // Compute layout

--- a/docs/getting-started/ecs-api.md
+++ b/docs/getting-started/ecs-api.md
@@ -195,14 +195,10 @@ const loop = createGameLoop(world, { targetFPS: 30 });
 
 loop.registerSystem(LoopPhase.UPDATE, movementSystem);
 
-// To see output, register render systems and initialize the render pipeline:
-// import { layoutSystem, renderSystem, outputSystem, setOutputStream, setOutputBuffer, setRenderBuffer } from 'blecsd/systems';
-// import { createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
-// import { createDirtyTracker } from 'blecsd/core';
-// setOutputStream(process.stdout);
-// const db = createDoubleBuffer(80, 24);
-// setOutputBuffer(db);
-// setRenderBuffer(createDirtyTracker(80, 24), getBackBuffer(db));
+// To see output, initialize the render pipeline and register render systems:
+// import { createRenderPipeline } from 'blecsd';
+// import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
+// createRenderPipeline(process.stdout);
 // loop.registerSystem(LoopPhase.LAYOUT, layoutSystem);
 // loop.registerSystem(LoopPhase.RENDER, renderSystem);
 // loop.registerSystem(LoopPhase.POST_RENDER, outputSystem);

--- a/docs/guides/cheat-sheet.md
+++ b/docs/guides/cheat-sheet.md
@@ -356,6 +356,24 @@ enableMouse(world, eid);
 
 ## Rendering
 
+### Using `createRenderPipeline()` (recommended)
+
+```typescript
+import { createWorld, createScreenEntity } from 'blecsd/core';
+import { createRenderPipeline } from 'blecsd';
+import { renderSystem, outputSystem } from 'blecsd/systems';
+
+const world = createWorld();
+const { cols, rows } = createRenderPipeline(process.stdout);
+createScreenEntity(world, { width: cols, height: rows });
+
+// Render
+renderSystem(world);                       // Render to screen buffer
+outputSystem(world);                       // Flush buffer to terminal
+```
+
+### Manual pipeline setup
+
 ```typescript
 import { createWorld, createScreenEntity, createDirtyTracker } from 'blecsd/core';
 import {
@@ -383,22 +401,29 @@ outputSystem(world);                       // Flush buffer to terminal
 
 ## Game Loop
 
+### Using `createApp()` (recommended)
+
 ```typescript
-import { createWorld, createGameLoop, LoopPhase, createDirtyTracker } from 'blecsd/core';
-import {
-  inputSystem, layoutSystem, renderSystem, outputSystem,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { createApp } from 'blecsd';
+
+// createApp() handles world, render pipeline, program, and shutdown
+const app = await createApp({ fps: 60 });
+
+// ... add entities to app.world ...
+
+const stop = app.start();   // Start the render loop
+// stop();                   // Stop the loop when done
+```
+
+### Using `createGameLoop()` (advanced)
+
+```typescript
+import { createWorld, createGameLoop, LoopPhase } from 'blecsd/core';
+import { createRenderPipeline } from 'blecsd';
+import { inputSystem, layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
 
 const world = createWorld();
-
-// Initialize render pipeline (see Rendering section above)
-const cols = 80, rows = 24;
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
+createRenderPipeline(process.stdout);
 
 // Game loop with registered systems
 const loop = createGameLoop(world, { targetFPS: 60 });

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -708,21 +708,13 @@ for (let i = 0; i < 10000; i++) {
 
 ### Double Buffering
 
-blECSd automatically uses double buffering to avoid tearing:
+blECSd automatically uses double buffering to avoid tearing. `createRenderPipeline()` (or `createApp()`) sets this up for you. Under the hood it creates a double buffer and dirty tracker:
 
 ```typescript
-import { createDoubleBuffer } from 'blecsd/terminal';
-import { outputSystem } from 'blecsd/systems';
-import { createWorld } from 'blecsd/core';
+import { createRenderPipeline } from 'blecsd';
 
-const dbWorld = createWorld();
-// Double buffer - render to back buffer, swap to front on flush
-const db = createDoubleBuffer(80, 24);
-
-// ... render to back buffer ...
-
-// Flush output (swap buffers and write to terminal)
-outputSystem(dbWorld);
+// One call wires up double buffering + dirty tracking
+createRenderPipeline(process.stdout);
 ```
 
 ### Dirty Rectangle Tracking

--- a/docs/tutorials/dashboard.md
+++ b/docs/tutorials/dashboard.md
@@ -40,24 +40,18 @@ In this tutorial, you'll build a system monitoring dashboard that displays CPU, 
 Create `dashboard.ts`:
 
 ```typescript
-import { createWorld, addEntity, createScreenEntity, createDirtyTracker } from 'blecsd/core';
+import { createWorld, addEntity, createScreenEntity } from 'blecsd/core';
+import { createRenderPipeline, onShutdown } from 'blecsd';
 import { setPosition, setDimensions } from 'blecsd/components';
-import {
-  layoutSystem, renderSystem, outputSystem,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
+import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
 import { createScheduler, LoopPhase } from 'blecsd/core';
-import { type KeyEvent } from 'blecsd/terminal';
-import { createProgram, createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { type KeyEvent, createProgram } from 'blecsd/terminal';
 import {
   createPanel, createText, createProgressBar, createLayout,
 } from 'blecsd/widgets';
 import { setContent, setParent, setStyle } from 'blecsd/components';
 import { setProgress } from 'blecsd/components';
 import * as os from 'os';
-
-const columns = process.stdout.columns ?? 80;
-const rows = process.stdout.rows ?? 24;
 
 const world = createWorld();
 const scheduler = createScheduler();
@@ -73,11 +67,9 @@ const program = createProgram({
 program.init();
 
 // Initialize render pipeline
+const { cols: columns, rows } = createRenderPipeline(process.stdout);
 createScreenEntity(world, { width: columns, height: rows });
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(columns, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(columns, rows), getBackBuffer(db));
+const shutdown = onShutdown(world, { program });
 ```
 
 ## Step 2: System Stats Functions
@@ -452,8 +444,7 @@ function handleKey(key: KeyEvent): void {
 
     case 'q':
       stopAutoRefresh();
-      program.destroy();
-      process.exit(0);
+      shutdown();
       break;
   }
 }
@@ -465,12 +456,6 @@ program.on('key', handleKey);
 ## Step 10: Main Loop
 
 ```typescript
-process.on('SIGINT', () => {
-  stopAutoRefresh();
-  program.destroy();
-  process.exit(0);
-});
-
 // Handle resize
 program.on('resize', () => {
   refreshDashboard();

--- a/docs/tutorials/file-browser.md
+++ b/docs/tutorials/file-browser.md
@@ -36,15 +36,12 @@ In this tutorial, you'll build a dual-pane file browser similar to Midnight Comm
 Create `file-browser.ts`:
 
 ```typescript
-import { createWorld, addEntity, createScreenEntity, createDirtyTracker } from 'blecsd/core';
+import { createWorld, addEntity, createScreenEntity } from 'blecsd/core';
+import { createRenderPipeline, onShutdown } from 'blecsd';
 import { setPosition, setDimensions } from 'blecsd/components';
-import {
-  layoutSystem, renderSystem, outputSystem,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
+import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
 import { createScheduler, LoopPhase } from 'blecsd/core';
-import { type KeyEvent } from 'blecsd/terminal';
-import { createProgram, createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { type KeyEvent, createProgram } from 'blecsd/terminal';
 import {
   createVirtualizedList, createPanel, createText, createScrollableText,
   setPanelTitle,
@@ -52,9 +49,6 @@ import {
 import { setContent, setParent } from 'blecsd/components';
 import * as fs from 'fs';
 import * as path from 'path';
-
-const cols = process.stdout.columns ?? 80;
-const rows = process.stdout.rows ?? 24;
 
 const world = createWorld();
 const scheduler = createScheduler();
@@ -71,11 +65,9 @@ const program = createProgram({
 program.init();
 
 // Initialize render pipeline
+const { cols, rows } = createRenderPipeline(process.stdout);
 createScreenEntity(world, { width: cols, height: rows });
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
+const shutdown = onShutdown(world, { program });
 ```
 
 ## Step 2: File Entry Interface
@@ -386,8 +378,7 @@ async function handleKey(key: KeyEvent): Promise<void> {
       break;
 
     case 'q':
-      program.destroy();
-      process.exit(0);
+      shutdown();
       break;
   }
 }
@@ -424,11 +415,6 @@ program.on('key', async (key: KeyEvent) => {
 // Handle window resize
 program.on('resize', () => {
   scheduler.run(world, 0);
-});
-
-process.on('SIGINT', () => {
-  program.destroy();
-  process.exit(0);
 });
 
 // Initial load

--- a/docs/tutorials/simple-game.md
+++ b/docs/tutorials/simple-game.md
@@ -40,14 +40,12 @@ Create `snake.ts`:
 import {
   createWorld, addEntity, removeEntity, hasComponent, addComponent,
   createBoxEntity, createTextEntity, createScheduler, LoopPhase,
-  createScreenEntity, createDirtyTracker,
+  createScreenEntity,
 } from 'blecsd/core';
+import { createRenderPipeline, onShutdown } from 'blecsd';
 import { setPosition, getPosition, setText, setContent, setStyle, setVisible } from 'blecsd/components';
-import {
-  layoutSystem, renderSystem, outputSystem,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { type KeyEvent, createProgram, createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
+import { type KeyEvent, createProgram } from 'blecsd/terminal';
 
 const world = createWorld();
 const scheduler = createScheduler();
@@ -65,13 +63,11 @@ const program = createProgram({
 program.init();
 
 // Initialize render pipeline
-const cols = process.stdout.columns ?? 80;
-const rows = process.stdout.rows ?? 24;
+const { cols, rows } = createRenderPipeline(process.stdout);
 createScreenEntity(world, { width: cols, height: rows });
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
+
+// Register clean shutdown on SIGINT/SIGTERM (returns a function you can call manually)
+const shutdown = onShutdown(world, { program });
 ```
 
 ## Step 2: Game Constants and State
@@ -447,8 +443,7 @@ function handleKey(key: KeyEvent): void {
       break;
 
     case 'q':
-      program.destroy();
-      process.exit(0);
+      shutdown();
       break;
   }
 }
@@ -479,11 +474,6 @@ function gameLoop(): void {
   // Run ECS systems (layout, render, output)
   scheduler.run(world, deltaTime);
 }
-
-process.on('SIGINT', () => {
-  program.destroy();
-  process.exit(0);
-});
 
 // Initialize game
 initializeSnake();

--- a/docs/tutorials/todo-list.md
+++ b/docs/tutorials/todo-list.md
@@ -40,14 +40,12 @@ import {
   createWorld, addEntity, removeEntity,
   createScheduler, LoopPhase, createEventBus,
   createBoxEntity, createTextEntity, createTextboxEntity,
-  createScreenEntity, createDirtyTracker,
+  createScreenEntity,
 } from 'blecsd/core';
+import { createRenderPipeline, onShutdown } from 'blecsd';
 import { setPosition, setDimensions, setParent, setText } from 'blecsd/components';
-import {
-  layoutSystem, renderSystem, outputSystem, blurAll, focusEntity,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { type KeyEvent, createProgram, createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { layoutSystem, renderSystem, outputSystem, blurAll, focusEntity } from 'blecsd/systems';
+import { type KeyEvent, createProgram } from 'blecsd/terminal';
 
 // Create the ECS world
 const world = createWorld();
@@ -65,14 +63,10 @@ const program = createProgram({
 });
 program.init();
 
-// Initialize render pipeline
-const cols = process.stdout.columns ?? 80;
-const rows = process.stdout.rows ?? 24;
+// Initialize render pipeline and register clean shutdown
+const { cols, rows } = createRenderPipeline(process.stdout);
 createScreenEntity(world, { width: cols, height: rows });
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
+const shutdown = onShutdown(world, { program });
 ```
 
 ## Step 2: Define Todo State
@@ -252,8 +246,7 @@ function handleKey(key: KeyEvent): void {
 
     case 'q':
       // Quit
-      program.destroy();
-      process.exit(0);
+      shutdown();
       break;
   }
 }
@@ -315,12 +308,6 @@ program.on('key', (key: KeyEvent) => {
 
   // Run the scheduler to update the UI
   scheduler.run(world, 0);
-});
-
-// Handle exit signals
-process.on('SIGINT', () => {
-  program.destroy();
-  process.exit(0);
 });
 
 // Initial render

--- a/examples/counter-demo.ts
+++ b/examples/counter-demo.ts
@@ -13,7 +13,7 @@ import {
 	outputSystem,
 	renderSystem,
 } from '../src/systems/index';
-import { createRenderPipeline, onShutdown } from '../src/app';
+import { createRenderPipeline } from '../src/app';
 import { createProgram } from '../src/terminal/index';
 
 const { cols, rows } = createRenderPipeline(process.stdout);


### PR DESCRIPTION
Addresses issue #1315

## Changes

Updates all user-facing docs and examples to use the new convenience APIs from PR #1310:

### README.md
- **Quick Start**: Replaced 30-line manual setup with 10-line `createApp()` example
- **Library Design**: Uses `createRenderPipeline()` instead of manual buffer setup

### Getting Started
- **concepts.md**: Render pipeline example uses `createRenderPipeline()`
- **ecs-api.md**: Commented pipeline setup uses `createRenderPipeline()`

### Guides
- **cheat-sheet.md**: Added `createApp()` sections for Rendering and Game Loop, kept manual setup as fallback
- **performance.md**: Double Buffering section simplified to show `createRenderPipeline()`

### Tutorials (all 4)
- simple-game, todo-list, dashboard, file-browser: Use `createRenderPipeline()` + `onShutdown()` instead of manual buffer wiring and SIGINT handlers

### Examples
- counter-demo.ts: Removed unused `onShutdown` import

### Not changed (intentionally)
- **docs/api/**: Low-level API reference docs that explain internals
- **hello-world.md**: Already updated; Low-Level API section kept for reference
- **templates/**: Placeholder metadata only, no source code to update