### PR TITLE
docs: standardize API docs to subpath imports and fix inconsistencies

### DIFF
--- a/docs/api/components/animation.md
+++ b/docs/api/components/animation.md
@@ -330,3 +330,15 @@ interface PlayAnimationOptions {
   startFrame?: number;
 }
 ```
+
+## Namespace API
+
+The `animation` namespace groups all related functions into a single import:
+
+```typescript
+import { animation } from 'blecsd/components';
+
+// Available methods: get,has,getByName,getIdByName,getData,getEntity,register,unregister, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/behavior.md
+++ b/docs/api/components/behavior.md
@@ -302,3 +302,15 @@ interface BehaviorDirection {
   readonly dy: number;
 }
 ```
+
+## Namespace API
+
+The `behavior` namespace groups all related functions into a single import:
+
+```typescript
+import { behavior } from 'blecsd/components';
+
+// Available methods: get,has,set,remove,getType,getState,getTarget,setTarget, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/camera.md
+++ b/docs/api/components/camera.md
@@ -319,3 +319,15 @@ interface CameraBounds {
   readonly maxY: number;
 }
 ```
+
+## Namespace API
+
+The `camera` namespace groups all related functions into a single import:
+
+```typescript
+import { camera } from 'blecsd/components';
+
+// Available methods: get,has,set,remove,getPosition,setPosition,moveBy,centerOn, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/checkbox.md
+++ b/docs/api/components/checkbox.md
@@ -357,3 +357,15 @@ const values = getFormValues(world, form);
 - [Form Component](./form.md) - Form container for field management
 - RadioButton Component - Single selection from group
 - [TextInput Component](./textInput.md) - Text entry field
+
+## Namespace API
+
+The `checkbox` namespace groups all related functions into a single import:
+
+```typescript
+import { checkbox } from 'blecsd/components';
+
+// Available methods: attach,is,getState,isInState,sendEvent,handleKeyPress,check,uncheck, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/collision.md
+++ b/docs/api/components/collision.md
@@ -319,3 +319,15 @@ interface CollisionPair {
   readonly isTrigger: boolean;
 }
 ```
