### PR TITLE
docs: fix 34 signature warnings and standardize widget API docs

### DIFF
--- a/docs/api/widgets/layout.md
+++ b/docs/api/widgets/layout.md
@@ -52,7 +52,7 @@ Creates a new Layout widget with the specified configuration.
 
 ```typescript
 // Basic inline layout (default)
-const layoutA = createLayout(world, addEntity(world));
+const layoutA = createLayout(world, addEntity(world), {});
 
 // Grid layout with 3 columns
 const gridLayout = createLayout(world, addEntity(world), {
@@ -145,7 +145,7 @@ The layout widget provides a chainable API for all operations.
 The underlying entity ID.
 
 ```typescript
-const layoutB = createLayout(world, addEntity(world));
+const layoutB = createLayout(world, addEntity(world), {});
 console.log(layoutB.eid); // Entity ID number
 layoutB.destroy();
 ```
@@ -157,7 +157,7 @@ layoutB.destroy();
 Shows the layout.
 
 ```typescript
-const layoutC = createLayout(world, addEntity(world));
+const layoutC = createLayout(world, addEntity(world), {});
 layoutC.show();
 layoutC.destroy();
 ```
@@ -169,7 +169,7 @@ layoutC.destroy();
 Hides the layout.
 
 ```typescript
-const layoutD = createLayout(world, addEntity(world));
+const layoutD = createLayout(world, addEntity(world), {});
 layoutD.hide();
 layoutD.destroy();
 ```
@@ -185,7 +185,7 @@ layoutD.destroy();
 Sets the absolute position.
 
 ```typescript
-const layoutE = createLayout(world, addEntity(world));
+const layoutE = createLayout(world, addEntity(world), {});
 layoutE.setPosition(20, 15);
 layoutE.destroy();
 ```
@@ -197,7 +197,7 @@ layoutE.destroy();
 Moves the layout by a relative amount.
 
 ```typescript
-const layoutF = createLayout(world, addEntity(world));
+const layoutF = createLayout(world, addEntity(world), {});
 layoutF.move(5, -3);
 layoutF.destroy();
 ```
@@ -213,7 +213,7 @@ layoutF.destroy();
 Gets the current layout mode.
 
 ```typescript
-const layoutG = createLayout(world, addEntity(world));
+const layoutG = createLayout(world, addEntity(world), {});
 const mode = layoutG.getLayoutMode(); // 'inline' | 'grid' | 'flex'
 console.log(mode);
 layoutG.destroy();
@@ -226,7 +226,7 @@ layoutG.destroy();
 Sets the gap between children.
 
 ```typescript
-const layoutH = createLayout(world, addEntity(world));
+const layoutH = createLayout(world, addEntity(world), {});
 layoutH.setGap(2);
 layoutH.destroy();
 ```
@@ -238,7 +238,7 @@ layoutH.destroy();
 Gets the current gap between children.
 
 ```typescript
-const layoutI = createLayout(world, addEntity(world));
+const layoutI = createLayout(world, addEntity(world), {});
 const gap = layoutI.getGap(); // number
 console.log(gap);
 layoutI.destroy();
@@ -251,7 +251,7 @@ layoutI.destroy();
 Recalculates and applies layout positions to all children.
 
 ```typescript
-const layoutJ = createLayout(world, addEntity(world));
+const layoutJ = createLayout(world, addEntity(world), {});
 layoutJ.recalculate();
 layoutJ.destroy();
 ```
@@ -267,7 +267,7 @@ layoutJ.destroy();
 Focuses the layout.
 
 ```typescript
-const layoutK = createLayout(world, addEntity(world));
+const layoutK = createLayout(world, addEntity(world), {});
 layoutK.focus();
 layoutK.destroy();
 ```
@@ -279,7 +279,7 @@ layoutK.destroy();
 Removes focus from the layout.
 
 ```typescript
-const layoutL = createLayout(world, addEntity(world));
+const layoutL = createLayout(world, addEntity(world), {});
 layoutL.blur();
 layoutL.destroy();
 ```
@@ -291,7 +291,7 @@ layoutL.destroy();
 Checks if the layout is currently focused.
 
 ```typescript
-const layoutM = createLayout(world, addEntity(world));
+const layoutM = createLayout(world, addEntity(world), {});
 const focused = layoutM.isFocused(); // boolean
 console.log(focused);
 layoutM.destroy();
