### PR TITLE
refactor: extract shared callback helpers from select and slider systems

### DIFF
--- a/src/systems/callbackHelpers.ts
+++ b/src/systems/callbackHelpers.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared callback helpers for system callback stores.
+ *
+ * Eliminates duplicated get/register/fire/clear callback patterns
+ * across selectSystem, sliderSystem, and other systems.
+ *
+ * @module systems/callbackHelpers
+ */
+
+import type { Entity, World } from '../core/types';
+import { getWorldStore } from '../core/worldStore';
+
+/**
+ * Creates a typed getter for a world-scoped callback store.
+ *
+ * @param storeKey - Unique key for the world store (e.g., 'select:changeCallbacks')
+ * @returns A function that retrieves the callback map from a world
+ *
+ * @example
+ * ```typescript
+ * const getChangeCallbacks = createCallbackStore<SelectCallback>('select:changeCallbacks');
+ * const callbacks = getChangeCallbacks(world).get(eid);
+ * ```
+ */
+export function createCallbackStore<T>(
+	storeKey: string,
+): (world: World) => Map<Entity, T[]> {
+	return (world: World) => getWorldStore<Entity, T[]>(world, storeKey);
+}
+
+/**
+ * Fire all callbacks registered for an entity.
+ *
+ * @param eid - The entity ID
+ * @param callbackMap - Map of entity to callbacks
+ */
+export function fireCallbacks(
+	eid: Entity,
+	callbackMap: Map<Entity, Array<() => void>>,
+): void {
+	const callbacks = callbackMap.get(eid);
+	if (!callbacks) return;
+	for (const cb of callbacks) {
+		cb();
+	}
+}
+
+/**
+ * Register a callback for an entity and return an unsubscribe function.
+ *
+ * @param store - The callback store map
+ * @param eid - The entity ID
+ * @param callback - The callback to register
+ * @returns Unsubscribe function that removes the callback
+ *
+ * @example
+ * ```typescript
+ * const unsub = registerCallback(getChangeCallbacks(world), eid, myCallback);
+ * // Later:
+ * unsub(); // removes the callback
+ * ```
+ */
+export function registerCallback<T>(
+	store: Map<Entity, T[]>,
+	eid: Entity,
+	callback: T,
+): () => void {
+	const callbacks = store.get(eid) ?? [];
+	callbacks.push(callback);
+	store.set(eid, callbacks);
+
+	return () => {
+		const cbs = store.get(eid);
+		if (cbs) {
+			const idx = cbs.indexOf(callback);
+			if (idx !== -1) {
+				cbs.splice(idx, 1);
+			}
+		}
+	};
+}
+
+/**
+ * Clear all callbacks for a specific entity from multiple stores.
+ *
+ * @param eid - The entity ID
+ * @param stores - The callback store maps to clear
+ */
+export function clearEntityCallbacks(
+	eid: Entity,
+	...stores: Map<Entity, unknown[]>[]
+): void {
+	for (const store of stores) {
+		store.delete(eid);
+	}
+}
+
+/**
+ * Clear all callbacks from multiple stores (full reset).
+ *
+ * @param stores - The callback store maps to clear
+ */
+export function clearAllCallbacks(
+	...stores: Map<Entity, unknown[]>[]
+): void {
+	for (const store of stores) {
+		store.clear();
+	}
+}

--- a/src/systems/selectSystem.ts
+++ b/src/systems/selectSystem.ts
@@ -32,6 +32,13 @@ import {
 } from '../components/stateMachine';
 import type { Entity, World } from '../core/types';
 import { getWorldStore } from '../core/worldStore';
+import {
+	clearAllCallbacks,
+	clearEntityCallbacks,
+	createCallbackStore,
+	fireCallbacks,
+	registerCallback,
+} from './callbackHelpers';
 
 // =============================================================================
 // WORLD-SCOPED STORES (REPLACED MODULE-LEVEL SINGLETONS)
@@ -48,37 +55,17 @@ function getDisplayStore(world: World): Map<Entity, SelectDisplay> {
 }
 
 /** Get world-scoped store for select change callbacks */
