### PR TITLE
docs: Fix terminal/utils/guides — add missing pages, fix signatures & imports

### DIFF
--- a/docs/api/terminal/colors.md
+++ b/docs/api/terminal/colors.md
@@ -205,8 +205,7 @@ truecolorToHex(0xff0000);   // '#ff0000'
 ### Unified Parsing
 
 ```typescript
-import { parseColor } from 'blecsd/utils';
-import { toColor256, toTruecolor, toHex } from 'blecsd/terminal';
+import { parseColor, toColor256, toTruecolor, toHex } from 'blecsd/terminal';
 
 // Parse any color format to RGB
 parseColor('#ff0000');              // { r: 255, g: 0, b: 0 }

--- a/docs/api/terminal/custom-streams.md
+++ b/docs/api/terminal/custom-streams.md
@@ -1,0 +1,364 @@
+# Custom Streams
+
+Low-level API for integrating any Readable/Writable stream pair with the blECSd terminal system.
+
+## Overview
+
+The custom stream API allows you to use any Node.js stream as terminal input/output, enabling integration with telnet, SSH, websockets, or any custom transport layer. Each stream pair creates a `StreamSession` that provides a normalized interface for terminal I/O.
+
+**Use Cases:**
+- Building custom network protocols
+- Bridging to non-standard transports
+- Testing terminal applications with mock streams
+- Creating custom server implementations
+
+## Imports
+
+```typescript
+import {
+  createStreamSession,
+  writeToSession,
+  endSession,
+  type StreamSession,
+  type StreamSessionConfig,
+  type StreamDataHandler,
+  type StreamResizeHandler,
+  type StreamCloseHandler,
+} from 'blecsd/terminal';
+```
+
+## Basic Usage
+
+```typescript
+import { createStreamSession, writeToSession, endSession } from 'blecsd/terminal';
+import { PassThrough } from 'node:stream';
+
+const input = new PassThrough();
+const output = new PassThrough();
+
+const session = createStreamSession({
+  input,
+  output,
+  width: 80,
+  height: 24,
+});
+
+// Write terminal output to the session
+writeToSession(session, '\x1b[2J\x1b[HHello!');
+
+// Read input events
+session.onData((data) => console.log('Input:', data));
+
+// Clean up
+endSession(session);
+```
+
+## API
+
+### `createStreamSession(config)`
+
+Create a stream session from any Readable/Writable pair.
+
+**Parameters:**
+- `config: StreamSessionConfig` — Session configuration
+
+**Returns:** `StreamSession`
+
+**Example:**
+```typescript
+import { PassThrough } from 'node:stream';
+
+const session = createStreamSession({
+  input: new PassThrough(),
+  output: new PassThrough(),
+  width: 80,
+  height: 24,
+  termType: 'xterm-256color',
+  encoding: 'utf-8',
+});
+```
+
+### `writeToSession(session, data)`
+
+Write terminal output data to a stream session.
+
+**Parameters:**
+- `session: StreamSession` — The stream session
+- `data: string` — Terminal output data (ANSI sequences, text, etc.)
+
+**Returns:** `boolean` — Whether the write succeeded
+
+**Example:**
+```typescript
+// Write with ANSI codes
+writeToSession(session, '\x1b[2J\x1b[H'); // Clear screen and home
+writeToSession(session, '\x1b[1;32mGreen text\x1b[0m\r\n');
+
+// Write plain text
+writeToSession(session, 'Hello, world!\r\n');
+```
+
+### `endSession(session, reason?)`
+
+End a stream session, cleaning up resources.
+
+**Parameters:**
+- `session: StreamSession` — The stream session to end
+- `reason?: string` — Optional reason for ending (default: 'ended')
+
+**Example:**
+```typescript
+endSession(session, 'user disconnected');
+```
+
+## Types
+
+### `StreamSessionConfig`
+
+Configuration for creating a custom stream session.
+
+```typescript
+interface StreamSessionConfig {
+  /** Readable stream for input (e.g., socket, stdin, PassThrough) */
+  readonly input: Readable;
+  /** Writable stream for output (e.g., socket, stdout, PassThrough) */
+  readonly output: Writable;
+  /** Terminal width (default: 80) */
+  readonly width?: number;
+  /** Terminal height (default: 24) */
+  readonly height?: number;
+  /** Terminal type identifier (default: 'xterm') */
+  readonly termType?: string;
+  /** Encoding for input data (default: 'utf-8') */
+  readonly encoding?: BufferEncoding;
+}
+```
+
+### `StreamSession`
+
+A stream-based terminal session.
+
+```typescript
+interface StreamSession {
+  /** Unique session ID */
+  readonly id: string;
+  /** Terminal width */
+  width: number;
+  /** Terminal height */
+  height: number;
+  /** Terminal type */
+  readonly termType: string;
+  /** Whether the session is active */
+  active: boolean;
+  /** The underlying input stream */
+  readonly input: Readable;
+  /** The underlying output stream */
+  readonly output: Writable;
+  /** Register a data handler */
+  onData(handler: StreamDataHandler): () => void;
+  /** Register a resize handler */
+  onResize(handler: StreamResizeHandler): () => void;
+  /** Register a close handler */
+  onClose(handler: StreamCloseHandler): () => void;
+  /** Emit a resize event (used by transport layers like telnet NAWS) */
+  emitResize(width: number, height: number): void;
+}
+```
+
+### Handler Types
+
+```typescript
+/** Data handler callback */
+type StreamDataHandler = (data: string) => void;
+
+/** Resize handler callback */
+type StreamResizeHandler = (width: number, height: number) => void;
+
+/** Close handler callback */
+type StreamCloseHandler = (reason: string) => void;
+```
+
+## Event Handling
+
+### Data Events
+
+Handle incoming terminal input:
+
+```typescript
+const unsubscribe = session.onData((data) => {
+  console.log('Received:', data);
+  
+  // Echo back
+  writeToSession(session, data);
+  
+  // Check for Ctrl+C
+  if (data === '\x03') {
+    endSession(session, 'Ctrl+C');
+  }
+});
+
+// Later: unsubscribe
+unsubscribe();
+```
+
+### Resize Events
+
+Handle terminal window size changes:
+
+```typescript
+session.onResize((width, height) => {
+  console.log(`Terminal resized to ${width}x${height}`);
+  
+  // Redraw your UI with new dimensions
+  redrawUI(width, height);
+});
+
+// Manually trigger resize (for protocol implementations)
+session.emitResize(120, 30);
+```
+
+### Close Events
+
+Handle session termination:
+
+```typescript
+session.onClose((reason) => {
+  console.log(`Session closed: ${reason}`);
+  
+  // Cleanup application state
+  cleanup();
+});
+```
+
+## Complete Example: Echo Server
+
+```typescript
+import { createStreamSession, writeToSession, endSession } from 'blecsd/terminal';
+import { createServer } from 'node:net';
+import { PassThrough } from 'node:stream';
+
+const server = createServer((socket) => {
+  const inputStream = new PassThrough();
+  const outputStream = new PassThrough();
+
+  const session = createStreamSession({
+    input: inputStream,
+    output: outputStream,
+    width: 80,
+    height: 24,
+    termType: 'xterm',
+  });
+
+  // Forward socket data to input stream
+  socket.on('data', (data) => inputStream.write(data));
+
+  // Forward output stream to socket
+  outputStream.on('data', (chunk) => socket.write(chunk));
+
+  // Handle disconnection
+  socket.on('close', () => {
+    endSession(session, 'socket closed');
+  });
+
+  // Welcome message
+  writeToSession(session, '\x1b[2J\x1b[H'); // Clear screen
+  writeToSession(session, 'Welcome to Echo Server!\r\n\r\n');
+  writeToSession(session, '> ');
+
+  // Echo handler
+  session.onData((data) => {
+    if (data === '\x03') { // Ctrl+C
+      writeToSession(session, '\r\nGoodbye!\r\n');
+      socket.end();
+      return;
+    }
+
+    if (data === '\r' || data === '\n') {
+      writeToSession(session, '\r\n> ');
+    } else {
+      writeToSession(session, data); // Echo
+    }
+  });
+
+  session.onResize((width, height) => {
+    console.log(`Client resized: ${width}x${height}`);
+  });
+
+  session.onClose((reason) => {
+    console.log(`Session ended: ${reason}`);
+  });
+});
+
+server.listen(3000, () => {
+  console.log('Echo server listening on port 3000');
+});
+```
+
+## Integration with Transport Protocols
+
+### Telnet Example
+
+For telnet integration, use the higher-level [Telnet Server](./telnet-server.md) API, which handles protocol negotiation automatically.
+
+### WebSocket Example
+
+```typescript
+import { WebSocketServer } from 'ws';
+import { createStreamSession, writeToSession } from 'blecsd/terminal';
+import { PassThrough } from 'node:stream';
+
+const wss = new WebSocketServer({ port: 8080 });
+
+wss.on('connection', (ws) => {
+  const input = new PassThrough();
+  const output = new PassThrough();
+
+  const session = createStreamSession({ input, output });
+
+  // WebSocket → input stream
+  ws.on('message', (data) => input.write(data.toString()));
+
+  // Output stream → WebSocket
+  output.on('data', (chunk) => ws.send(chunk.toString()));
+
+  // Cleanup
+  ws.on('close', () => endSession(session, 'websocket closed'));
+
+  // App logic
+  writeToSession(session, 'Connected via WebSocket!\r\n');
+});
+```
+
+## Testing with Mock Streams
+
+```typescript
+import { createStreamSession, writeToSession } from 'blecsd/terminal';
+import { PassThrough } from 'node:stream';
+
+// Create mock streams
+const input = new PassThrough();
+const output = new PassThrough();
+
+const session = createStreamSession({ input, output });
+
+// Capture output
+const outputData: string[] = [];
+output.on('data', (chunk) => outputData.push(chunk.toString()));
+
+// Simulate input
+session.onData((data) => {
+  writeToSession(session, `Echo: ${data}\r\n`);
+});
+
+input.write('Hello');
+input.write('\r\n');
+
+// Assert
+console.log(outputData); // ['Echo: Hello\r\n']
+```
+
+## See Also
+
+- [Telnet Server](./telnet-server.md) — Telnet protocol with automatic negotiation
+- [SSH Server](./ssh-server.md) — SSH protocol with authentication
+- [Server App](./server-app.md) — Higher-level server application framework

--- a/docs/api/terminal/process.md
+++ b/docs/api/terminal/process.md
@@ -1,0 +1,444 @@
+# Process Utilities
+
+Process spawning and execution utilities with automatic terminal state management.
+
+## Overview
+
+The process utilities provide functions for spawning child processes, executing shell commands, and interacting with external editors. All functions automatically manage terminal state (alternate buffer, mouse tracking, raw mode) to ensure clean transitions between your terminal application and external processes.
+
+**Key Features:**
+- Automatic terminal state save/restore
+- Support for alternate buffer and mouse tracking
+- Async and sync execution modes
+- External editor integration
+- Shell command utilities
+
+## Imports
+
+```typescript
+import {
+  spawn,
+  exec,
+  execSync,
+  readEditor,
+  getDefaultEditor,
+  processUtils,
+  type SpawnOptions,
+  type ExecOptions,
+  type ExecResult,
+  type EditorOptions,
+} from 'blecsd/terminal';
+
+// Or use the process namespace (note: shadows Node.js global `process`)
+import { process as proc } from 'blecsd/terminal';
+proc.spawn('ls', ['-la']);
+```
+
+## API
+
+### `spawn(file, args?, options?)`
+
+Spawn a child process with terminal state management.
+
+Automatically handles:
+1. Exiting alternate screen buffer (if active)
+2. Showing the cursor
+3. Disabling mouse tracking (if enabled)
+4. Exiting raw mode
+
+When the process exits, the terminal state is restored.
+
+**Parameters:**
+- `file: string` — Command to spawn
+- `args?: string[]` — Arguments for the command (default: `[]`)
+- `options?: SpawnOptions` — Spawn options including terminal state
+
+**Returns:** `ChildProcess` — The spawned child process
+
+**Example:**
+```typescript
+import { spawn } from 'blecsd/terminal';
+
+// Spawn a shell command
+const child = spawn('ls', ['-la'], {
+  isAlternateBuffer: true,
+  isMouseEnabled: true,
+  onExit: (code, signal) => {
+    console.log('Process exited with code:', code);
+  },
+});
+```
+
+### `exec(file, args?, options?)`
+
+Execute a command and wait for it to complete.
+
+This is a Promise-based wrapper around `spawn` that collects and returns the stdout/stderr of the process.
+
+**Parameters:**
+- `file: string` — Command to execute
+- `args?: string[]` — Arguments for the command (default: `[]`)
+- `options?: ExecOptions` — Exec options
+
+**Returns:** `Promise<ExecResult>` — Promise resolving to the exec result
+
+**Example:**
+```typescript
+import { exec } from 'blecsd/terminal';
+
+const result = await exec('git', ['status'], {
+  isAlternateBuffer: true,
+  timeout: 5000, // 5 second timeout
+});
+console.log(result.stdout);
+console.log(result.stderr);
+console.log('Exit code:', result.exitCode);
+```
+
+### `execSync(file, args?, options?)`
+
+Execute a command synchronously.
+
+**Warning:** This blocks the event loop until the command completes. Use sparingly.
+
+**Parameters:**
+- `file: string` — Command to execute
+- `args?: string[]` — Arguments for the command (default: `[]`)
+- `options?: Omit<SpawnOptions, 'onExit'>` — Spawn options (excluding `onExit`)
+
+**Returns:** `ExecResult` — The exec result
+
+**Example:**
+```typescript
+import { execSync } from 'blecsd/terminal';
+
+const result = execSync('date');
+console.log(result.stdout);
+```
+
+### `readEditor(options?)`
+
+Open an external editor and return the edited content.
+
+This function:
+1. Creates a temporary file with the initial content
+2. Opens the editor (uses `EDITOR`/`VISUAL` env var or specified editor)
+3. Waits for the editor to close
+4. Returns the edited content
+5. Cleans up the temporary file
+
+**Parameters:**
+- `options?: EditorOptions` — Editor options
+
+**Returns:** `Promise<string>` — Promise resolving to the edited content
+
+**Example:**
+```typescript
+import { readEditor } from 'blecsd/terminal';
+
+// Open editor with initial content
+const edited = await readEditor({
+  content: 'Initial content to edit',
+  extension: '.md',
+  isAlternateBuffer: true,
+});
+console.log('Edited content:', edited);
+
+// Use a specific editor
+const edited2 = await readEditor({
+  editor: 'nano',
+  content: 'Edit me!',
+});
+```
+
+### `getDefaultEditor()`
+
+Get the default editor command.
+
+Checks `EDITOR`, then `VISUAL` environment variables, then falls back to `'vi'`.
+
+**Returns:** `string` — The editor command
+
+**Example:**
+```typescript
+import { getDefaultEditor } from 'blecsd/terminal';
+
+const editor = getDefaultEditor();
+console.log('Default editor:', editor);
+// Example output: "vim", "nano", "code --wait", etc.
+```
+
+### `processUtils`
+
+Utilities namespace for common process operations.
+
+#### `processUtils.commandExists(command)`
+
+Check if a command exists in PATH.
+
+**Parameters:**
+- `command: string` — Command to check
+
+**Returns:** `boolean` — True if command exists
+
+**Example:**
+```typescript
+import { processUtils } from 'blecsd/terminal';
+
+if (processUtils.commandExists('git')) {
+  console.log('Git is installed');
+}
+```
+
+#### `processUtils.getShell()`
+
+Get the shell command for the current platform.
+
+**Returns:** `{ shell: string; args: string[] }`
+
+**Example:**
+```typescript
+import { processUtils, spawn } from 'blecsd/terminal';
+
+const { shell, args } = processUtils.getShell();
+spawn(shell, [...args, 'echo hello']);
+```
+
+#### `processUtils.shellEscape(str)`
+
+Escape a string for use in shell commands.
+
+**Parameters:**
+- `str: string` — String to escape
+
+**Returns:** `string` — Escaped string
+
+**Example:**
+```typescript
+import { processUtils } from 'blecsd/terminal';
+
+const filename = 'file with spaces.txt';
+const escaped = processUtils.shellEscape(filename);
+// On Unix: 'file with spaces.txt'
+// On Windows: "file with spaces.txt"
+```
+
+## Types
+
+### `SpawnOptions`
+
+Options for spawning a process.
+
+```typescript
+interface SpawnOptions extends SpawnOptionsWithoutStdio {
+  /** Output stream for terminal restoration (default: process.stdout) */
+  output?: Writable;
+  /** Input stream for terminal state (default: process.stdin) */
+  input?: NodeJS.ReadStream;
+  /** Whether the terminal is in alternate buffer mode (default: false) */
+  isAlternateBuffer?: boolean;
+  /** Whether mouse tracking is enabled (default: false) */
+  isMouseEnabled?: boolean;
+  /** Callback when process exits */
+  onExit?: (code: number | null, signal: NodeJS.Signals | null) => void;
+}
+```
+
+### `ExecOptions`
+
+Options for executing a process and waiting.
+
+```typescript
+interface ExecOptions extends SpawnOptions {
+  /** Timeout in milliseconds (default: no timeout) */
+  timeout?: number;
+  /** Maximum buffer size for output (default: 10MB) */
+  maxBuffer?: number;
+  /** Encoding for output (default: 'utf8') */
+  encoding?: BufferEncoding;
+}
+```
+
+### `ExecResult`
+
+Result of an exec operation.
+
+```typescript
+interface ExecResult {
+  /** Standard output */
+  stdout: string;
+  /** Standard error */
+  stderr: string;
+  /** Exit code (null if killed by signal) */
+  exitCode: number | null;
+  /** Signal that killed the process (null if exited normally) */
+  signal: NodeJS.Signals | null;
+}
+```
+
+### `EditorOptions`
+
+Options for opening an external editor.
+
+```typescript
+interface EditorOptions {
+  /** Initial content to edit */
+  content?: string;
+  /** File extension for temp file (default: '.txt') */
+  extension?: string;
+  /** Editor command (default: EDITOR or VISUAL env var, then 'vi') */
+  editor?: string;
+  /** Output stream for terminal restoration (default: process.stdout) */
+  output?: Writable;
+  /** Input stream for terminal state (default: process.stdin) */
+  input?: NodeJS.ReadStream;
+  /** Whether the terminal is in alternate buffer mode (default: false) */
+  isAlternateBuffer?: boolean;
+  /** Whether mouse tracking is enabled (default: false) */
+  isMouseEnabled?: boolean;
+}
+```
+
+## Complete Examples
+
+### Running Git Commands
+
+```typescript
+import { exec } from 'blecsd/terminal';
+
+async function checkGitStatus() {
+  const result = await exec('git', ['status', '--short'], {
+    isAlternateBuffer: true,
+  });
+  
+  if (result.exitCode === 0) {
+    console.log('Git status:', result.stdout);
+  } else {
+    console.error('Git error:', result.stderr);
+  }
+}
+```
+
+### Interactive Editor Workflow
+
+```typescript
+import { readEditor, getDefaultEditor } from 'blecsd/terminal';
+
+async function editCommitMessage() {
+  const editor = getDefaultEditor();
+  console.log(`Using editor: ${editor}`);
+  
+  const message = await readEditor({
+    content: '# Enter commit message\n\n',
+    extension: '.txt',
+    editor,
+    isAlternateBuffer: true,
+  });
+  
+  // Filter out comment lines
+  const finalMessage = message
+    .split('\n')
+    .filter(line => !line.startsWith('#'))
+    .join('\n')
+    .trim();
+  
+  if (!finalMessage) {
+    console.log('Commit message empty, aborting');
+  } else {
+    console.log('Commit message:', finalMessage);
+  }
+}
+```
+
+### Shell Command with Timeout
+
+```typescript
+import { exec } from 'blecsd/terminal';
+
+async function runWithTimeout() {
+  try {
+    const result = await exec('long-running-command', [], {
+      timeout: 5000, // 5 seconds
+      maxBuffer: 1024 * 1024, // 1MB
+    });
+    console.log('Command completed:', result.stdout);
+  } catch (err) {
+    if (err.message.includes('timeout')) {
+      console.error('Command timed out');
+    } else {
+      console.error('Command failed:', err);
+    }
+  }
+}
+```
+
+### Spawning a Long-Running Process
+
+```typescript
+import { spawn } from 'blecsd/terminal';
+
+function tailLogFile() {
+  const child = spawn('tail', ['-f', '/var/log/app.log'], {
+    isAlternateBuffer: true,
+    onExit: (code, signal) => {
+      console.log(`tail exited: code=${code}, signal=${signal}`);
+    },
+  });
+  
+  // Kill on Ctrl+C
+  process.on('SIGINT', () => {
+    child.kill('SIGTERM');
+  });
+}
+```
+
+## Namespace Usage
+
+The `process` namespace provides the same functions as a single import:
+
+```typescript
+import { process as proc } from 'blecsd/terminal';
+
+// Execute synchronously
+const result = proc.execSync('ls', ['-la']);
+console.log(result.stdout);
+
+// Execute asynchronously
+const asyncResult = await proc.exec('git', ['status']);
+console.log(asyncResult.stdout);
+
+// Spawn process
+const child = proc.spawn('tail', ['-f', 'log.txt']);
+
+// Open editor
+const editor = proc.getDefaultEditor();
+const text = await proc.readEditor({
+  content: 'Initial content',
+  editor,
+  extension: '.md',
+});
+```
+
+**Note:** Importing the `process` namespace will shadow the Node.js global `process`. Use an alias (`import { process as proc }`) if you need both.
+
+## Terminal State Management
+
+All process functions automatically manage terminal state transitions:
+
+**Before spawning:**
+1. Exit alternate buffer (if `isAlternateBuffer: true`)
+2. Show cursor
+3. Disable mouse tracking (if `isMouseEnabled: true`)
+4. Exit raw mode (if `input.setRawMode` was enabled)
+
+**After process exits:**
+1. Re-enter alternate buffer (if it was active)
+2. Re-enable mouse tracking (if it was enabled)
+3. Re-enter raw mode (if it was enabled)
+
+This ensures clean transitions without manual cleanup code.
+
+## See Also
+
+- [Server App](./server-app.md) — Higher-level application framework
+- [ANSI Codes](../ansi.md) — Terminal escape sequences

--- a/docs/api/terminal/server-app.md
+++ b/docs/api/terminal/server-app.md
@@ -1,0 +1,496 @@
+# Server App
+
+Unified server application factory for creating TCP, Telnet, and SSH servers.
+
+## Overview
+
+The `createServerApp` function provides a single entry point for creating network-accessible terminal applications. Each client connection receives its own `StreamSession` for integration with the blECSd terminal system.
+
+**Supported Modes:**
+- **TCP** — Raw TCP socket connections (no protocol)
+- **Telnet** — Telnet protocol with NAWS and TTYPE negotiation
+- **SSH** — SSH protocol with public key or password authentication
+
+## Imports
+
+```typescript
+import {
+  createServerApp,
+  type ServerApp,
+  type ServerAppConfig,
+  type TCPServerAppConfig,
+  type TelnetServerAppConfig,
+  type SSHServerAppConfig,
+} from 'blecsd/terminal';
+```
+
+## Basic Usage
+
+```typescript
+import { createServerApp } from 'blecsd/terminal';
+import { writeToSession } from 'blecsd/terminal';
+
+// Create a telnet server
+const app = createServerApp({
+  mode: 'telnet',
+  port: 2323,
+  onSession: (session) => {
+    writeToSession(session, 'Welcome to blECSd!\r\n');
+  },
+});
+
+// Start the server
+await app.start();
+console.log(`Listening on port ${app.port}`);
+
+// Later: stop the server
+await app.stop();
+```
+
+## API
+
+### `createServerApp(config)`
+
+Create a server app for the specified mode.
+
+**Parameters:**
+- `config: ServerAppConfig` — Server configuration with mode and mode-specific options
+
+**Returns:** `ServerApp` — A server instance with start/stop methods
+
+**Example:**
+```typescript
+// TCP mode
+const tcp = createServerApp({
+  mode: 'tcp',
+  port: 3000,
+  onSession: (session) => {
+    // Handle session
+  },
+});
+
+// Telnet mode (with NAWS + TTYPE negotiation)
+const telnet = createServerApp({
+  mode: 'telnet',
+  port: 2323,
+  onSession: (session) => {
+    // Handle session
+  },
+});
+
+// SSH mode (with key auth)
+const ssh = createServerApp({
+  mode: 'ssh',
+  port: 2222,
+  hostKey: readFileSync('host_key'),
+  authorizedKeys: [
+    { key: readFileSync('user.pub') },
+  ],
+  onSession: (session, username) => {
+    console.log(`User ${username} connected`);
+    // Handle session
+  },
+});
+```
+
+## Types
+
+### `ServerApp`
+
+Running server app instance.
+
+```typescript
+interface ServerApp {
+  /** Server mode */
+  readonly mode: ServerMode;
+  /** Port the server is listening on */
+  readonly port: number;
+  /** Whether the server is running */
+  readonly running: boolean;
+  /** Number of active client sessions */
+  readonly clientCount: number;
+  /** Active sessions */
+  readonly sessions: ReadonlyMap<string, StreamSession>;
+  /** Start the server */
+  start(): Promise<void>;
+  /** Stop the server and disconnect all clients */
+  stop(): Promise<void>;
+}
+```
+
+### `TCPServerAppConfig`
+
+TCP-specific configuration.
+
+```typescript
+interface TCPServerAppConfig {
+  readonly mode: 'tcp';
+  /** TCP port to listen on */
+  readonly port: number;
+  /** Host to bind to (default: '0.0.0.0') */
+  readonly host?: string;
+  /** Maximum concurrent clients (default: 10) */
+  readonly maxClients?: number;
+  /** Called when a new client session is established */
+  readonly onSession?: (session: StreamSession) => void;
+  /** Called when a session ends */
+  readonly onSessionEnd?: (sessionId: string, reason: string) => void;
+}
+```
+
+### `TelnetServerAppConfig`
+
+Telnet-specific configuration.
+
+```typescript
+interface TelnetServerAppConfig {
+  readonly mode: 'telnet';
+  /** TCP port to listen on */
+  readonly port: number;
+  /** Host to bind to (default: '0.0.0.0') */
+  readonly host?: string;
+  /** Maximum concurrent clients (default: 10) */
+  readonly maxClients?: number;
+  /** Called when a new client session is established */
+  readonly onSession?: (session: StreamSession) => void;
+  /** Called when a session ends */
+  readonly onSessionEnd?: (sessionId: string, reason: string) => void;
+}
+```
+
+### `SSHServerAppConfig`
+
+SSH-specific configuration.
+
+```typescript
+interface SSHServerAppConfig {
+  readonly mode: 'ssh';
+  /** TCP port to listen on */
+  readonly port: number;
+  /** Host to bind to (default: '0.0.0.0') */
+  readonly host?: string;
+  /** Host private key (PEM format) */
+  readonly hostKey: Buffer | string;
+  /** Authorized public keys */
+  readonly authorizedKeys?: SSHAuthorizedKey[];
+  /** Allow password authentication */
+  readonly allowPassword?: boolean;
+  /** Password validation function */
+  readonly validatePassword?: (username: string, password: string) => boolean;
+  /** Maximum concurrent clients (default: 10) */
+  readonly maxClients?: number;
+  /** Called when a new client session is established */
+  readonly onSession?: (session: StreamSession, username: string) => void;
+  /** Called when a session ends */
+  readonly onSessionEnd?: (sessionId: string, reason: string) => void;
+  /** Server identification string */
+  readonly serverIdent?: string;
+}
+```
+
+## Server Modes
+
+### TCP Mode
+
+Raw TCP socket connections with no protocol negotiation.
+
+```typescript
+const app = createServerApp({
+  mode: 'tcp',
+  port: 3000,
+  host: '127.0.0.1',
+  maxClients: 5,
+  onSession: (session) => {
+    writeToSession(session, 'Connected via TCP\r\n');
+    
+    session.onData((data) => {
+      writeToSession(session, `Echo: ${data}`);
+    });
+  },
+  onSessionEnd: (sessionId, reason) => {
+    console.log(`Session ${sessionId} ended: ${reason}`);
+  },
+});
+
+await app.start();
+```
+
+**Use Cases:**
+- Custom binary protocols
+- Simple text-based protocols
+- Testing and debugging
+
+### Telnet Mode
+
+Telnet protocol with automatic negotiation for window size and terminal type.
+
+```typescript
+const app = createServerApp({
+  mode: 'telnet',
+  port: 2323,
+  onSession: (session) => {
+    writeToSession(session, '\x1b[2J\x1b[H'); // Clear screen
+    writeToSession(session, 'Welcome to Telnet Server!\r\n');
+    
+    session.onResize((width, height) => {
+      console.log(`Terminal resized: ${width}x${height}`);
+    });
+    
+    session.onData((data) => {
+      if (data === '\x03') { // Ctrl+C
+        writeToSession(session, '\r\nGoodbye!\r\n');
+        session.input.end();
+      } else {
+        writeToSession(session, data); // Echo
+      }
+    });
+  },
+});
+
+await app.start();
+console.log('Telnet server on port 2323');
+```
+
+**Protocol Support:**
+- NAWS (Negotiate About Window Size)
+- TTYPE (Terminal Type)
+- SGA (Suppress Go Ahead)
+- ECHO
+
+**Use Cases:**
+- Interactive terminal applications
+- MUD/text games
+- Remote administration tools
+
+### SSH Mode
+
+SSH protocol with public key or password authentication.
+
+```typescript
+import { readFileSync } from 'node:fs';
+
+const app = createServerApp({
+  mode: 'ssh',
+  port: 2222,
+  hostKey: readFileSync('./host_key'),
+  authorizedKeys: [
+    { key: readFileSync('./keys/admin.pub'), comment: 'admin' },
+    { key: readFileSync('./keys/user.pub'), comment: 'user' },
+  ],
+  onSession: (session, username) => {
+    writeToSession(session, `Welcome, ${username}!\r\n\r\n`);
+    
+    session.onData((data) => {
+      // Handle user input
+      writeToSession(session, data);
+    });
+  },
+  onSessionEnd: (sessionId, reason) => {
+    console.log(`Session ${sessionId} ended: ${reason}`);
+  },
+});
+
+await app.start();
+console.log('SSH server on port 2222');
+```
+
+**Authentication Options:**
+- Public key (most secure)
+- Password (requires `allowPassword: true` and `validatePassword`)
+- No auth (development only — omit both options)
+
+**Use Cases:**
+- Secure remote access
+- Production deployments
+- Multi-user systems
+
+## Complete Example: Multi-Protocol Server
+
+```typescript
+import { createServerApp, writeToSession } from 'blecsd/terminal';
+import { readFileSync } from 'node:fs';
+
+// Session handler (shared across modes)
+function handleSession(session: StreamSession, info?: string) {
+  const greeting = info ? `Welcome, ${info}!` : 'Welcome!';
+  writeToSession(session, '\x1b[2J\x1b[H'); // Clear screen
+  writeToSession(session, `${greeting}\r\n\r\n`);
+  writeToSession(session, '> ');
+
+  session.onData((data) => {
+    const input = data.toString();
+    
+    if (input === '\x03') { // Ctrl+C
+      writeToSession(session, '\r\nGoodbye!\r\n');
+      session.input.end();
+      return;
+    }
+    
+    if (input === '\r' || input === '\n') {
+      writeToSession(session, '\r\n> ');
+    } else {
+      writeToSession(session, input); // Echo
+    }
+  });
+
+  session.onResize((width, height) => {
+    console.log(`Session ${session.id} resized: ${width}x${height}`);
+  });
+
+  session.onClose((reason) => {
+    console.log(`Session ${session.id} closed: ${reason}`);
+  });
+}
+
+// Create multiple servers
+const servers = [
+  // TCP on port 3000
+  createServerApp({
+    mode: 'tcp',
+    port: 3000,
+    onSession: handleSession,
+  }),
+
+  // Telnet on port 2323
+  createServerApp({
+    mode: 'telnet',
+    port: 2323,
+    onSession: handleSession,
+  }),
+
+  // SSH on port 2222
+  createServerApp({
+    mode: 'ssh',
+    port: 2222,
+    hostKey: readFileSync('./host_key'),
+    authorizedKeys: [
+      { key: readFileSync('./keys/admin.pub') },
+    ],
+    onSession: (session, username) => handleSession(session, username),
+  }),
+];
+
+// Start all servers
+await Promise.all(servers.map(s => s.start()));
+
+console.log('All servers started:');
+servers.forEach(s => {
+  console.log(`- ${s.mode.toUpperCase()} on port ${s.port}`);
+});
+
+// Graceful shutdown
+process.on('SIGINT', async () => {
+  console.log('\nShutting down...');
+  await Promise.all(servers.map(s => s.stop()));
+  process.exit(0);
+});
+```
+
+## Server Management
+
+### Starting a Server
+
+```typescript
+const app = createServerApp({ mode: 'tcp', port: 3000, onSession: () => {} });
+
+try {
+  await app.start();
+  console.log(`Server listening on port ${app.port}`);
+} catch (err) {
+  console.error('Failed to start server:', err);
+}
+```
+
+### Stopping a Server
+
+```typescript
+await app.stop();
+console.log('Server stopped');
+```
+
+### Monitoring Client Count
+
+```typescript
+setInterval(() => {
+  console.log(`Active clients: ${app.clientCount}`);
+}, 5000);
+```
+
+### Accessing Sessions
+
+```typescript
+for (const [id, session] of app.sessions) {
+  console.log(`Session ${id}: ${session.width}x${session.height}`);
+}
+```
+
+## SSH Server Setup
+
+### Generate Host Key
+
+```bash
+ssh-keygen -t rsa -b 4096 -f ./host_key -N ""
+```
+
+### Generate User Keys
+
+```bash
+ssh-keygen -t rsa -b 4096 -f ./keys/admin -N ""
+```
+
+### Password Authentication
+
+```typescript
+const app = createServerApp({
+  mode: 'ssh',
+  port: 2222,
+  hostKey: readFileSync('./host_key'),
+  allowPassword: true,
+  validatePassword: (username, password) => {
+    const users = {
+      admin: 'secret123',
+      guest: 'guest',
+    };
+    return users[username] === password;
+  },
+  onSession: (session, username) => {
+    writeToSession(session, `Logged in as ${username}\r\n`);
+  },
+});
+```
+
+## Error Handling
+
+```typescript
+const app = createServerApp({
+  mode: 'telnet',
+  port: 2323,
+  onSession: (session) => {
+    try {
+      writeToSession(session, 'Welcome!\r\n');
+    } catch (err) {
+      console.error('Session error:', err);
+    }
+  },
+  onSessionEnd: (sessionId, reason) => {
+    console.log(`Session ${sessionId} ended: ${reason}`);
+  },
+});
+
+try {
+  await app.start();
+} catch (err) {
+  if (err.code === 'EADDRINUSE') {
+    console.error('Port already in use');
+  } else {
+    console.error('Server error:', err);
+  }
+}
+```
+
+## See Also
+
+- [Telnet Server](./telnet-server.md) — Low-level telnet server API
+- [SSH Server](./ssh-server.md) — Low-level SSH server API
+- [Custom Streams](./custom-streams.md) — Stream session API
+- [Process Utilities](./process.md) — Spawning external processes

--- a/docs/api/terminal/ssh-server.md
+++ b/docs/api/terminal/ssh-server.md
@@ -1,0 +1,338 @@
+# SSH Server
+
+Provides an SSH server for secure remote terminal access to blECSd applications.
+
+## Overview
+
+The SSH server uses the `ssh2` package to provide authenticated, encrypted access to your blECSd terminal applications. Each connecting client receives its own `StreamSession` with proper PTY dimensions and supports both key-based and password authentication.
+
+**Features:**
+- Public key authentication
+- Password authentication (optional)
+- PTY (pseudo-terminal) support with window resize
+- Secure encrypted connections
+- Multi-client support
+
+## Prerequisites
+
+The `ssh2` package is required as a peer dependency:
+
+```bash
+npm install ssh2
+```
+
+## Imports
+
+```typescript
+import {
+  createSSHServer,
+  startSSHServer,
+  stopSSHServer,
+  getSSHClientCount,
+  type SSHServerConfig,
+  type SSHServerState,
+  type SSHAuthorizedKey,
+} from 'blecsd/terminal';
+```
+
+## Basic Usage
+
+```typescript
+import { createSSHServer, startSSHServer, stopSSHServer } from 'blecsd/terminal';
+import { writeToSession } from 'blecsd/terminal';
+import { readFileSync } from 'node:fs';
+
+const server = createSSHServer({
+  port: 2222,
+  hostKey: readFileSync('/path/to/host_key'),
+  onSession: (session, username) => {
+    writeToSession(session, `Welcome via SSH, ${username}!\r\n`);
+  },
+});
+
+await startSSHServer(server);
+```
+
+## API
+
+### `createSSHServer(config)`
+
+Create an SSH server.
+
+**Parameters:**
+- `config: SSHServerConfig` — Server configuration
+
+**Returns:** `SSHServerState`
+
+**Example:**
+```typescript
+const server = createSSHServer({
+  port: 2222,
+  host: '0.0.0.0',
+  hostKey: readFileSync('./host_key'),
+  authorizedKeys: [
+    { key: readFileSync('./authorized_keys/user1.pub') },
+    { key: readFileSync('./authorized_keys/user2.pub'), comment: 'user2@example.com' },
+  ],
+  maxClients: 10,
+  onSession: (session, username) => {
+    console.log(`User ${username} connected`);
+    // Handle session
+  },
+  onSessionEnd: (sessionId, reason) => {
+    console.log(`Session ${sessionId} ended: ${reason}`);
+  },
+  serverIdent: 'MyApp_SSH_v1',
+});
+```
+
+### `startSSHServer(state)`
+
+Start the SSH server, accepting connections.
+
+**Parameters:**
+- `state: SSHServerState` — Server state returned from `createSSHServer`
+
+**Returns:** `Promise<void>` — Resolves when the server is listening
+
+**Throws:** `Error` if the `ssh2` package is not installed
+
+**Example:**
+```typescript
+try {
+  await startSSHServer(server);
+  console.log('SSH server listening on port 2222');
+} catch (err) {
+  console.error('Failed to start SSH server:', err);
+}
+```
+
+### `stopSSHServer(state)`
+
+Stop the SSH server and disconnect all clients.
+
+**Parameters:**
+- `state: SSHServerState` — Server state
+
+**Returns:** `Promise<void>` — Resolves when the server has stopped
+
+**Example:**
+```typescript
+await stopSSHServer(server);
+console.log('SSH server stopped');
+```
+
+### `getSSHClientCount(state)`
+
+Get the number of active SSH sessions.
+
+**Parameters:**
+- `state: SSHServerState` — Server state
+
+**Returns:** `number`
+
+**Example:**
+```typescript
+const activeClients = getSSHClientCount(server);
+console.log(`Active SSH clients: ${activeClients}`);
+```
+
+## Types
+
+### `SSHServerConfig`
+
+Configuration for the SSH server.
+
+```typescript
+interface SSHServerConfig {
+  /** TCP port to listen on */
+  readonly port: number;
+  /** Host to bind to (default: '0.0.0.0') */
+  readonly host?: string;
+  /** Host private key (PEM format) */
+  readonly hostKey: Buffer | string;
+  /** Authorized public keys for authentication */
+  readonly authorizedKeys?: readonly SSHAuthorizedKey[];
+  /** Allow password authentication (default: false) */
+  readonly allowPassword?: boolean;
+  /** Password validation function (required if allowPassword is true) */
+  readonly validatePassword?: (username: string, password: string) => boolean;
+  /** Maximum concurrent clients (default: 10) */
+  readonly maxClients?: number;
+  /** Called when a new client session is established */
+  readonly onSession?: (session: StreamSession, username: string) => void;
+  /** Called when a session ends */
+  readonly onSessionEnd?: (sessionId: string, reason: string) => void;
+  /** Server identification string (default: 'blECSd_SSH') */
+  readonly serverIdent?: string;
+}
+```
+
+### `SSHServerState`
+
+SSH server state object.
+
+```typescript
+interface SSHServerState {
+  /** Server configuration */
+  readonly config: SSHServerConfig;
+  /** Whether the server is listening */
+  running: boolean;
+  /** Active sessions */
+  readonly sessions: Map<string, StreamSession>;
+  /** Internal server reference */
+  _server: SSH2ServerInstance | null;
+}
+```
+
+### `SSHAuthorizedKey`
+
+Authorized key entry for SSH authentication.
+
+```typescript
+interface SSHAuthorizedKey {
+  /** The public key data (OpenSSH format or raw Buffer) */
+  readonly key: Buffer | string;
+  /** Optional comment/username associated with the key */
+  readonly comment?: string;
+}
+```
+
+## Authentication
+
+### Public Key Authentication
+
+Load authorized keys from files:
+
+```typescript
+import { readFileSync } from 'node:fs';
+
+const server = createSSHServer({
+  port: 2222,
+  hostKey: readFileSync('./host_key'),
+  authorizedKeys: [
+    { key: readFileSync('./keys/alice.pub'), comment: 'alice' },
+    { key: readFileSync('./keys/bob.pub'), comment: 'bob' },
+  ],
+  onSession: (session, username) => {
+    writeToSession(session, `Authenticated as ${username}\r\n`);
+  },
+});
+```
+
+### Password Authentication
+
+Enable password authentication with a validation function:
+
+```typescript
+const server = createSSHServer({
+  port: 2222,
+  hostKey: readFileSync('./host_key'),
+  allowPassword: true,
+  validatePassword: (username, password) => {
+    // Example: simple username/password check
+    const users = {
+      alice: 'password123',
+      bob: 'secret456',
+    };
+    return users[username] === password;
+  },
+  onSession: (session, username) => {
+    writeToSession(session, `Welcome, ${username}!\r\n`);
+  },
+});
+```
+
+### No Authentication (Development Only)
+
+For development/testing, omit both `authorizedKeys` and `allowPassword`:
+
+```typescript
+const server = createSSHServer({
+  port: 2222,
+  hostKey: readFileSync('./host_key'),
+  // No auth configured — accepts any connection
+  onSession: (session, username) => {
+    writeToSession(session, 'Connected (no auth)\r\n');
+  },
+});
+```
+
+## Generating Host Keys
+
+Use `ssh-keygen` to generate a host key:
+
+```bash
+ssh-keygen -t rsa -b 4096 -f ./host_key -N ""
+```
+
+## Complete Example
+
+```typescript
+import { createSSHServer, startSSHServer, stopSSHServer } from 'blecsd/terminal';
+import { writeToSession } from 'blecsd/terminal';
+import { readFileSync } from 'node:fs';
+
+// Create server with key auth
+const server = createSSHServer({
+  port: 2222,
+  host: '127.0.0.1',
+  hostKey: readFileSync('./host_key'),
+  authorizedKeys: [
+    { key: readFileSync('./authorized_keys/admin.pub'), comment: 'admin' },
+  ],
+  maxClients: 5,
+  onSession: (session, username) => {
+    writeToSession(session, '\x1b[2J\x1b[H'); // Clear screen
+    writeToSession(session, `Welcome to blECSd, ${username}!\r\n\r\n`);
+    writeToSession(session, '> ');
+
+    session.onData((data) => {
+      const input = data.toString();
+      if (input === '\r' || input === '\n') {
+        writeToSession(session, '\r\n> ');
+      } else if (input === '\x03') { // Ctrl+C
+        writeToSession(session, '\r\nGoodbye!\r\n');
+        session.input.end();
+      } else {
+        writeToSession(session, input); // Echo
+      }
+    });
+
+    session.onResize((width, height) => {
+      console.log(`Client resized: ${width}x${height}`);
+    });
+  },
+  onSessionEnd: (sessionId, reason) => {
+    console.log(`Session ${sessionId} ended: ${reason}`);
+  },
+});
+
+// Start server
+await startSSHServer(server);
+console.log('SSH server listening on 127.0.0.1:2222');
+
+// Graceful shutdown
+process.on('SIGINT', async () => {
+  await stopSSHServer(server);
+  process.exit(0);
+});
+```
+
+## Client Connection
+
+Connect using any SSH client:
+
+```bash
+# With key authentication
+ssh -p 2222 -i ~/.ssh/id_rsa user@localhost
+
+# With password authentication
+ssh -p 2222 user@localhost
+```
+
+## See Also
+
+- [Custom Streams](./custom-streams.md) — Low-level stream session API
+- [Telnet Server](./telnet-server.md) — Alternative without encryption
+- [Server App](./server-app.md) — Higher-level server application framework

--- a/docs/api/terminal/telnet-server.md
+++ b/docs/api/terminal/telnet-server.md
@@ -1,0 +1,217 @@
+# Telnet Server
+
+Implements a telnet server with proper protocol negotiation for blECSd terminal applications.
+
+## Overview
+
+The telnet server provides a network interface for remote terminal access to your blECSd applications. Each connecting client receives its own `StreamSession` for integration with the blECSd terminal system.
+
+**Protocol Support:**
+- NAWS (Negotiate About Window Size, RFC 1073)
+- TTYPE (Terminal Type, RFC 1091)
+- SGA (Suppress Go Ahead)
+- ECHO
+
+## Imports
+
+```typescript
+import {
+  createTelnetServer,
+  startTelnetServer,
+  stopTelnetServer,
+  getTelnetClientCount,
+  type TelnetServerConfig,
+  type TelnetServerState,
+} from 'blecsd/terminal';
+```
+
+## Basic Usage
+
+```typescript
+import { createTelnetServer, startTelnetServer, stopTelnetServer } from 'blecsd/terminal';
+import { writeToSession } from 'blecsd/terminal';
+
+const server = createTelnetServer({
+  port: 2323,
+  onSession: (session) => {
+    writeToSession(session, 'Welcome to blECSd!\r\n');
+    session.onData((data) => console.log('Input:', data));
+  },
+});
+
+await startTelnetServer(server);
+```
+
+## API
+
+### `createTelnetServer(config)`
+
+Create a telnet server.
+
+**Parameters:**
+- `config: TelnetServerConfig` — Server configuration
+
+**Returns:** `TelnetServerState`
+
+**Example:**
+```typescript
+const server = createTelnetServer({
+  port: 2323,
+  host: '0.0.0.0',
+  maxClients: 10,
+  onSession: (session) => {
+    // Handle new client session
+  },
+  onSessionEnd: (sessionId, reason) => {
+    console.log(`Session ${sessionId} ended: ${reason}`);
+  },
+});
+```
+
+### `startTelnetServer(state)`
+
+Start the telnet server, accepting connections.
+
+**Parameters:**
+- `state: TelnetServerState` — Server state returned from `createTelnetServer`
+
+**Returns:** `Promise<void>` — Resolves when the server is listening
+
+**Example:**
+```typescript
+await startTelnetServer(server);
+console.log('Telnet server listening on port 2323');
+```
+
+### `stopTelnetServer(state)`
+
+Stop the telnet server and disconnect all clients.
+
+**Parameters:**
+- `state: TelnetServerState` — Server state
+
+**Returns:** `Promise<void>` — Resolves when the server has stopped
+
+**Example:**
+```typescript
+await stopTelnetServer(server);
+console.log('Telnet server stopped');
+```
+
+### `getTelnetClientCount(state)`
+
+Get the number of active telnet sessions.
+
+**Parameters:**
+- `state: TelnetServerState` — Server state
+
+**Returns:** `number`
+
+**Example:**
+```typescript
+const activeClients = getTelnetClientCount(server);
+console.log(`Active clients: ${activeClients}`);
+```
+
+## Types
+
+### `TelnetServerConfig`
+
+Configuration for the telnet server.
+
+```typescript
+interface TelnetServerConfig {
+  /** TCP port to listen on */
+  readonly port: number;
+  /** Host to bind to (default: '0.0.0.0') */
+  readonly host?: string;
+  /** Maximum concurrent clients (default: 10) */
+  readonly maxClients?: number;
+  /** Called when a new client session is established */
+  readonly onSession?: (session: StreamSession) => void;
+  /** Called when a session ends */
+  readonly onSessionEnd?: (sessionId: string, reason: string) => void;
+}
+```
+
+### `TelnetServerState`
+
+Telnet server state object.
+
+```typescript
+interface TelnetServerState {
+  /** Server configuration */
+  readonly config: TelnetServerConfig;
+  /** Whether the server is listening */
+  running: boolean;
+  /** Active sessions */
+  readonly sessions: Map<string, StreamSession>;
+  /** Internal TCP server */
+  _server: Server | null;
+}
+```
+
+## Complete Example
+
+```typescript
+import { createTelnetServer, startTelnetServer, stopTelnetServer } from 'blecsd/terminal';
+import { createStreamSession, writeToSession } from 'blecsd/terminal';
+
+// Create server
+const server = createTelnetServer({
+  port: 2323,
+  host: '127.0.0.1',
+  maxClients: 5,
+  onSession: (session) => {
+    writeToSession(session, '\x1b[2J\x1b[H'); // Clear screen
+    writeToSession(session, 'Welcome to blECSd Terminal!\r\n\r\n');
+    writeToSession(session, '> ');
+
+    session.onData((data) => {
+      const input = data.toString();
+      if (input === '\r' || input === '\n') {
+        writeToSession(session, '\r\n> ');
+      } else if (input === '\x03') { // Ctrl+C
+        writeToSession(session, '\r\nGoodbye!\r\n');
+        session.input.end();
+      } else {
+        writeToSession(session, input); // Echo
+      }
+    });
+
+    session.onResize((width, height) => {
+      console.log(`Client resized: ${width}x${height}`);
+    });
+  },
+  onSessionEnd: (sessionId, reason) => {
+    console.log(`Session ${sessionId} ended: ${reason}`);
+  },
+});
+
+// Start server
+await startTelnetServer(server);
+console.log('Telnet server listening on 127.0.0.1:2323');
+
+// Graceful shutdown
+process.on('SIGINT', async () => {
+  await stopTelnetServer(server);
+  process.exit(0);
+});
+```
+
+## Protocol Details
+
+The server automatically handles telnet protocol negotiation:
+
+1. **ECHO**: Server echoes client input (suppresses client local echo)
+2. **SGA**: Suppress Go Ahead for line-at-a-time operation
+3. **NAWS**: Negotiates terminal window size, updates session on resize
+4. **TTYPE**: Requests client terminal type
+
+All protocol handling is transparent — you work with clean data streams through the `StreamSession` interface.
+
+## See Also
+
+- [Custom Streams](./custom-streams.md) — Low-level stream session API
+- [SSH Server](./ssh-server.md) — SSH alternative with authentication
+- [Server App](./server-app.md) — Higher-level server application framework

--- a/docs/guides/animations.md
+++ b/docs/guides/animations.md
@@ -2,6 +2,15 @@
 
 Modern UIs use physics-based animations for natural, responsive interactions. blECSd provides the same animation primitives used by iOS, Android, and web frameworks, adapted for terminal applications.
 
+**Setup Note:** Examples show manual world creation. For new projects, use `createApp()`:
+
+```typescript
+import { createApp } from 'blecsd';
+const { world, run, stop } = createApp();
+// ... add animations ...
+await run();
+```
+
 ## Why Physics in UIs?
 
 Physics-based animations feel more natural than linear tweens:

--- a/docs/guides/cheat-sheet.md
+++ b/docs/guides/cheat-sheet.md
@@ -689,10 +689,10 @@ Use namespace imports from `'blecsd/components'`, `'blecsd/systems'`, etc. for:
 
 <!-- blecsd-doccheck:ignore -->
 ```typescript