+
+## Namespace API
+
+The `collision` namespace groups all related functions into a single import:
+
+```typescript
+import { collision } from 'blecsd/components';
+
+// Available methods: get,has,set,remove,getAABB,test,testAABB,testCircle, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/form.md
+++ b/docs/api/components/form.md
@@ -426,3 +426,15 @@ The form automatically extracts values based on field type:
 - RadioButton Component - Single selection
 - [Select Component](./select.md) - Dropdown selection
 - [Slider Component](./slider.md) - Range selection
+
+## Namespace API
+
+The `form` namespace groups all related functions into a single import:
+
+```typescript
+import { form } from 'blecsd/components';
+
+// Available methods: attach,is,handleKeyPress,registerField,unregisterField,getFields,getTabOrder,getValues, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/health.md
+++ b/docs/api/components/health.md
@@ -226,3 +226,15 @@ interface HealthOptions {
   regen?: number;
 }
 ```
+
+## Namespace API
+
+The `health` namespace groups all related functions into a single import:
+
+```typescript
+import { health } from 'blecsd/components';
+
+// Available methods: get,has,set,remove,getPercent,setCurrent,setMax,update, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/particle.md
+++ b/docs/api/components/particle.md
@@ -326,3 +326,15 @@ interface EmitterAppearance {
   fadeOut?: boolean;
 }
 ```
+
+## Namespace API
+
+The `particle` namespace groups all related functions into a single import:
+
+```typescript
+import { particle } from 'blecsd/components';
+
+// Available methods: get,has,set,remove,isDead,getColor,getProgress,track, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/progressBar.md
+++ b/docs/api/components/progressBar.md
@@ -376,3 +376,15 @@ function takeDamage(amount: number) {
 - [Slider Component](./slider.md) - Interactive range selection
 - [Loading Widget](../widgets/loading.md) - Indeterminate progress
 - [Form Component](./form.md) - Form container
+
+## Namespace API
+
+The `progressBar` namespace groups all related functions into a single import:
+
+```typescript
+import { progressBar } from 'blecsd/components';
+
+// Available methods: attach,is,render,get,set,reset,complete,increment, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/radioButton.md
+++ b/docs/api/components/radioButton.md
@@ -442,3 +442,15 @@ const values = getFormValues(world, form);
 - [Form Component](./form.md) - Form container for field management
 - Checkbox Component - Boolean toggle (non-exclusive)
 - [Select Component](./select.md) - Dropdown selection
+
+## Namespace API
+
+The `radio` namespace groups all related functions into a single import:
+
+```typescript
+import { radio } from 'blecsd/components';
+
+// Available methods: attach,is,getState,isInState,sendEvent,handleKeyPress,select,deselect, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/screen.md
+++ b/docs/api/components/screen.md
@@ -263,3 +263,15 @@ console.log(hasScreenSingleton(world)); // false
 | `setFullUnicode(world, eid, enabled)` | Set Unicode support |
 | `isAutoPadding(world, eid)` | Check auto padding |
 | `setAutoPadding(world, eid, enabled)` | Set auto padding |
+
+## Namespace API
+
+The `screenComponent` namespace groups all related functions into a single import:
+
+```typescript
+import { screenComponent } from 'blecsd/components';
+
+// Available methods: get,has,is,getData,getSize,init,destroy,resize, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/select.md
+++ b/docs/api/components/select.md
@@ -443,3 +443,15 @@ const values = getFormValues(world, form);
 - [Form Component](./form.md) - Form container
 - RadioButton Component - Alternative for few options
 - Checkbox Component - Boolean toggle
+
+## Namespace API
+
+The `select` namespace groups all related functions into a single import:
+
+```typescript
+import { select } from 'blecsd/components';
+
+// Available methods: attach,is,getState,isInState,sendEvent,handleKeyPress,open,close, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/slider.md
+++ b/docs/api/components/slider.md
@@ -479,3 +479,15 @@ Object.values(colorSliders).forEach(eid => {
 - [Form Component](./form.md) - Form container
 - [ProgressBar Component](./progressBar.md) - Non-interactive progress display
 - [Select Component](./select.md) - Discrete value selection
+
+## Namespace API
+
+The `slider` namespace groups all related functions into a single import:
+
+```typescript
+import { slider } from 'blecsd/components';
+
+// Available methods: attach,is,getState,isInState,sendEvent,handleKeyPress,render,focus, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/spinner.md
+++ b/docs/api/components/spinner.md
@@ -458,3 +458,15 @@ function updateAllSpinners(deltaMs: number) {
 - [Loading Widget](../widgets/loading.md) - Higher-level loading indicator
 - [Animation Component](./animation.md) - Sprite-based animation
 - [Content Component](../content.md) - Text content display
+
+## Namespace API
+
+The `spinner` namespace groups all related functions into a single import:
+
+```typescript
+import { spinner } from 'blecsd/components';
+
+// Available methods: add,has,remove,getData,getChar,advance,update,reset, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/sprite.md
+++ b/docs/api/components/sprite.md
@@ -258,3 +258,15 @@ interface SpriteData {
   readonly spriteSheetId: number;
 }
 ```
+
+## Namespace API
+
+The `sprite` namespace groups all related functions into a single import:
+
+```typescript
+import { sprite } from 'blecsd/components';
+
+// Available methods: get,has,set,setByName,remove,register,unregister,getIdByName, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/state-machine.md
+++ b/docs/api/components/state-machine.md
@@ -221,3 +221,15 @@ console.log(isInState(world, entity, 'open')); // true
 // Each frame
 updateStateAge(world, [entity], deltaTime);
 ```
+
+## Namespace API
+
+The `stateMachine` namespace groups all related functions into a single import:
+
+```typescript
+import { stateMachine } from 'blecsd/components';
+
+// Available methods: attach,detach,has, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/textInput.md
+++ b/docs/api/components/textInput.md
@@ -439,3 +439,15 @@ setTextInputConfig(world, passwordInput, {
 - [Form Component](./form.md) - Form container for field management
 - Checkbox Component - Boolean toggle
 - [Select Component](./select.md) - Dropdown selection
+
+## Namespace API
+
+The `textInput` namespace groups all related functions into a single import:
+
+```typescript
+import { textInput } from 'blecsd/components';
+
+// Available methods: attach,is,getState,isInState,sendEvent,handleKeyPress,focus,blur, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/tilemap.md
+++ b/docs/api/components/tilemap.md
@@ -331,3 +331,15 @@ interface RenderedTileCell {
   readonly bg: number;
 }
 ```
+
+## Namespace API
+
+The `tilemap` namespace groups all related functions into a single import:
+
+```typescript
+import { tilemap } from 'blecsd/components';
+
+// Available methods: get,has,set,remove,getDataId,render,tile,get, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/user-data.md
+++ b/docs/api/components/user-data.md
@@ -231,3 +231,15 @@ The ECS approach provides:
 
 - Components - Understanding ECS components
 - [Entity Data](../core/entity-data.md) - Alternative typed storage
+
+## Namespace API
+
+The `userData` namespace groups all related functions into a single import:
+
+```typescript
+import { userData } from 'blecsd/components';
+
+// Available methods: get,has,set,remove,getOrCreate,getCount,clearAll, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/components/velocity.md
+++ b/docs/api/components/velocity.md
@@ -257,8 +257,8 @@ import { Velocity } from 'blecsd/components';
 
 const world = createWorld();
 const eid = addEntity(world);
-setVelocity(world, eid, { x: 5, y: 0 });
-setAcceleration(world, eid, { x: 0, y: 9.8 });
+setVelocity(world, eid, 5, 0);
+setAcceleration(world, eid, 0, 9.8);
 const entities = [eid];
 
 for (const eid of entities) {
@@ -301,3 +301,15 @@ interface AccelerationData {
   readonly y: number;
 }
 ```
+
+## Namespace API
+
+The `velocity` namespace groups all related functions into a single import:
+
+```typescript
+import { velocity } from 'blecsd/components';
+
+// Available methods: get,has,set,add,remove,setOptions,stop,applyToEntity, ...
+```
+
+This is equivalent to importing individual functions but provides better discoverability. See the [namespace pattern](../index.md#namespace-pattern) for details.

--- a/docs/api/core/gameLoop.md
+++ b/docs/api/core/gameLoop.md
@@ -2,7 +2,25 @@
 
 The game loop manages the main update cycle with input priority guarantees, lifecycle hooks, fixed timestep support, and performance statistics.
 
-> **Note**: For most applications, use [`createApp()`](../app.md) which handles world, loop, and render pipeline setup automatically. The APIs below are for advanced use cases requiring custom loop configuration.
+## Quick Start with createApp
+
+For most applications, [`createApp()`](../app.md) handles world creation, screen setup, render pipeline, and shutdown — no manual game loop needed:
+
+```typescript
+import { createApp } from 'blecsd';
+
+const app = await createApp({ fps: 30, fullscreen: true });
+
+// app.world   — the ECS world
+// app.program — terminal program (input handling)
+// app.render()   — manual render (layout → render → output)
+// app.start()    — start the FPS-based render loop
+// app.shutdown() — clean up terminal and exit
+
+app.start();
+```
+
+Use the lower-level `createGameLoop` API below when you need custom phase ordering, fixed timestep, or per-phase system registration.
 
 ## Import
 
@@ -29,7 +47,7 @@ blECSd uses a fixed phase ordering where **INPUT always runs first**. This is a 
 | `EARLY_UPDATE` | 1 | Pre-update logic (AI decisions, state machine transitions) |
 | `UPDATE` | 2 | Main game logic (movement, gameplay mechanics) |
 | `LATE_UPDATE` | 3 | Post-update corrections (camera follow, constraint solving) |
-| `PHYSICS` | 4 | Physics-based animations, springs, momentum, transitions |
+| `ANIMATION` | 4 | Animation, physics, tweens, springs, and transitions |
 | `LAYOUT` | 5 | UI layout calculation (flex, grid, constraints) |
 | `RENDER` | 6 | Screen rendering (draw calls, buffer writes) |
 | `POST_RENDER` | 7 | Cleanup after render (debug overlays, stat collection) |
@@ -215,7 +233,7 @@ const loop = createGameLoop(world, {
 // Frame execution order in fixed timestep:
 // 1. Process INPUT (every frame, at render rate)
 // 2. Accumulate real time
-// 3. Run fixed updates at consistent rate (UPDATE, LATE_UPDATE, PHYSICS)
+// 3. Run fixed updates at consistent rate (UPDATE, LATE_UPDATE, ANIMATION)
 // 4. Calculate interpolation alpha
 // 5. Run render phases (LAYOUT, RENDER, POST_RENDER)
 loop.step(1/60);
@@ -263,7 +281,7 @@ const aiPhaseId = manager.registerPhase('AI', LoopPhase.UPDATE);
 
 // Get all phases in order
 const phases = manager.getPhaseOrder();
-// [INPUT, EARLY_UPDATE, UPDATE, 'AI', LATE_UPDATE, PHYSICS, LAYOUT, RENDER, POST_RENDER]
+// [INPUT, EARLY_UPDATE, UPDATE, 'AI', LATE_UPDATE, ANIMATION, LAYOUT, RENDER, POST_RENDER]
 
 // Check if a phase is built-in
 isBuiltinPhase(LoopPhase.INPUT);  // true
@@ -278,7 +296,7 @@ enum LoopPhase {
   EARLY_UPDATE = 1,
   UPDATE = 2,
   LATE_UPDATE = 3,
-  PHYSICS = 4,
+  ANIMATION = 4,
   LAYOUT = 5,
   RENDER = 6,
   POST_RENDER = 7,

--- a/docs/api/core/phase-manager.md
+++ b/docs/api/core/phase-manager.md
@@ -2,6 +2,8 @@
 
 Configurable game loop execution order. Allows users to add custom phases between the default phases while ensuring INPUT always runs first.
 
+> **Tip:** For standard applications, [`createApp()`](./gameLoop.md#quick-start-with-createapp) handles phase management automatically.
+
 ## Quick Start
 
 ```typescript

--- a/docs/api/core/scene.md
+++ b/docs/api/core/scene.md
@@ -2,6 +2,8 @@
 
 Scene management for game screens. Provides a scene stack with lifecycle callbacks, scene transitions, and per-scene system registration. Scenes can be pushed/popped for overlays or switched directly.
 
+> **Tip:** For standard applications, [`createApp()`](./gameLoop.md#quick-start-with-createapp) handles phase management automatically.
+
 ## Quick Start
 
 ```typescript

--- a/docs/api/core/scheduler.md
+++ b/docs/api/core/scheduler.md
@@ -2,7 +2,7 @@
 
 The Scheduler manages the ordered execution of ECS systems across phases. It enforces input priority by protecting the INPUT phase and provides methods for registering, unregistering, and querying systems.
 
-> **Note**: For most applications, use [`createApp()`](../app.md) which automatically wires the scheduler and registers core systems. This API is for advanced scenarios requiring custom system scheduling.
+> **Tip:** For most applications, [`createApp()`](../app.md) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
 
 ## Import
 

--- a/docs/api/core/types.md
+++ b/docs/api/core/types.md
@@ -2,6 +2,8 @@
 
 Core type definitions for blECSd. Defines the fundamental types used throughout the library.
 
+> **Tip:** For standard applications, [`createApp()`](./gameLoop.md#quick-start-with-createapp) handles phase management automatically.
+
 ## Quick Start
 
 ```typescript

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,47 @@
 # API Reference
 
+## Import Convention
+
+blECSd uses **subpath imports** to organize its API into logical modules:
+
+```typescript
+import { createWorld, addEntity } from 'blecsd/core';        // ECS foundation
+import { position, content, setPosition } from 'blecsd/components'; // Component data & helpers
+import { layoutSystem, renderSystem } from 'blecsd/systems';  // ECS systems
+import { createProgram } from 'blecsd/terminal';              // Terminal I/O
+```
+
+The top-level `'blecsd'` export provides a curated subset for quick starts (including `createApp`), but subpath imports are recommended for clarity and tree-shaking.
+
+### Namespace Pattern
+
+Many components export **namespace objects** — frozen plain objects that group related functions:
+
+```typescript
+import { position, content, scroll } from 'blecsd/components';
+
+position.set(world, eid, 10, 5);
+content.setText(world, eid, 'Hello');
+scroll.toTop(world, eid);
+```
+
+These are purely functional (no `this`, no state). Individual functions like `setPosition` are also available as direct imports.
+
+### Quick Start with createApp
+
+For most applications, `createApp()` handles all boilerplate:
+
+```typescript
+import { createApp } from 'blecsd';
+
+const app = await createApp({ fps: 30 });
+// app.world, app.program, app.render(), app.start(), app.shutdown()
+```
+
+See [Game Loop](./core/gameLoop.md) for lower-level control.
+
+---
+
 ## Widgets
 
 Pre-built UI widgets with chainable APIs. Each widget wraps ECS components for easier use.

--- a/docs/api/position.md
+++ b/docs/api/position.md
@@ -216,6 +216,28 @@ interface PositionData {
 
 ---
 
+## Namespace API
+
+The `position` namespace groups all position-related functions into a single import:
+
+```typescript
+import { position } from 'blecsd/components';
+
+position.set(world, eid, 10, 5);
+position.get(world, eid);
+position.has(world, eid);
+position.moveBy(world, eid, 1, 0);
+position.setKeyword(world, eid, 'center');
+position.setPercent(world, eid, 50, 50);
+
+// Z-index sub-namespace
+position.zIndex.set(world, eid, 10);
+position.zIndex.bringToFront(world, eid, siblings);
+position.zIndex.sendToBack(world, eid, siblings);
+```
+
+See the [namespace pattern](./index.md#namespace-pattern) for details.
+
 ## See Also
 
 - [Dimensions Component](./dimensions.md) - Entity width and height

--- a/docs/api/systems/animationSystem.md
+++ b/docs/api/systems/animationSystem.md
@@ -2,7 +2,7 @@
 
 The animation system updates sprite animations for all entities with the Animation component. It processes frame timing, direction, looping, and automatically updates sprite frames.
 
-> **Note**: For most applications, use [`createApp()`](../app.md) which sets up the game loop automatically. You only need to register this system if you're managing the loop manually.
+> **Tip:** For most applications, [`createApp()`](../app.md) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
 
 ## Import
 

--- a/docs/api/systems/behavior.md
+++ b/docs/api/systems/behavior.md
@@ -2,6 +2,8 @@
 
 ECS system for processing AI behaviors each frame, including patrol, chase, flee, and custom behaviors.
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 ## Overview
 
 The behavior system handles:

--- a/docs/api/systems/cameraSystem.md
+++ b/docs/api/systems/cameraSystem.md
@@ -2,6 +2,8 @@
 
 The camera system updates camera positions to follow target entities. It supports smooth following with configurable smoothing and dead zones.
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 ## Import
 
 ```typescript

--- a/docs/api/systems/collisionSystem.md
+++ b/docs/api/systems/collisionSystem.md
@@ -2,7 +2,7 @@
 
 The collision system detects collisions between entities with Collider and Position components. It emits events for collision start/end and trigger enter/exit, supporting both solid colliders and trigger zones.
 
-> **Note**: For most applications, use [`createApp()`](../app.md) for application setup. You'll need to manually register the collision system if you're using it.
+> **Tip:** For most applications, [`createApp()`](../app.md) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
 
 ## Import
 

--- a/docs/api/systems/focus.md
+++ b/docs/api/systems/focus.md
@@ -2,7 +2,7 @@
 
 ECS system for managing keyboard focus and tab navigation between interactive entities.
 
-> **Note**: For most applications, use [`createApp()`](../app.md) for setup. You'll need to manually register the focus system with your scheduler if you're managing the game loop yourself.
+> **Tip:** For most applications, [`createApp()`](../app.md) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
 
 ## Overview
 

--- a/docs/api/systems/frame-budget.md
+++ b/docs/api/systems/frame-budget.md
@@ -2,6 +2,8 @@
 
 Performance profiling and frame budget enforcement system with rolling statistics and per-phase budget tracking.
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 ## Overview
 
 The frame budget manager handles:

--- a/docs/api/systems/input-system.md
+++ b/docs/api/systems/input-system.md
@@ -2,6 +2,8 @@
 
 ECS system for processing keyboard and mouse events with hit testing and focus management.
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 ## Overview
 
 The input system handles:

--- a/docs/api/systems/layout.md
+++ b/docs/api/systems/layout.md
@@ -2,7 +2,7 @@
 
 The layout system computes absolute positions and dimensions for all entities in tree order. It runs in the LAYOUT phase before rendering to pre-compute positions based on hierarchy, relative positioning, and percentage dimensions.
 
-> **Note**: For most applications, use [`createApp()`](../app.md) which automatically registers the layout system in the correct phase. The APIs below are for advanced use cases.
+> **Tip:** For most applications, [`createApp()`](../app.md) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
 
 ## Overview
 

--- a/docs/api/systems/movementSystem.md
+++ b/docs/api/systems/movementSystem.md
@@ -2,6 +2,8 @@
 
 The movement system updates entity positions based on velocity. It handles acceleration, friction, speed clamping, and applies the final velocity to position.
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 ## Import
 
 ```typescript

--- a/docs/api/systems/output.md
+++ b/docs/api/systems/output.md
@@ -2,7 +2,7 @@
 
 The output system writes rendered content to the terminal. It runs in the POST_RENDER phase after all rendering is complete and generates optimized ANSI escape sequences for efficient terminal output.
 
-> **Note**: For most applications, use [`createApp()`](../app.md) which handles output setup and cleanup automatically. The APIs below are for advanced scenarios requiring custom output management.
+> **Tip:** For most applications, [`createApp()`](../app.md) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
 
 ## Overview
 

--- a/docs/api/systems/particle.md
+++ b/docs/api/systems/particle.md
@@ -2,6 +2,8 @@
 
 ECS system for spawning, updating, and removing particles with rate-based and burst-based emitters.
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 ## Overview
 
 The particle system handles:

--- a/docs/api/systems/render.md
+++ b/docs/api/systems/render.md
@@ -2,7 +2,7 @@
 
 The render system draws entities to the screen buffer. It runs in the RENDER phase after layout computation and handles background fills, borders, and content rendering.
 
-> **Note**: For most applications, use [`createApp()`](../app.md) or [`createRenderPipeline()`](../app.md#createrenderpipeline) to handle render pipeline setup automatically. The APIs below are for advanced use cases.
+> **Tip:** For most applications, [`createApp()`](../app.md) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
 
 ## Overview
 

--- a/docs/api/systems/smooth-scroll.md
+++ b/docs/api/systems/smooth-scroll.md
@@ -2,6 +2,8 @@
 
 Physics-based smooth scrolling system with momentum, friction, and overscroll bounce.
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 ## Overview
 
 The smooth scroll system handles:

--- a/docs/api/systems/spatial-hash.md
+++ b/docs/api/systems/spatial-hash.md
@@ -2,6 +2,8 @@
 
 > **Module:** `systems/spatialHash`
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 Spatial hash grid for O(1) collision lookups using uniform grid partitioning with incremental update support.
 
 ## Overview

--- a/docs/api/systems/stateMachineSystem.md
+++ b/docs/api/systems/stateMachineSystem.md
@@ -2,6 +2,8 @@
 
 The state machine system updates the `stateAge` for all entities with a StateMachine component. This enables time-based state transitions and animations by tracking how long an entity has been in its current state.
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 ## Import
 
 ```typescript

--- a/docs/api/systems/tilemap-renderer.md
+++ b/docs/api/systems/tilemap-renderer.md
@@ -2,6 +2,8 @@
 
 ECS system for rendering tile maps to a 2D character buffer with camera support and layer compositing.
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 ## Overview
 
 The tilemap renderer handles:

--- a/docs/api/systems/virtualizedRenderSystem.md
+++ b/docs/api/systems/virtualizedRenderSystem.md
@@ -2,6 +2,8 @@
 
 The virtualized render system efficiently renders large content by only drawing visible lines. It achieves 60fps scroll performance with 10M+ lines by skipping off-screen content.
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 ## Import
 
 ```typescript

--- a/docs/api/systems/visibility-culling.md
+++ b/docs/api/systems/visibility-culling.md
@@ -2,6 +2,8 @@
 
 Efficient entity visibility determination using spatial indexing with incremental update support.
 
+> **Tip:** For standard applications, [`createApp()`](../core/gameLoop.md#quick-start-with-createapp) handles system execution automatically. Register this system with the scheduler only when you need custom phase control.
+
 ## Overview
 
 The visibility culling system handles:


### PR DESCRIPTION
Addresses issue #1340

## Changes

### API Index (docs/api/index.md)
- Added **Import Convention** section explaining subpath imports pattern
- Added **Namespace Pattern** section documenting component namespace objects
- Added **Quick Start with createApp** section

### Game Loop & Scheduler (Phase 2: createApp Integration)
- Added createApp() quick-start section to `gameLoop.md`
- Added createApp() tip to `scheduler.md`, `phase-manager.md`, `types.md`, `scene.md`
- Added createApp() tip to all 18 system docs that reference game loop APIs

### Namespace Pattern Documentation (Phase 3)
- Added Namespace API section to 20 component docs (animation, behavior, camera, checkbox, collision, form, health, particle, progressBar, radioButton, screen, select, slider, spinner, sprite, state-machine, textInput, tilemap, user-data, velocity)
- Added detailed position namespace documentation with zIndex sub-namespace example

### Bug Fixes (Phase 4: Signature Verification)
- **Fixed PHYSICS → ANIMATION**: gameLoop.md phase table and code examples incorrectly used `PHYSICS` instead of `ANIMATION` (value 4 in LoopPhase enum)
- **Fixed velocity.md signatures**: Direct Component Access example used object syntax `setVelocity(world, eid, { x: 5, y: 0 })` but actual signature is `setVelocity(world, eid, 5, 0)`

### Cross-Reference & Link Verification (Phase 5)
- Verified all cross-references in core/, components/, systems/ — no broken links
- Verified documented function names match source exports
- All 66 API docs use correct subpath imports (already standardized)

## Files Changed
45 files across docs/api/core/, docs/api/components/, docs/api/systems/, and docs/api/