-function getChangeCallbacks(world: World): Map<Entity, SelectCallback[]> {
-	return getWorldStore<Entity, SelectCallback[]>(world, 'select:changeCallbacks');
-}
+const getChangeCallbacks = createCallbackStore<SelectCallback>('select:changeCallbacks');
 
 /** Get world-scoped store for select open callbacks */
-function getOpenCallbacks(world: World): Map<Entity, (() => void)[]> {
-	return getWorldStore<Entity, (() => void)[]>(world, 'select:openCallbacks');
-}
+const getOpenCallbacks = createCallbackStore<() => void>('select:openCallbacks');
 
 /** Get world-scoped store for select close callbacks */
-function getCloseCallbacks(world: World): Map<Entity, (() => void)[]> {
-	return getWorldStore<Entity, (() => void)[]>(world, 'select:closeCallbacks');
-}
+const getCloseCallbacks = createCallbackStore<() => void>('select:closeCallbacks');
 
 // =============================================================================
 // INTERNAL HELPERS
 // =============================================================================
-
-/**
- * Fire callbacks from a callback map.
- *
- * @param eid - The entity ID
- * @param callbackMap - Map of entity to callbacks
- */
-function fireCallbacks(eid: Entity, callbackMap: Map<Entity, Array<() => void>>): void {
-	const callbacks = callbackMap.get(eid);
-	if (!callbacks) return;
-	for (const cb of callbacks) {
-		cb();
-	}
-}
 
 /**
  * Handle select state change callbacks.
@@ -649,19 +636,7 @@ export function getSelectIndicator(world: World, eid: Entity): string {
  * ```
  */
 export function onSelectChange(world: World, eid: Entity, callback: SelectCallback): () => void {
-	const callbacks = getChangeCallbacks(world).get(eid) ?? [];
-	callbacks.push(callback);
-	getChangeCallbacks(world).set(eid, callbacks);
-
-	return () => {
-		const cbs = getChangeCallbacks(world).get(eid);
-		if (cbs) {
-			const idx = cbs.indexOf(callback);
-			if (idx !== -1) {
-				cbs.splice(idx, 1);
-			}
-		}
-	};
+	return registerCallback(getChangeCallbacks(world), eid, callback);
 }
 
 /**
@@ -673,19 +648,7 @@ export function onSelectChange(world: World, eid: Entity, callback: SelectCallba
  * @returns Unsubscribe function
  */
 export function onSelectOpen(world: World, eid: Entity, callback: () => void): () => void {
-	const callbacks = getOpenCallbacks(world).get(eid) ?? [];
-	callbacks.push(callback);
-	getOpenCallbacks(world).set(eid, callbacks);
-
-	return () => {
-		const cbs = getOpenCallbacks(world).get(eid);
-		if (cbs) {
-			const idx = cbs.indexOf(callback);
-			if (idx !== -1) {
-				cbs.splice(idx, 1);
-			}
-		}
-	};
+	return registerCallback(getOpenCallbacks(world), eid, callback);
 }
 
 /**
@@ -697,19 +660,7 @@ export function onSelectOpen(world: World, eid: Entity, callback: () => void): (
  * @returns Unsubscribe function
  */
 export function onSelectClose(world: World, eid: Entity, callback: () => void): () => void {
-	const callbacks = getCloseCallbacks(world).get(eid) ?? [];
-	callbacks.push(callback);
-	getCloseCallbacks(world).set(eid, callbacks);
-
-	return () => {
-		const cbs = getCloseCallbacks(world).get(eid);
-		if (cbs) {
-			const idx = cbs.indexOf(callback);
-			if (idx !== -1) {
-				cbs.splice(idx, 1);
-			}
-		}
-	};
+	return registerCallback(getCloseCallbacks(world), eid, callback);
 }
 
 /**
@@ -719,9 +670,12 @@ export function onSelectClose(world: World, eid: Entity, callback: () => void): 
  * @param eid - The entity ID
  */
 export function clearSelectCallbacks(world: World, eid: Entity): void {
-	getChangeCallbacks(world).delete(eid);
-	getOpenCallbacks(world).delete(eid);
-	getCloseCallbacks(world).delete(eid);
+	clearEntityCallbacks(
+		eid,
+		getChangeCallbacks(world),
+		getOpenCallbacks(world),
+		getCloseCallbacks(world),
+	);
 }
 
 // =============================================================================