-import { createWorld, addEntity } from 'blecsd/core';
+import { createWorld, createListEntity, addEntity } from 'blecsd/core';
 import { enableInput } from 'blecsd/components';
 import { renderSystem } from 'blecsd/systems';
-import { createPanel, createList } from 'blecsd/widgets';
+import { createPanel } from 'blecsd/widgets';
 import { createEventBus } from 'blecsd/core';
 
 // Setup
@@ -705,8 +705,7 @@ const panel = createPanel(world, {
   title: 'My App'
 });
 
-const entity = addEntity(world);
-const list = createList(world, entity, {
+const list = createListEntity(world, {
   items: [
     { label: 'Option 1', value: '1' },
     { label: 'Option 2', value: '2' }
@@ -728,7 +727,7 @@ render(world);
 <!-- blecsd-doccheck:ignore -->
 ```typescript
 // Create list with selection handling
-const list = createList(world, entity, { items: [...] });
+const list = createListEntity(world, { items: [...] });
 
 const inputBus = createEventBus();
 inputBus.on('key', (e) => {

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -2,6 +2,14 @@
 
 This guide explains how blECSd handles errors, how to work with the error system in your applications, and best practices for building robust terminal UIs.
 
+**Setup Note:** Examples show error handling patterns. For new projects, use `createApp()` for streamlined setup:
+
+```typescript
+import { createApp } from 'blecsd';
+const { world, run, stop } = createApp();
+// ... handle errors as shown below ...
+```
+
 ## Overview
 
 blECSd uses a typed error system built on functional programming principles. All errors are:

--- a/docs/guides/how-to.md
+++ b/docs/guides/how-to.md
@@ -2,6 +2,18 @@
 
 Practical, task-oriented guides for common blECSd operations.
 
+**Recommended Setup:** For new projects, use `createApp()` to streamline initialization:
+
+```typescript
+import { createApp } from 'blecsd';
+
+const { world, run, stop } = createApp();
+// ... build your UI ...
+await run();
+```
+
+`createApp()` handles world creation, system registration, and terminal program lifecycle automatically. Examples below show manual setup for educational purposes — feel free to use `createApp()` instead.
+
 ## Table of Contents
 
 ### Basic Tasks

--- a/docs/guides/migrating-from-blessed.md
+++ b/docs/guides/migrating-from-blessed.md
@@ -38,6 +38,35 @@ This guide helps you transition from the original blessed.js library to blECSd's
 ✅ **Actively maintained**: Regular updates, responsive to issues
 ✅ **Explicit control**: You control the game loop
 
+## Recommended Setup Pattern
+
+**For new projects, use `createApp()` for streamlined setup:**
+
+```typescript
+import { createApp } from 'blecsd';
+
+// One-line setup with sensible defaults
+const { world, run, stop } = createApp();
+
+// Add your UI components
+const box = createBox(world, { x: 10, y: 5, width: 30, height: 10 });
+setText(world, box, 'Hello World!');
+
+// Start rendering
+await run();
+
+// Later: cleanup
+await stop();
+```
+
+**`createApp()` handles:**
+- World creation
+- System registration (render, output, input)
+- Terminal program lifecycle
+- Graceful cleanup on exit
+
+For more control, you can still use the manual setup shown below.
+
 ## Key Architectural Differences
 
 ### blessed.js: Object-Oriented

--- a/docs/guides/styling-and-theming.md
+++ b/docs/guides/styling-and-theming.md
@@ -17,6 +17,17 @@ Every visual element in blECSd is an entity with data stored in typed arrays. St
 
 ---
 
+**Setup Note:** Examples below use manual component manipulation for clarity. For new projects, use `createApp()` for streamlined setup:
+
+```typescript
+import { createApp } from 'blecsd';
+const { world, run, stop } = createApp();
+// ... style your entities ...
+await run();
+```
+
+---
+
 ## How does the style system work?
 
 The `Renderable` component is the single source of truth for visual appearance. It stores style data in SoA (Structure of Arrays) typed arrays:

--- a/docs/guides/terminal-app-patterns.md
+++ b/docs/guides/terminal-app-patterns.md
@@ -2,6 +2,17 @@
 
 Practical patterns for building terminal applications with blECSd. Each section shows how to combine existing widgets, systems, and APIs to implement common application features.
 
+**Setup Note:** Examples below use manual `createWorld()` for clarity. For new projects, consider using `createApp()` for streamlined setup:
+
+```typescript
+import { createApp } from 'blecsd';
+const { world, run, stop } = createApp();
+// ... add your components ...
+await run();
+```
+
+See the [How-To Guide](./how-to.md) for more on `createApp()`.
+
 ## Command Palette
 
 blECSd ships with a `createCommandPalette` widget that provides VS Code-style quick command search.

--- a/docs/guides/understanding-ecs.md
+++ b/docs/guides/understanding-ecs.md
@@ -2,6 +2,14 @@
 
 This guide explains ECS (Entity Component System) for developers new to the paradigm, and how blECSd uses ECS to build high-performance terminal UIs.
 
+**Quick Start:** For new projects, use `createApp()` to skip manual ECS setup:
+
+```typescript
+import { createApp } from 'blecsd';
+const { world, run, stop } = createApp();
+// ... build your UI using ECS patterns shown below ...
+```
+
 ## What is ECS?
 
 Entity Component System (ECS) is a data-oriented architecture pattern where:


### PR DESCRIPTION
From research #1331

## Overview
Three doc areas fixed: 5 missing terminal doc pages, 2 wrong signatures in cheat-sheet, 1 wrong import path in colors doc, and guides missing `createApp()` references. All docs-only changes.

## Changes

### Phase 1: Add missing terminal docs
- ✅ Create `docs/api/terminal/telnet-server.md` — document `createTelnetServer`, `startTelnetServer`, `stopTelnetServer`
- ✅ Create `docs/api/terminal/ssh-server.md` — document `createSSHServer`, `startSSHServer`, `stopSSHServer`
- ✅ Create `docs/api/terminal/custom-streams.md` — document `createStreamSession`, `writeToSession`, `endSession`
- ✅ Create `docs/api/terminal/process.md` — document `spawn`, `exec`, `execSync`, `readEditor`, `getDefaultEditor`
- ✅ Create `docs/api/terminal/server-app.md` — document `createServerApp`

### Phase 2: Fix cheat-sheet and colors doc
- ✅ Fix `docs/guides/cheat-sheet.md` line 709: change `createListEntity(world, entity, {...})` to `createListEntity(world, {...})`
- ✅ Fix `docs/guides/cheat-sheet.md` line 731: same fix for second occurrence
- ✅ Fix `docs/api/terminal/colors.md` line 208: change `import { parseColor } from 'blecsd/utils'` to `import { parseColor } from 'blecsd/terminal'`

### Phase 3: Update guides with createApp()
- ✅ Update `docs/guides/migrating-from-blessed.md` — add `createApp()` as recommended setup pattern
- ✅ Update `docs/guides/terminal-app-patterns.md` — reference `createApp()` at beginning
- ✅ Update `docs/guides/how-to.md` — add `createApp()` recommendation
- ✅ Update `docs/guides/styling-and-theming.md` — add `createApp()` setup note
- ✅ Update `docs/guides/animations.md` — add `createApp()` setup note
- ✅ Update `docs/guides/error-handling.md` — add `createApp()` setup note
- ✅ Update `docs/guides/understanding-ecs.md` — add `createApp()` quick start note

Closes #1338