### PR TITLE
refactor: deduplicate media package render helpers — re-export from core

### DIFF
--- a/packages/media/src/render/ansi-helpers.ts
+++ b/packages/media/src/render/ansi-helpers.ts
@@ -1,135 +1,31 @@
 /**
  * ANSI renderer helper functions.
  *
+ * Functions shared with the core terminal graphics module are re-exported
+ * from `blecsd/terminal` to avoid duplication. Functions unique to the
+ * media package (pixel extraction, dithering) are defined here.
+ *
  * @module media/render/ansi-helpers
  */
 
 import type { RGB, RGBA } from 'blecsd/terminal';
 import { blendWithAlpha, PALETTE_RGB, rgbToColor256 } from 'blecsd/terminal';
 import type { Bitmap } from './ansi-types';
-import { ASCII_RAMP } from './ansi-types';
 
-/**
- * Converts RGB values to the nearest 256-color palette index.
- *
- * @param r - Red channel (0-255)
- * @param g - Green channel (0-255)
- * @param b - Blue channel (0-255)
- * @returns The nearest 256-color palette index
- *
- * @example
- * ```typescript
- * import { rgbTo256Color } from 'blecsd';
- *
- * rgbTo256Color(255, 0, 0);     // 9 (bright red)
- * ```
- */
-export function rgbTo256Color(r: number, g: number, b: number): number {
-	return rgbToColor256({ r, g, b }) as number;
-}
+// ─── Re-exported from core ──────────────────────────────────────────────────
+// These functions are identical to their `blecsd/terminal` counterparts.
+// Re-exporting avoids maintaining two copies.
 
-/**
- * Maps a luminance value (0-1) to an ASCII character from the character ramp.
- *
- * @param luminance - Brightness value from 0 (black) to 1 (white)
- * @returns An ASCII character representing the brightness level
- *
- * @example
- * ```typescript
- * import { luminanceToChar } from 'blecsd';
- *
- * luminanceToChar(0);    // ' ' (space, darkest)
- * luminanceToChar(1);    // '@' (brightest)
- * ```
- */
-export function luminanceToChar(luminance: number): string {
-	const clamped = Math.max(0, Math.min(1, luminance));
-	const index = Math.round(clamped * (ASCII_RAMP.length - 1));
-	return ASCII_RAMP[index] ?? ' ';
-}
+export {
+	blendWithBackground,
+	luminanceToChar,
+	rgbLuminance,
+	rgbTo256Color,
+	scaleBitmap,
+} from 'blecsd/terminal';
 
