### PR TITLE
docs: fix simple-game.md tutorial doccheck execution failure

### DIFF
--- a/docs/tutorials/simple-game.md
+++ b/docs/tutorials/simple-game.md
@@ -121,11 +121,8 @@ const state: GameState = {
 ## Step 3: Create UI
 
 ```typescript
-const columns = process.stdout.columns || 80;
-const rows = process.stdout.rows || 24;
-
-// Calculate centered game area
-const gameX = Math.floor((columns - GRID_WIDTH - 2) / 2);
+// Calculate centered game area (using cols and rows from Step 1)
+const gameX = Math.floor((cols - GRID_WIDTH - 2) / 2);
 const gameY = Math.floor((rows - GRID_HEIGHT - 4) / 2);
 
 // Game panel (createBoxEntity returns an entity ID)


### PR DESCRIPTION
Addresses issue #1350

## Changes
- Fixed conflicting declaration of `rows` variable in Step 3 of the simple-game.md tutorial
- Removed redundant redeclaration of `columns` and `rows` that were already available from Step 1

## Problem
The tutorial had `rows` declared twice:
1. In Step 1: `const { cols, rows } = createRenderPipeline(process.stdout);`
2. In Step 3: `const rows = process.stdout.rows || 24;`

This conflicting declaration caused the doccheck transform to wrap each code block in separate scopes, making the `GRID_WIDTH` constant from Step 2 unavailable in Step 3, resulting in a `ReferenceError: GRID_WIDTH is not defined`.

## Solution
Updated Step 3 to use the `cols` and `rows` values from Step 1 instead of redeclaring them.

## Verification
Ran `pnpm doccheck` and confirmed that `docs/tutorials/simple-game.md` now passes (test results show 200 pages passed, up from 199).