@@ -828,7 +782,9 @@ export function resetSelectStore(world: World): void {
 	selectStore.optionCount.fill(0);
 	getOptionsStore(world).clear();
 	getDisplayStore(world).clear();
-	getChangeCallbacks(world).clear();
-	getOpenCallbacks(world).clear();
-	getCloseCallbacks(world).clear();
+	clearAllCallbacks(
+		getChangeCallbacks(world),
+		getOpenCallbacks(world),
+		getCloseCallbacks(world),
+	);
 }

--- a/src/systems/sliderSystem.ts
+++ b/src/systems/sliderSystem.ts
@@ -42,6 +42,13 @@ import {
 import type { Entity, World } from '../core/types';
 import { getWorldStore } from '../core/worldStore';
 import { SliderRangeSchema, SliderStepSchema } from '../schemas/components';
+import {
+	clearAllCallbacks,
+	clearEntityCallbacks,
+	createCallbackStore,
+	fireCallbacks,
+	registerCallback,
+} from './callbackHelpers';
 
 // =============================================================================
 // WORLD-SCOPED STORES (REPLACED MODULE-LEVEL SINGLETONS)
@@ -53,19 +60,13 @@ function getDisplayStore(world: World): Map<Entity, SliderDisplay> {
 }
 
 /** Get world-scoped store for slider change callbacks */
-function getChangeCallbacks(world: World): Map<Entity, SliderChangeCallback[]> {
-	return getWorldStore<Entity, SliderChangeCallback[]>(world, 'slider:changeCallbacks');
-}
+const getChangeCallbacks = createCallbackStore<SliderChangeCallback>('slider:changeCallbacks');
 
 /** Get world-scoped store for drag start callbacks */
-function getDragStartCallbacks(world: World): Map<Entity, (() => void)[]> {
-	return getWorldStore<Entity, (() => void)[]>(world, 'slider:dragStartCallbacks');
-}
+const getDragStartCallbacks = createCallbackStore<() => void>('slider:dragStartCallbacks');
 
 /** Get world-scoped store for drag end callbacks */
-function getDragEndCallbacks(world: World): Map<Entity, (() => void)[]> {
-	return getWorldStore<Entity, (() => void)[]>(world, 'slider:dragEndCallbacks');
-}
+const getDragEndCallbacks = createCallbackStore<() => void>('slider:dragEndCallbacks');
 
 // =============================================================================
 // INTERNAL HELPERS
@@ -89,17 +90,6 @@ function roundToStep(value: number, step: number, min: number): number {
 }
 
 /**
- * Fire callbacks from a callback map.
- */
-function fireSliderCallbacks(eid: Entity, callbackMap: Map<Entity, Array<() => void>>): void {
-	const callbacks = callbackMap.get(eid);
-	if (!callbacks) return;
-	for (const cb of callbacks) {
-		cb();
-	}
-}
-
-/**
  * Handle slider state change callbacks.
  */
 function handleSliderStateChange(
@@ -109,9 +99,9 @@ function handleSliderStateChange(
 	newState: SliderState,
 ): void {
 	if (previousState !== 'dragging' && newState === 'dragging') {
-		fireSliderCallbacks(eid, getDragStartCallbacks(world));
+		fireCallbacks(eid, getDragStartCallbacks(world));
 	} else if (previousState === 'dragging' && newState !== 'dragging') {
-		fireSliderCallbacks(eid, getDragEndCallbacks(world));
+		fireCallbacks(eid, getDragEndCallbacks(world));
 	}
 }
 
@@ -691,19 +681,7 @@ export function onSliderChange(
 	eid: Entity,
 	callback: SliderChangeCallback,
 ): () => void {
-	const callbacks = getChangeCallbacks(world).get(eid) ?? [];
-	callbacks.push(callback);
-	getChangeCallbacks(world).set(eid, callbacks);
-
-	return () => {
-		const cbs = getChangeCallbacks(world).get(eid);
-		if (cbs) {
-			const idx = cbs.indexOf(callback);
-			if (idx !== -1) {
-				cbs.splice(idx, 1);
-			}
-		}
-	};
+	return registerCallback(getChangeCallbacks(world), eid, callback);
 }
 
 /**
@@ -715,19 +693,7 @@ export function onSliderChange(
  * @returns Unsubscribe function
  */
 export function onSliderDragStart(world: World, eid: Entity, callback: () => void): () => void {
-	const callbacks = getDragStartCallbacks(world).get(eid) ?? [];
-	callbacks.push(callback);
-	getDragStartCallbacks(world).set(eid, callbacks);
-
-	return () => {
-		const cbs = getDragStartCallbacks(world).get(eid);
-		if (cbs) {
-			const idx = cbs.indexOf(callback);
-			if (idx !== -1) {
-				cbs.splice(idx, 1);
-			}
-		}
-	};
+	return registerCallback(getDragStartCallbacks(world), eid, callback);
 }
 
 /**
@@ -739,19 +705,7 @@ export function onSliderDragStart(world: World, eid: Entity, callback: () => voi
  * @returns Unsubscribe function
  */
 export function onSliderDragEnd(world: World, eid: Entity, callback: () => void): () => void {
-	const callbacks = getDragEndCallbacks(world).get(eid) ?? [];
-	callbacks.push(callback);
-	getDragEndCallbacks(world).set(eid, callbacks);
-
-	return () => {
-		const cbs = getDragEndCallbacks(world).get(eid);
-		if (cbs) {
-			const idx = cbs.indexOf(callback);
-			if (idx !== -1) {
-				cbs.splice(idx, 1);
-			}
-		}
-	};
+	return registerCallback(getDragEndCallbacks(world), eid, callback);
 }
 
 /**
@@ -761,9 +715,12 @@ export function onSliderDragEnd(world: World, eid: Entity, callback: () => void)
  * @param eid - The entity ID
  */
 export function clearSliderCallbacks(world: World, eid: Entity): void {
-	getChangeCallbacks(world).delete(eid);
-	getDragStartCallbacks(world).delete(eid);
-	getDragEndCallbacks(world).delete(eid);
+	clearEntityCallbacks(
+		eid,
+		getChangeCallbacks(world),
+		getDragStartCallbacks(world),
+		getDragEndCallbacks(world),
+	);
 }
 
 // =============================================================================
@@ -914,7 +871,9 @@ export function resetSliderStore(world: World): void {
 	sliderStore.orientation.fill(0);
 	sliderStore.showValue.fill(0);
 	getDisplayStore(world).clear();
-	getChangeCallbacks(world).clear();
-	getDragStartCallbacks(world).clear();
-	getDragEndCallbacks(world).clear();
+	clearAllCallbacks(
+		getChangeCallbacks(world),
+		getDragStartCallbacks(world),
+		getDragEndCallbacks(world),
+	);
 }


### PR DESCRIPTION
Addresses issue #1357

## Changes

Created `src/systems/callbackHelpers.ts` with shared utilities:
- `createCallbackStore<T>()` — factory for typed world-scoped callback store getters
- `fireCallbacks()` — fire all callbacks for an entity
- `registerCallback<T>()` — register callback + return unsubscribe function
- `clearEntityCallbacks()` — clear callbacks for a specific entity across multiple stores
- `clearAllCallbacks()` — full reset across multiple stores

Updated `selectSystem.ts` and `sliderSystem.ts` to use shared helpers, eliminating ~6 duplicated callback registration/unregistration blocks and 2 duplicated `fireCallbacks` implementations.

All 12,745 passing tests continue to pass (3 pre-existing failures in `screenProcess.test.ts` are unrelated).