### PR TITLE
docs: update getting-started, tutorials, and examples to use createAp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,60 +30,25 @@ npm install blecsd
 Create a terminal app with a bordered panel, text, and keyboard input:
 
 ```typescript
-import { createWorld, createScreenEntity, createBoxEntity, createTextEntity } from 'blecsd/core';
-import { createDirtyTracker } from 'blecsd/core';
-import {
-  layoutSystem, renderSystem, outputSystem, cleanup,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { createProgram, createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { createApp } from 'blecsd';
+import { createBoxEntity, createTextEntity } from 'blecsd/core';
 
-const cols = process.stdout.columns ?? 80;
-const rows = process.stdout.rows ?? 24;
+const app = await createApp({ fullscreen: true, fps: 30 });
 
-// 1. Initialize the terminal (alternate screen, hidden cursor, raw mode)
-const program = createProgram();
-await program.init();
-
-// 2. Create the ECS world and screen entity
-const world = createWorld();
-createScreenEntity(world, { width: cols, height: rows });
-
-// 3. Wire up the render pipeline buffers
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
-
-// 4. Build your UI
-const panel = createBoxEntity(world, {
+const panel = createBoxEntity(app.world, {
   x: 2, y: 1, width: 40, height: 12,
   border: { type: 1, top: true, bottom: true, left: true, right: true },
 });
 
-createTextEntity(world, {
+createTextEntity(app.world, {
   x: 4, y: 2, text: 'My Dashboard', parent: panel,
 });
 
-// 5. Render
-function render(): void {
-  layoutSystem(world);
-  renderSystem(world);
-  outputSystem(world);
-}
-
-render();
-
-// 6. Handle keyboard input
-program.on('key', (event) => {
-  if (event.name === 'q' || (event.ctrl && event.name === 'c')) {
-    cleanup(world);
-    program.destroy();
-    process.exit(0);
-  }
-  render();
-});
+app.program.on('key', (e) => { if (e.name === 'q') app.shutdown(); });
+app.start();
 ```
+
+`createApp()` handles world creation, render pipeline wiring, alternate screen, and shutdown signals — all in one call. See the [hello world guide](docs/getting-started/hello-world.md) for details.
 
 ## Namespace Imports
 
@@ -277,9 +242,8 @@ blECSd is a library, not a framework:
 
 ```typescript
 import { createWorld, addEntity } from 'blecsd/core';
-import { createDirtyTracker } from 'blecsd/core';
-import { layoutSystem, renderSystem, outputSystem, setOutputStream, setOutputBuffer, setRenderBuffer } from 'blecsd/systems';
-import { createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { createRenderPipeline } from 'blecsd';
+import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
 import { position, renderable } from 'blecsd/components';
 
 const world = createWorld();
@@ -289,11 +253,8 @@ const eid = addEntity(world);
 position.set(world, eid, 10, 5);
 renderable.show(world, eid);
 
-// Initialize buffers (required for render/output systems)
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(80, 24);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(80, 24), getBackBuffer(db));
+// Initialize the render pipeline in one call
+createRenderPipeline(process.stdout);
 
 // Call systems when you want
 layoutSystem(world);

--- a/docs/api/systems/output.md
+++ b/docs/api/systems/output.md
@@ -1,5 +1,7 @@
 # Output System
 
+> **Tip:** For most applications, use [`createRenderPipeline()`](../../getting-started/hello-world.md) or [`createApp()`](../../getting-started/hello-world.md) to wire up the output pipeline automatically. The low-level APIs below are for advanced use cases.
+
 The output system writes rendered content to the terminal. It runs in the POST_RENDER phase after all rendering is complete and generates optimized ANSI escape sequences for efficient terminal output.
 
 ## Overview

--- a/docs/api/systems/render.md
+++ b/docs/api/systems/render.md
@@ -1,5 +1,7 @@
 # Render System
 
+> **Tip:** For most applications, use [`createRenderPipeline()`](../../getting-started/hello-world.md) or [`createApp()`](../../getting-started/hello-world.md) to wire up the render pipeline automatically. The low-level APIs below are for advanced use cases.
+
 The render system draws entities to the screen buffer. It runs in the RENDER phase after layout computation and handles background fills, borders, and content rendering.
 
 ## Overview

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -83,21 +83,13 @@ Systems are functions that process entities with specific components. blECSd pro
 
 ```typescript
 import { createWorld } from 'blecsd/core';