@@ -308,7 +308,7 @@ layoutM.destroy();
 Appends a child entity.
 
 ```typescript
-const layoutN = createLayout(world, addEntity(world));
+const layoutN = createLayout(world, addEntity(world), {});
 const childEid = addEntity(world);
 layoutN.append(childEid);
 layoutN.destroy();
@@ -321,7 +321,7 @@ layoutN.destroy();
 Gets all direct children.
 
 ```typescript
-const layoutO = createLayout(world, addEntity(world));
+const layoutO = createLayout(world, addEntity(world), {});
 const children = layoutO.getChildren();
 console.log(children.length);
 layoutO.destroy();
@@ -338,7 +338,7 @@ layoutO.destroy();
 Destroys the widget.
 
 ```typescript
-const layoutP = createLayout(world, addEntity(world));
+const layoutP = createLayout(world, addEntity(world), {});
 layoutP.destroy();
 ```
 
@@ -445,7 +445,7 @@ console.log(flexPositions.size);
 Checks if an entity is a layout widget.
 
 ```typescript
-const layoutQ = createLayout(world, addEntity(world));
+const layoutQ = createLayout(world, addEntity(world), {});
 if (isLayout(world, layoutQ.eid)) {
   // Handle layout-specific logic
 }

--- a/docs/api/widgets/scrollableBox.md
+++ b/docs/api/widgets/scrollableBox.md
@@ -48,7 +48,7 @@ Creates a new ScrollableBox widget with the specified configuration.
 
 ```typescript
 // Basic scrollable box