-/**
- * Calculates the perceived luminance of an RGB color.
- * Uses ITU-R BT.601 weights for perceptual accuracy.
- *
- * @param r - Red channel (0-255)
- * @param g - Green channel (0-255)
- * @param b - Blue channel (0-255)
- * @returns Luminance value from 0 to 1
- *
- * @example
- * ```typescript
- * import { rgbLuminance } from 'blecsd';
- *
- * rgbLuminance(255, 255, 255); // 1.0
- * rgbLuminance(0, 0, 0);       // 0.0
- * ```
- */
-export function rgbLuminance(r: number, g: number, b: number): number {
-	return (r * 0.299 + g * 0.587 + b * 0.114) / 255;
-}
-
-/**
- * Scales a bitmap to the target dimensions using nearest-neighbor sampling.
- *
- * @param bitmap - Source bitmap with RGBA pixel data
- * @param targetWidth - Desired width in pixels
- * @param targetHeight - Desired height in pixels
- * @returns A new Bitmap with scaled pixel data
- *
- * @example
- * ```typescript
- * import { scaleBitmap } from 'blecsd';
- *
- * const small = scaleBitmap(largeBitmap, 80, 24);
- * ```
- */
-export function scaleBitmap(bitmap: Bitmap, targetWidth: number, targetHeight: number): Bitmap {
-	if (targetWidth <= 0 || targetHeight <= 0) {
-		return { width: 0, height: 0, data: new Uint8Array(0) };
-	}
-
-	const data = new Uint8Array(targetWidth * targetHeight * 4);
-	const xRatio = bitmap.width / targetWidth;
-	const yRatio = bitmap.height / targetHeight;
-
-	for (let y = 0; y < targetHeight; y++) {
-		const srcY = Math.min(Math.floor(y * yRatio), bitmap.height - 1);
-		for (let x = 0; x < targetWidth; x++) {
-			const srcX = Math.min(Math.floor(x * xRatio), bitmap.width - 1);
-			const srcIdx = (srcY * bitmap.width + srcX) * 4;
-			const dstIdx = (y * targetWidth + x) * 4;
-			data[dstIdx] = bitmap.data[srcIdx] ?? 0;
-			data[dstIdx + 1] = bitmap.data[srcIdx + 1] ?? 0;
-			data[dstIdx + 2] = bitmap.data[srcIdx + 2] ?? 0;
-			data[dstIdx + 3] = bitmap.data[srcIdx + 3] ?? 0;
-		}
-	}
-
-	return { width: targetWidth, height: targetHeight, data };
-}
-
-/**
- * Blends a pixel with an alpha channel over an opaque background color.
- *
- * @param pixel - Foreground pixel with RGBA channels
- * @param bg - Opaque background color
- * @returns The composited RGB color
- *
- * @example
- * ```typescript
- * import { blendWithBackground } from 'blecsd';
- *
- * const result = blendWithBackground(
- *   { r: 255, g: 0, b: 0, a: 128 },
- *   { r: 0, g: 0, b: 0 }
- * );
- * ```
- */
-export function blendWithBackground(pixel: RGBA, bg: RGB): RGB {
-	const normalizedAlpha = pixel.a / 255;
-	return blendWithAlpha({ r: pixel.r, g: pixel.g, b: pixel.b, a: normalizedAlpha }, bg);
-}
+// ─── Media-specific helpers ─────────────────────────────────────────────────
+// These are not exported from core (private in cellRenderer.ts).
 
 /**
  * Extracts an RGBA pixel from a bitmap at the given coordinates.
@@ -155,7 +51,8 @@ export function resolvePixel(bitmap: Bitmap, x: number, y: number, bg: RGB): RGB
 	if (pixel.a === 0) {
 		return bg;
 	}
-	return blendWithBackground(pixel, bg);
+	const normalizedAlpha = pixel.a / 255;
+	return blendWithAlpha({ r: pixel.r, g: pixel.g, b: pixel.b, a: normalizedAlpha }, bg);
 }
 
 /**

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -490,6 +490,12 @@ export type {
 	RenderedCell,
 	RenderOptions as GraphicsRenderOptions,
 	VectorRenderOptions,
+	// Cell renderer types (used by @blecsd/media)
+	AnsiRenderOptions,
+	Bitmap,
+	Cell,
+	CellMap,
+	RenderMode,
 } from './graphics';
 export {
 	// Backend name constants
@@ -563,6 +569,14 @@ export {
 	selectBackend,
 	setCellColor,
 	setDot,
+	// Cell renderer helpers (used by @blecsd/media)
+	blendWithBackground,
+	cellMapToString,
+	luminanceToChar,
+	renderToAnsi,
+	rgbLuminance,
+	rgbTo256Color,
+	scaleBitmap,
 } from './graphics';
 // Input control
 export type {


### PR DESCRIPTION
Fixes #1355

Replaces 5 duplicated functions in `packages/media/src/render/ansi-helpers.ts` with re-exports from `blecsd/terminal`:
- `rgbTo256Color`
- `rgbLuminance`  
- `scaleBitmap`
- `blendWithBackground`
- `luminanceToChar`

Also adds cell renderer type/function exports to `src/terminal/index.ts` so the media package can import them via the `blecsd/terminal` subpath.

Media-specific helpers (`getPixel`, `resolvePixel`, `distributeError`, `applyDithering`) are kept since they're private in core.