-import {
-  layoutSystem, renderSystem, outputSystem,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
-import { createDirtyTracker } from 'blecsd/core';
+import { createRenderPipeline } from 'blecsd';
+import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
 
 const world = createWorld();
 
-// Initialize render pipeline (required before renderSystem/outputSystem)
-const cols = 80, rows = 24;
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
+// Initialize render pipeline in one call
+const { cols, rows } = createRenderPipeline(process.stdout);
 
 // Run the render pipeline
 layoutSystem(world);   // Compute layout

--- a/docs/getting-started/ecs-api.md
+++ b/docs/getting-started/ecs-api.md
@@ -195,14 +195,10 @@ const loop = createGameLoop(world, { targetFPS: 30 });
 
 loop.registerSystem(LoopPhase.UPDATE, movementSystem);
 
-// To see output, register render systems and initialize the render pipeline:
-// import { layoutSystem, renderSystem, outputSystem, setOutputStream, setOutputBuffer, setRenderBuffer } from 'blecsd/systems';
-// import { createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
-// import { createDirtyTracker } from 'blecsd/core';
-// setOutputStream(process.stdout);
-// const db = createDoubleBuffer(80, 24);
-// setOutputBuffer(db);
-// setRenderBuffer(createDirtyTracker(80, 24), getBackBuffer(db));
+// To see output, wire the render pipeline and register render systems:
+// import { createRenderPipeline } from 'blecsd';
+// import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
+// createRenderPipeline(process.stdout, { cols: 80, rows: 24 });
 // loop.registerSystem(LoopPhase.LAYOUT, layoutSystem);
 // loop.registerSystem(LoopPhase.RENDER, renderSystem);
 // loop.registerSystem(LoopPhase.POST_RENDER, outputSystem);

--- a/docs/guides/cheat-sheet.md
+++ b/docs/guides/cheat-sheet.md
@@ -357,22 +357,15 @@ enableMouse(world, eid);
 ## Rendering
 
 ```typescript
-import { createWorld, createScreenEntity, createDirtyTracker } from 'blecsd/core';
-import {
-  renderSystem, outputSystem,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { createRenderPipeline } from 'blecsd';
+import { createWorld, createScreenEntity } from 'blecsd/core';
+import { renderSystem, outputSystem } from 'blecsd/systems';
 
 const world = createWorld();
-const cols = 80, rows = 24;
-createScreenEntity(world, { width: cols, height: rows });
 
-// Initialize render pipeline (required before first render)
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
+// Initialize render pipeline in one call
+const { cols, rows } = createRenderPipeline(process.stdout);
+createScreenEntity(world, { width: cols, height: rows });
 
 // Render
 renderSystem(world);                       // Render to screen buffer
@@ -384,45 +377,27 @@ outputSystem(world);                       // Flush buffer to terminal
 ## Game Loop
 
 ```typescript
-import { createWorld, createGameLoop, LoopPhase, createDirtyTracker } from 'blecsd/core';
-import {
-  inputSystem, layoutSystem, renderSystem, outputSystem,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { createApp } from 'blecsd';
+import { createGameLoop, LoopPhase } from 'blecsd/core';
+import { inputSystem, layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
+
+// Option 1: Use createApp() for full bootstrap
+const app = await createApp({ fps: 60 });
+app.start(); // starts the render loop
+
+// Option 2: Manual game loop with createRenderPipeline()
+import { createRenderPipeline } from 'blecsd';
+import { createWorld } from 'blecsd/core';
 
 const world = createWorld();
+createRenderPipeline(process.stdout);
 
-// Initialize render pipeline (see Rendering section above)
-const cols = 80, rows = 24;
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
-
-// Game loop with registered systems
 const loop = createGameLoop(world, { targetFPS: 60 });
 loop.registerSystem(LoopPhase.LAYOUT, layoutSystem);
 loop.registerSystem(LoopPhase.RENDER, renderSystem);
 loop.registerSystem(LoopPhase.POST_RENDER, outputSystem);
 loop.start();
 
-// Or: custom game loop
-let running = true;
-function customLoop() {
-  inputSystem(world);
-  layoutSystem(world);
-  renderSystem(world);
-  outputSystem(world);
-
-  if (running) {
-    setTimeout(customLoop, 16);  // ~60 FPS
-  }
-}
-customLoop();
-
-// Stop
-running = false;
 loop.stop();
 ```
 

--- a/docs/tutorials/dashboard.md
+++ b/docs/tutorials/dashboard.md
@@ -40,15 +40,11 @@ In this tutorial, you'll build a system monitoring dashboard that displays CPU, 
 Create `dashboard.ts`:
 
 ```typescript
-import { createWorld, addEntity, createScreenEntity, createDirtyTracker } from 'blecsd/core';
+import { createApp } from 'blecsd';
+import { addEntity, createScheduler, LoopPhase } from 'blecsd/core';
 import { setPosition, setDimensions } from 'blecsd/components';
-import {
-  layoutSystem, renderSystem, outputSystem,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { createScheduler, LoopPhase } from 'blecsd/core';
-import { type KeyEvent } from 'blecsd/terminal';
-import { createProgram, createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
+import type { KeyEvent } from 'blecsd/terminal';
 import {
   createPanel, createText, createProgressBar, createLayout,
 } from 'blecsd/widgets';
@@ -56,28 +52,15 @@ import { setContent, setParent, setStyle } from 'blecsd/components';
 import { setProgress } from 'blecsd/components';
 import * as os from 'os';
 
-const columns = process.stdout.columns ?? 80;
-const rows = process.stdout.rows ?? 24;
+// Bootstrap the app
+const app = await createApp({ fullscreen: true });
+const { world, program, cols: columns, rows } = app;
 
-const world = createWorld();
 const scheduler = createScheduler();
 
 scheduler.registerSystem(LoopPhase.LAYOUT, layoutSystem);
 scheduler.registerSystem(LoopPhase.RENDER, renderSystem);
 scheduler.registerSystem(LoopPhase.POST_RENDER, outputSystem);
-
-const program = createProgram({
-  useAlternateScreen: true,
-  hideCursor: true,
-});
-program.init();
-
-// Initialize render pipeline
-createScreenEntity(world, { width: columns, height: rows });
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(columns, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(columns, rows), getBackBuffer(db));
 ```
 
 ## Step 2: System Stats Functions
@@ -452,8 +435,7 @@ function handleKey(key: KeyEvent): void {
 
     case 'q':
       stopAutoRefresh();
-      program.destroy();
-      process.exit(0);
+      app.shutdown();
       break;
   }
 }
@@ -465,11 +447,8 @@ program.on('key', handleKey);
 ## Step 10: Main Loop
 
 ```typescript
-process.on('SIGINT', () => {
-  stopAutoRefresh();
-  program.destroy();
-  process.exit(0);
-});
+// Shutdown signals are handled automatically by createApp()
+// (stopAutoRefresh can be registered via onShutdown's onBeforeExit callback)
 
 // Handle resize
 program.on('resize', () => {

--- a/docs/tutorials/file-browser.md
+++ b/docs/tutorials/file-browser.md
@@ -36,15 +36,11 @@ In this tutorial, you'll build a dual-pane file browser similar to Midnight Comm
 Create `file-browser.ts`:
 
 ```typescript
-import { createWorld, addEntity, createScreenEntity, createDirtyTracker } from 'blecsd/core';
+import { createApp } from 'blecsd';
+import { addEntity, createScheduler, LoopPhase } from 'blecsd/core';
 import { setPosition, setDimensions } from 'blecsd/components';
-import {
-  layoutSystem, renderSystem, outputSystem,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { createScheduler, LoopPhase } from 'blecsd/core';
-import { type KeyEvent } from 'blecsd/terminal';
-import { createProgram, createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
+import type { KeyEvent } from 'blecsd/terminal';
 import {
   createVirtualizedList, createPanel, createText, createScrollableText,
   setPanelTitle,
@@ -53,29 +49,16 @@ import { setContent, setParent } from 'blecsd/components';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const cols = process.stdout.columns ?? 80;
-const rows = process.stdout.rows ?? 24;
+// Bootstrap the app
+const app = await createApp({ fullscreen: true });
+const { world, program, cols, rows } = app;
 
-const world = createWorld();
 const scheduler = createScheduler();
 
 // Register systems
 scheduler.registerSystem(LoopPhase.LAYOUT, layoutSystem);
 scheduler.registerSystem(LoopPhase.RENDER, renderSystem);
 scheduler.registerSystem(LoopPhase.POST_RENDER, outputSystem);
-
-const program = createProgram({
-  useAlternateScreen: true,
-  hideCursor: true,
-});
-program.init();
-
-// Initialize render pipeline
-createScreenEntity(world, { width: cols, height: rows });
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
 ```
 
 ## Step 2: File Entry Interface
@@ -386,8 +369,7 @@ async function handleKey(key: KeyEvent): Promise<void> {
       break;
 
     case 'q':
-      program.destroy();
-      process.exit(0);
+      app.shutdown();
       break;
   }
 }
@@ -426,10 +408,7 @@ program.on('resize', () => {
   scheduler.run(world, 0);
 });
 
-process.on('SIGINT', () => {
-  program.destroy();
-  process.exit(0);
-});
+// Shutdown signals are handled automatically by createApp()
 
 // Initial load
 (async () => {

--- a/docs/tutorials/simple-game.md
+++ b/docs/tutorials/simple-game.md
@@ -37,41 +37,24 @@ In this tutorial, you'll build a simple snake-like game that demonstrates blECSd
 Create `snake.ts`:
 
 ```typescript
+import { createApp, onShutdown } from 'blecsd';
 import {
-  createWorld, addEntity, removeEntity, hasComponent, addComponent,
+  addEntity, removeEntity, hasComponent, addComponent,
   createBoxEntity, createTextEntity, createScheduler, LoopPhase,
-  createScreenEntity, createDirtyTracker,
 } from 'blecsd/core';
 import { setPosition, getPosition, setText, setContent, setStyle, setVisible } from 'blecsd/components';
-import {
-  layoutSystem, renderSystem, outputSystem,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { type KeyEvent, createProgram, createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { layoutSystem, renderSystem, outputSystem } from 'blecsd/systems';
+import type { KeyEvent } from 'blecsd/terminal';
 
-const world = createWorld();
+const app = await createApp({ fullscreen: true });
+const { world, program, cols, rows } = app;
+
 const scheduler = createScheduler();
 
 // Register built-in systems
 scheduler.registerSystem(LoopPhase.LAYOUT, layoutSystem);
 scheduler.registerSystem(LoopPhase.RENDER, renderSystem);
 scheduler.registerSystem(LoopPhase.POST_RENDER, outputSystem);
-
-// Create terminal program (handles alternate screen and cursor automatically)
-const program = createProgram({
-  useAlternateScreen: true,
-  hideCursor: true,
-});
-program.init();
-
-// Initialize render pipeline
-const cols = process.stdout.columns ?? 80;
-const rows = process.stdout.rows ?? 24;
-createScreenEntity(world, { width: cols, height: rows });
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
 ```
 
 ## Step 2: Game Constants and State
@@ -447,8 +430,7 @@ function handleKey(key: KeyEvent): void {
       break;
 
     case 'q':
-      program.destroy();
-      process.exit(0);
+      app.shutdown();
       break;
   }
 }
@@ -480,10 +462,7 @@ function gameLoop(): void {
   scheduler.run(world, deltaTime);
 }
 
-process.on('SIGINT', () => {
-  program.destroy();
-  process.exit(0);
-});
+// Shutdown signals are handled automatically by createApp()
 
 // Initialize game
 initializeSnake();

--- a/docs/tutorials/todo-list.md
+++ b/docs/tutorials/todo-list.md
@@ -36,43 +36,25 @@ In this tutorial, you'll build a simple todo list application that demonstrates 
 Create a new file `todo.ts`:
 
 ```typescript
+import { createApp } from 'blecsd';
 import {
-  createWorld, addEntity, removeEntity,
+  addEntity, removeEntity,
   createScheduler, LoopPhase, createEventBus,
   createBoxEntity, createTextEntity, createTextboxEntity,
-  createScreenEntity, createDirtyTracker,
 } from 'blecsd/core';
 import { setPosition, setDimensions, setParent, setText } from 'blecsd/components';
-import {
-  layoutSystem, renderSystem, outputSystem, blurAll, focusEntity,
-  setOutputStream, setOutputBuffer, setRenderBuffer,
-} from 'blecsd/systems';
-import { type KeyEvent, createProgram, createDoubleBuffer, getBackBuffer } from 'blecsd/terminal';
+import { layoutSystem, renderSystem, outputSystem, blurAll, focusEntity } from 'blecsd/systems';
+import type { KeyEvent } from 'blecsd/terminal';
 
-// Create the ECS world
-const world = createWorld();
+// Bootstrap the app (world, render pipeline, program, shutdown handlers)
+const app = await createApp({ fullscreen: true });
+const { world, program, cols, rows } = app;
 
 // Create the scheduler and register systems
 const scheduler = createScheduler();
 scheduler.registerSystem(LoopPhase.LAYOUT, layoutSystem);
 scheduler.registerSystem(LoopPhase.RENDER, renderSystem);
 scheduler.registerSystem(LoopPhase.POST_RENDER, outputSystem);
-
-// Create terminal program
-const program = createProgram({
-  useAlternateScreen: true,
-  hideCursor: true,
-});
-program.init();
-
-// Initialize render pipeline
-const cols = process.stdout.columns ?? 80;
-const rows = process.stdout.rows ?? 24;
-createScreenEntity(world, { width: cols, height: rows });
-setOutputStream(process.stdout);
-const db = createDoubleBuffer(cols, rows);
-setOutputBuffer(db);
-setRenderBuffer(createDirtyTracker(cols, rows), getBackBuffer(db));
 ```
 
 ## Step 2: Define Todo State
@@ -252,8 +234,7 @@ function handleKey(key: KeyEvent): void {
 
     case 'q':
       // Quit
-      program.destroy();
-      process.exit(0);
+      app.shutdown();
       break;
   }
 }
@@ -317,11 +298,7 @@ program.on('key', (key: KeyEvent) => {
   scheduler.run(world, 0);
 });
 
-// Handle exit signals
-process.on('SIGINT', () => {
-  program.destroy();
-  process.exit(0);
-});
+// Shutdown signals are handled automatically by createApp()
 
 // Initial render
 scheduler.run(world, 0);


### PR DESCRIPTION
…p() API (#1315)

- README quickstart: replaced 30-line manual setup with 10-line createApp()
- tutorials (snake, todo, dashboard, file-browser): use createApp() for bootstrap, app.shutdown() for exit
- cheat-sheet: updated Rendering and Game Loop sections
- concepts.md: replaced manual pipeline with createRenderPipeline()
- ecs-api.md: simplified commented render pipeline example
- API reference (render, output): added tip pointing to createApp()
- Net reduction: ~158 lines of boilerplate removed