-const scrollBoxA = createScrollableBox(world, addEntity(world));
+const scrollBoxA = createScrollableBox(world, addEntity(world), {});
 
 // Full configuration
 const styledScrollBox = createScrollableBox(world, addEntity(world), {
@@ -95,7 +95,7 @@ The scrollable box widget provides a chainable API for all operations.
 The underlying entity ID.
 
 ```typescript
-const sbA = createScrollableBox(world, addEntity(world));
+const sbA = createScrollableBox(world, addEntity(world), {});
 console.log(sbA.eid); // Entity ID number
 sbA.destroy();
 ```
@@ -107,7 +107,7 @@ sbA.destroy();
 Shows the scrollable box.
 
 ```typescript
-const sbB = createScrollableBox(world, addEntity(world));
+const sbB = createScrollableBox(world, addEntity(world), {});
 sbB.show();
 sbB.destroy();
 ```
@@ -119,7 +119,7 @@ sbB.destroy();
 Hides the scrollable box.
 
 ```typescript
-const sbC = createScrollableBox(world, addEntity(world));
+const sbC = createScrollableBox(world, addEntity(world), {});
 sbC.hide();
 sbC.destroy();
 ```
@@ -135,7 +135,7 @@ sbC.destroy();
 Sets the absolute position.
 
 ```typescript
-const sbD = createScrollableBox(world, addEntity(world));
+const sbD = createScrollableBox(world, addEntity(world), {});
 sbD.setPosition(20, 15);
 sbD.destroy();
 ```
@@ -147,7 +147,7 @@ sbD.destroy();
 Moves the scrollable box by a relative amount.
 
 ```typescript
-const sbE = createScrollableBox(world, addEntity(world));
+const sbE = createScrollableBox(world, addEntity(world), {});
 sbE.move(5, -3); // Move right 5, up 3
 sbE.destroy();
 ```
@@ -163,7 +163,7 @@ sbE.destroy();
 Sets the text content.
 
 ```typescript
-const sbF = createScrollableBox(world, addEntity(world));
+const sbF = createScrollableBox(world, addEntity(world), {});
 sbF.setContent('New content');
 sbF.destroy();
 ```
@@ -175,7 +175,7 @@ sbF.destroy();
 Gets the current text content.
 
 ```typescript
-const sbG = createScrollableBox(world, addEntity(world));
+const sbG = createScrollableBox(world, addEntity(world), {});
 const sbContent = sbG.getContent();
 console.log(sbContent);
 sbG.destroy();
@@ -256,7 +256,7 @@ sbL.destroy();
 Sets the total scrollable content size.
 
 ```typescript
-const sbM = createScrollableBox(world, addEntity(world));
+const sbM = createScrollableBox(world, addEntity(world), {});
 sbM.setScrollSize(200, 500);
 sbM.destroy();
 ```
@@ -268,7 +268,7 @@ sbM.destroy();
 Sets the viewport (visible area) size.
 
 ```typescript
-const sbN = createScrollableBox(world, addEntity(world));
+const sbN = createScrollableBox(world, addEntity(world), {});
 sbN.setViewport(80, 20);
 sbN.destroy();
 ```
@@ -321,7 +321,7 @@ sbQ.destroy();
 #### isAtTop / isAtBottom / isAtLeft / isAtRight
 
 ```typescript
-const sbR = createScrollableBox(world, addEntity(world));
+const sbR = createScrollableBox(world, addEntity(world), {});
 const atTop = sbR.isAtTop();
 const atBottom = sbR.isAtBottom();
 const atLeft = sbR.isAtLeft();
@@ -337,7 +337,7 @@ sbR.destroy();
 #### focus / blur / isFocused
 
 ```typescript
-const sbS = createScrollableBox(world, addEntity(world));
+const sbS = createScrollableBox(world, addEntity(world), {});
 sbS.focus();
 sbS.blur();
 const sbFocused = sbS.isFocused();
@@ -352,7 +352,7 @@ sbS.destroy();
 #### append / getChildren
 
 ```typescript
-const sbT = createScrollableBox(world, addEntity(world));
+const sbT = createScrollableBox(world, addEntity(world), {});
 const childEid = addEntity(world);
 sbT.append(childEid);
 const sbChildren = sbT.getChildren();
@@ -367,7 +367,7 @@ sbT.destroy();
 #### destroy
 
 ```typescript
-const sbU = createScrollableBox(world, addEntity(world));
+const sbU = createScrollableBox(world, addEntity(world), {});
 sbU.destroy();
 ```
 
@@ -378,7 +378,7 @@ sbU.destroy();
 ### isScrollableBox
 
 ```typescript
-const sbV = createScrollableBox(world, addEntity(world));
+const sbV = createScrollableBox(world, addEntity(world), {});
 if (isScrollableBox(world, sbV.eid)) {
   // Handle scrollable-box-specific logic
 }

--- a/docs/guides/cheat-sheet.md
+++ b/docs/guides/cheat-sheet.md
@@ -689,10 +689,10 @@ Use namespace imports from `'blecsd/components'`, `'blecsd/systems'`, etc. for:
 
 <!-- blecsd-doccheck:ignore -->
 ```typescript
-import { createWorld, createListEntity, addEntity } from 'blecsd/core';
+import { createWorld, addEntity } from 'blecsd/core';
 import { enableInput } from 'blecsd/components';
 import { renderSystem } from 'blecsd/systems';
-import { createPanel } from 'blecsd/widgets';
+import { createPanel, createList } from 'blecsd/widgets';
 import { createEventBus } from 'blecsd/core';
 
 // Setup
@@ -706,7 +706,7 @@ const panel = createPanel(world, {
 });
 
 const entity = addEntity(world);
-const list = createListEntity(world, entity, {
+const list = createList(world, entity, {
   items: [
     { label: 'Option 1', value: '1' },
     { label: 'Option 2', value: '2' }
@@ -728,7 +728,7 @@ render(world);
 <!-- blecsd-doccheck:ignore -->
 ```typescript
 // Create list with selection handling
-const list = createListEntity(world, entity, { items: [...] });
+const list = createList(world, entity, { items: [...] });
 
 const inputBus = createEventBus();
 inputBus.on('key', (e) => {


### PR DESCRIPTION
Addresses issue #1333

## Changes

### Phase 1: Fix all 34 signature warnings

- **scrollableBox.md** (15 warnings): Added missing 3rd config argument (`{}`) to all 2-arg `createScrollableBox(world, addEntity(world))` calls
- **layout.md** (17 warnings): Added missing 3rd config argument to all 2-arg `createLayout(world, addEntity(world))` calls  
- **cheat-sheet.md** (2 warnings): Replaced deprecated `createListEntity` with `createList`, updated imports from `blecsd/core` to `blecsd/widgets`

### Validation

- `pnpm doccheck` confirms **0 signature warnings** (down from 34)
- All widget factory calls now use the standardized 3-arg pattern: `createWidget(world, entity, config)`

### Note on pre-existing failures

The 11 test failures in `screenProcess.test.ts` and `counter-demo.example.test.ts` are pre-existing and unrelated to documentation changes (they involve missing `screenExec`/`screenSpawn` exports).